### PR TITLE
docs: define empirical knockdown coefficients alpha and n (#3)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,15 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install numpy scipy matplotlib pytest
+        pip install numpy scipy matplotlib pytest jsonschema
 
     - name: Run tests
       run: pytest tests/ -v --tb=short
+
+    - name: Install GUI extras
+      run: pip install "PyQt6>=6.5.0"
+
+    - name: Smoke-test GUI imports
+      env:
+        QT_QPA_PLATFORM: offscreen
+      run: python -c "import porosity_gui; print('porosity_gui imports OK')"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,7 @@ All notable changes to PorosityFE will be documented in this file.
 - PyQt6 desktop GUI with interactive porosity analysis
 - Empirical strength models: Judd-Wright (exponential) and Power Law correlations
 - 3D finite element solver with Eshelby-based stiffness degradation
-- 5 porosity distribution types: uniform, interface-concentrated, gradient, random clustered, layup-dependent
+- 3 porosity distribution types: uniform, clustered (midplane/surface/quarter), interface-concentrated
 - 3 void morphologies: spherical, cylindrical (prolate), penny-shaped (oblate)
 - 4 loading modes: compression, tension, shear, ILSS
 - 3 built-in material presets: T800/epoxy, E-glass/epoxy, T700/epoxy

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,6 +48,12 @@ To add a material system, add a new entry to the `MATERIALS` dictionary in `poro
 ## Adding New Porosity Models
 
 New empirical correlation models can be added to the `EmpiricalSolver` class. Each model should:
-- Accept porosity volume fraction as input
+- Accept porosity volume fraction as input (`Vp`, dimensionless fraction in `[0, 1]`)
 - Return a knockdown factor (0 to 1)
 - Include a literature reference in the docstring
+
+When introducing or recalibrating coefficients (e.g. a custom `alpha` for Judd-Wright or `n` for the power law):
+- Document the calibration coupon set (Vp range, layup, fiber/matrix system) and the test standard used (ASTM D2344 for ILSS, D7264 for flexure, D3039 for tension, D6641 for compression).
+- Fit on log-transformed data: regress `ln(KD)` vs `Vp` for the slope `−alpha`, or `ln(KD)` vs `ln(1 − Vp)` for `n`.
+- Note the validity bounds — both forms are commonly bounded to `Vp ≲ 0.05`.
+- Cross-reference the README "Empirical Strength Knockdown" section so user-facing docs stay in sync.

--- a/README.md
+++ b/README.md
@@ -22,11 +22,12 @@ Manufacturing defects like porosity are inevitable in composite structures. Engi
 ## Features
 
 - **Two porosity types**: Distributed microporosity (continuous field) + discrete macrovoids (explicit geometry)
-- **Five distribution models**: Uniform, interface-concentrated, clustered (midplane/surface), layup-dependent
+- **Three distribution models**: Uniform, clustered (midplane/surface/quarter), interface-concentrated
 - **Three void morphologies**: Spherical, cylindrical (prolate), penny-shaped (oblate)
 - **Four loading modes**: Compression, tension, shear, ILSS
+- **Three empirical knockdown models**: Judd-Wright (exponential), power-law, linear
 - **Two solver tiers**: Empirical correlations (fast) + 3D finite element (detailed)
-- **Three material presets**: T800/epoxy, T700/epoxy, E-glass/epoxy (or define your own)
+- **Six material presets**: T800/epoxy, T700/epoxy, E-glass/epoxy, IM7/8551, T300/934, CF/PEEK (or define your own)
 - **Discrete void modeling**: Explicit ellipsoidal voids with stress concentration factors
 - **Tsai-Wu failure criterion**: Full 3D multiaxial strength evaluation
 
@@ -147,16 +148,22 @@ KD = (1 - Vp)^n
 ```
 - `n` is a phenomenological exponent rooted in Mackenzie (1950) spherical-void elasticity and generalized empirically (Rice, 2005). `n = 1` corresponds to a simple area-reduction rule of mixtures; `n > 1` captures stress concentration around voids.
 
+**Linear**:
+```
+KD = max(1 - beta * Vp, 0)
+```
+- `beta` is the same kind of sensitivity coefficient as `alpha` in Judd-Wright (dimensionless when `Vp` is a fraction; `beta ≈ -ΔKD / ΔVp`). The linear form matches the original Judd & Wright (1978) "ILSS drops ~7% per 1% voids" reading directly, and is included for screening and easy hand-checks. It saturates to zero at `Vp = 1/beta` and is best used at low `Vp` (typically `< 0.05`).
+
 #### QI-calibrated coefficients (Elhajjar 2025)
 
-Calibrated against quasi-isotropic experimental data; reference scaling fraction `f_md_ref = 0.5`:
+`f_md_ref = 0.5` is the layup-scaling reference (`scale = 1.0` at `f_md = 0.5`); the QI coefficients below were tuned with this scaling already applied, so they are NOT raw fits to a single layup but represent the model's effective-baseline values:
 
-| Loading mode | `alpha` (Judd-Wright) | `n` (Power-Law) |
-|---|---|---|
-| Compression       | 6.9  | 2.8 |
-| Tension           | 3.9  | 1.8 |
-| Shear (in-plane)  | 8.0  | 3.5 |
-| ILSS              | 10.0 | 4.5 |
+| Loading mode | `alpha` (Judd-Wright) | `n` (Power-Law) | `beta` (Linear) |
+|---|---|---|---|
+| Compression       | 6.9  | 2.8 | 5.5 |
+| Tension           | 3.9  | 1.8 | 3.5 |
+| Shear (in-plane)  | 8.0  | 3.5 | 7.0 |
+| ILSS              | 10.0 | 4.5 | 9.0 |
 
 These values sit inside published CFRP ranges: `alpha ≈ 1–3` for fiber-dominated tension and `5–10` for matrix-dominated ILSS / flexure; `n ≈ 1–2` for stiffness-like properties and `3–5` for compression / ILSS.
 

--- a/README.md
+++ b/README.md
@@ -131,17 +131,69 @@ validate_porosity --quiet            # suppress progress output
 
 ### Empirical Strength Knockdown
 
+Both empirical models below take the **specimen-average** void volume fraction `Vp` as a dimensionless **fraction in `[0, 1]`** (e.g. 3% porosity → `Vp = 0.03`, never `Vp = 3.0`). Each returns a knockdown factor `KD ∈ (0, 1]` that multiplies the pristine strength `σ₀`.
+
 **Judd-Wright** (exponential decay):
 ```
 KD = exp(-alpha * Vp)
 ```
+- `alpha` is an empirical sensitivity coefficient. It is **dimensionless** when `Vp` is a fraction.
+- For small `Vp`, `KD ≈ 1 − alpha · Vp`, so `alpha` is approximately the fractional strength loss per unit `Vp`. Judd & Wright (1978) reported ILSS dropping ~7% per 1% voids in CFRP, which corresponds to `alpha ≈ 7`.
+- The exponential form is an engineering convention re-fit of Judd & Wright's linear data; it is well-behaved up to `Vp ≈ 0.04–0.05` and over-penalizes higher porosities.
 
 **Power Law**:
 ```
 KD = (1 - Vp)^n
 ```
+- `n` is a phenomenological exponent rooted in Mackenzie (1950) spherical-void elasticity and generalized empirically (Rice, 2005). `n = 1` corresponds to a simple area-reduction rule of mixtures; `n > 1` captures stress concentration around voids.
 
-Coefficients are layup-dependent: matrix-dominated layups (many off-axis plies) are more sensitive to porosity than fiber-dominated layups.
+#### QI-calibrated coefficients (Elhajjar 2025)
+
+Calibrated against quasi-isotropic experimental data; reference scaling fraction `f_md_ref = 0.5`:
+
+| Loading mode | `alpha` (Judd-Wright) | `n` (Power-Law) |
+|---|---|---|
+| Compression       | 6.9  | 2.8 |
+| Tension           | 3.9  | 1.8 |
+| Shear (in-plane)  | 8.0  | 3.5 |
+| ILSS              | 10.0 | 4.5 |
+
+These values sit inside published CFRP ranges: `alpha ≈ 1–3` for fiber-dominated tension and `5–10` for matrix-dominated ILSS / flexure; `n ≈ 1–2` for stiffness-like properties and `3–5` for compression / ILSS.
+
+#### Layup scaling
+
+PorosityFE adapts the QI coefficients to the user's layup via a matrix-dominated fraction `f_md` computed from the ply angles (0° → 0.0, ±45° → 0.5, 90° → 1.0):
+
+```
+alpha_eff(mode) = alpha_QI(mode) * (f_md / 0.5)
+n_eff(mode)     = max(n_QI(mode) * (f_md / 0.5), 0.1)
+```
+
+A floor of `0.15` is applied to the scale (`0.80` for ILSS, which is always matrix-dominated):
+
+| Layup | `f_md` | scale | `alpha_eff` (compression) |
+|---|---|---|---|
+| `[0]_16` (UD)              | 0.00 | 0.15 (floor) | 1.04  |
+| `[±45]_4s` (off-axis)      | 0.50 | 1.00          | 6.90  |
+| `[90]_8` (transverse)      | 1.00 | 2.00          | 13.80 |
+
+Matrix-dominated layups are penalized more by porosity than fiber-dominated layups, as expected physically.
+
+#### Validity bounds
+
+The calibration data covers `Vp ≲ 0.05`. Beyond that, both forms should be treated as extrapolations. `Vp` alone does not capture void *morphology* (size, aspect ratio, clustering), which is a known source of scatter — use the FE solver path when spatial stress-concentration detail is needed.
+
+#### Calibrating `alpha` / `n` for a custom material
+
+If your material system differs significantly from the calibration set:
+
+1. Manufacture a ladder of coupons spanning `Vp ≈ 0–5%` (vary autoclave debulk pressure or cure vacuum).
+2. Measure void content per ASTM D2734 (matrix burnoff) or D3171 (acid digestion); cross-check by μCT or polished cross-section.
+3. Run the relevant strength test: ASTM D2344 (ILSS / short-beam shear), D7264 (flexure), D3039 (tension), or D6641 (compression).
+4. Normalize each datum by the void-free baseline: `KD = σ(Vp) / σ(0)`.
+5. Regress `ln(KD)` vs `Vp` (slope `= −alpha`) for Judd-Wright, or `ln(KD)` vs `ln(1 − Vp)` (slope `= n`) for the power law.
+
+Custom `alpha` / `n` values are not currently exposed as public API; until a configuration hook lands, supply them by subclassing `EmpiricalSolver` and overriding `_JUDD_WRIGHT_ALPHA_QI` / `_POWER_LAW_N_QI`.
 
 ### Finite Element Solver
 
@@ -213,7 +265,9 @@ Related publication:
 
 ## References
 
-- Judd & Wright (1986) - Voids and their effects on mechanical properties of composites
+- Judd & Wright (1978) - Voids and their effects on the mechanical properties of composites — an appraisal. *SAMPE Journal* 14(1), 10–14
+- Mackenzie (1950) - The elastic constants of a solid containing spherical holes. *Proc. Phys. Soc. B* 63(1), 2–11
+- Rice (2005) - Use of normalized porosity in models for the porosity dependence of mechanical properties. *J. Mater. Sci.* 40, 983–989
 - Eshelby (1957) - The determination of the elastic field of an ellipsoidal inclusion
 - Mura (1987) - Micromechanics of Defects in Solids
 - Tsai & Wu (1971) - A general theory of strength for anisotropic materials

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ A floor of `0.15` is applied to the scale (`0.80` for ILSS, which is always matr
 
 | Layup | `f_md` | scale | `alpha_eff` (compression) |
 |---|---|---|---|
-| `[0]_16` (UD)              | 0.00 | 0.15 (floor) | 1.04  |
+| `[0]_16` (UD)              | 0.00 | 0.15 (floor) | 1.035 |
 | `[±45]_4s` (off-axis)      | 0.50 | 1.00          | 6.90  |
 | `[90]_8` (transverse)      | 1.00 | 2.00          | 13.80 |
 

--- a/porosity_fe_analysis.py
+++ b/porosity_fe_analysis.py
@@ -640,8 +640,14 @@ class EmpiricalSolver:
     local peak Vp that clustered distributions produce.
     """
 
-    # QI-calibrated coefficients (Elhajjar 2025, Sci. Rep. 15:25977)
-    # Reference layup: [0/45/90/-45/0]_s (f_md_ref = 0.5)
+    # QI-calibrated coefficients (Elhajjar 2025, Sci. Rep. 15:25977).
+    # Reference layup: [0/45/90/-45/0]_s (f_md_ref = 0.5).
+    # See README "Empirical Strength Knockdown" for definitions, units (alpha, n
+    # are dimensionless when Vp is a fraction in [0, 1]), validity bounds, and
+    # the calibration recipe for custom materials.
+    # Modes: 'compression' (sigma_1c, fiber+matrix), 'tension' (sigma_1t,
+    # fiber-dominated), 'shear' (tau_12, in-plane, matrix-dominated),
+    # 'ilss' (tau_ilss, short-beam, matrix/interface-dominated).
     _JUDD_WRIGHT_ALPHA_QI = {
         'compression': 6.9, 'tension': 3.9, 'shear': 8.0, 'ilss': 10.0,
     }
@@ -718,10 +724,24 @@ class EmpiricalSolver:
         return max(raw, floor)
 
     def _judd_wright(self, Vp: float, mode: str) -> float:
+        """Judd-Wright knockdown: KD = exp(-alpha * Vp).
+
+        Vp is a void volume fraction in [0, 1]. ``alpha`` is the
+        layup-scaled, mode-specific sensitivity coefficient (see
+        ``JUDD_WRIGHT_ALPHA`` and the README "Empirical Strength
+        Knockdown" section for definitions and ranges).
+        """
         alpha = self.JUDD_WRIGHT_ALPHA[mode]
         return float(np.exp(-alpha * Vp))
 
     def _power_law(self, Vp: float, mode: str) -> float:
+        """Power-law knockdown: KD = (1 - Vp)**n.
+
+        Vp is a void volume fraction in [0, 1]. ``n`` is the
+        layup-scaled, mode-specific exponent (see ``POWER_LAW_N`` and
+        the README "Empirical Strength Knockdown" section for
+        definitions and ranges).
+        """
         n = self.POWER_LAW_N[mode]
         return float((1.0 - Vp)**n)
 

--- a/porosity_fe_analysis.py
+++ b/porosity_fe_analysis.py
@@ -287,8 +287,17 @@ class PorosityField:
                  distribution: str = 'uniform', void_shape: Union[str, Tuple] = 'spherical',
                  cluster_location: str = 'midplane',
                  discrete_voids: Optional[List[VoidGeometry]] = None):
+        Vp = float(void_volume_fraction)
+        if not np.isfinite(Vp) or not (0.0 <= Vp <= 1.0):
+            hint = (f" Did you pass a percent? Use {Vp / 100:.4f} instead of {Vp}."
+                    if np.isfinite(Vp) and Vp > 1.0 else "")
+            raise ValueError(
+                f"void_volume_fraction must be a finite fraction in [0, 1], "
+                f"got {void_volume_fraction!r}.{hint}"
+            )
+
         self.material = material
-        self.Vp = void_volume_fraction
+        self.Vp = Vp
         self.distribution = distribution
         self.cluster_location = cluster_location
         self.discrete_voids = discrete_voids or []
@@ -728,6 +737,14 @@ class EmpiricalSolver:
         raw = self.f_md / ref
         return max(raw, floor)
 
+    @staticmethod
+    def _check_internal_Vp(Vp: float) -> float:
+        # Defensive: tolerate fp overshoot (~1e-15) from element-mean averaging
+        # by clipping to [0, 1]; reject non-finite outright.
+        if not np.isfinite(Vp):
+            raise ValueError(f"Internal Vp is non-finite: {Vp!r}")
+        return float(np.clip(Vp, 0.0, 1.0))
+
     def _judd_wright(self, Vp: float, mode: str) -> float:
         """Judd-Wright knockdown: KD = exp(-alpha * Vp).
 
@@ -736,6 +753,7 @@ class EmpiricalSolver:
         ``JUDD_WRIGHT_ALPHA`` and the README "Empirical Strength
         Knockdown" section for definitions and ranges).
         """
+        Vp = self._check_internal_Vp(Vp)
         alpha = self.JUDD_WRIGHT_ALPHA[mode]
         return float(np.exp(-alpha * Vp))
 
@@ -747,10 +765,12 @@ class EmpiricalSolver:
         the README "Empirical Strength Knockdown" section for
         definitions and ranges).
         """
+        Vp = self._check_internal_Vp(Vp)
         n = self.POWER_LAW_N[mode]
         return float((1.0 - Vp)**n)
 
     def _linear(self, Vp: float, mode: str) -> float:
+        Vp = self._check_internal_Vp(Vp)
         beta = self.LINEAR_BETA[mode]
         return float(max(1.0 - beta * Vp, 0.0))
 

--- a/porosity_fe_analysis.py
+++ b/porosity_fe_analysis.py
@@ -641,7 +641,12 @@ class EmpiricalSolver:
     """
 
     # QI-calibrated coefficients (Elhajjar 2025, Sci. Rep. 15:25977).
-    # Reference layup: [0/45/90/-45/0]_s (f_md_ref = 0.5).
+    # `_F_MD_REF = 0.5` below is the LAYUP-SCALING reference (scale = 1.0 at
+    # f_md = 0.5), NOT a property of the Elhajjar coupon layup itself
+    # (`[0/45/90/-45/0]_s`, which the binning rule below puts at f_md = 0.4).
+    # The coefficients were tuned with the layup-scaling already applied,
+    # so they represent the model's effective f_md = 0.5 baseline rather
+    # than the raw fit on a single layup.
     # See README "Empirical Strength Knockdown" for definitions, units (alpha, n
     # are dimensionless when Vp is a fraction in [0, 1]), validity bounds, and
     # the calibration recipe for custom materials.

--- a/porosity_gui.py
+++ b/porosity_gui.py
@@ -33,6 +33,65 @@ try:
 except ImportError:
     HAS_PYQT6 = False
 
+
+def parse_layup(text: str) -> list:
+    """Parse a layup string like '[0/45/-45/90]_3s' to a flat angle list.
+
+    Raises ValueError on malformed input (empty, non-numeric tokens,
+    invalid repeat counts) rather than silently substituting a default.
+    Pure function, kept module-level so it is testable without Qt.
+    """
+    text = (text or "").strip()
+    if not text:
+        raise ValueError("Layup string is empty.")
+
+    cleaned = text.replace("[", "").replace("]", "")
+
+    symmetric = cleaned.endswith("s")
+    if symmetric:
+        cleaned = cleaned[:-1]
+
+    repeat = 1
+    if "_" in cleaned:
+        cleaned, repeat_token = cleaned.rsplit("_", 1)
+        try:
+            repeat = int(repeat_token)
+        except ValueError as exc:
+            raise ValueError(
+                f"Invalid repeat count {repeat_token!r} in layup {text!r}; "
+                f"expected an integer after the '_' (e.g. '[0/90]_3s')."
+            ) from exc
+        if repeat < 1:
+            raise ValueError(
+                f"Repeat count must be >= 1, got {repeat} in layup {text!r}."
+            )
+
+    sep = "/" if "/" in cleaned else ","
+    tokens = [a.strip() for a in cleaned.split(sep) if a.strip()]
+    if not tokens:
+        raise ValueError(f"No ply angles found in layup {text!r}.")
+    try:
+        angles = [float(a) for a in tokens]
+    except ValueError as exc:
+        bad = next((a for a in tokens if not _is_float(a)), tokens[0])
+        raise ValueError(
+            f"Invalid ply angle {bad!r} in layup {text!r}; "
+            f"expected numeric degrees (e.g. '[0/45/-45/90]_3s')."
+        ) from exc
+
+    angles = angles * repeat
+    if symmetric:
+        angles = angles + list(reversed(angles))
+    return angles
+
+
+def _is_float(s: str) -> bool:
+    try:
+        float(s)
+        return True
+    except ValueError:
+        return False
+
 try:
     from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg as FigureCanvas
     from matplotlib.figure import Figure
@@ -134,28 +193,42 @@ if HAS_PYQT6:
                     return
 
                 # --- FE Solver ---
+                # FESolver BCs don't support ILSS short-beam shear today; rather
+                # than silently substituting compression and reporting a knockdown
+                # the user didn't ask for (#9), skip the FE pass entirely for
+                # ILSS and let the empirical bar stand alone in the comparison.
                 loading_mode = cfg["loading_mode"]
-                # ilss not supported by FESolver BCs; fall back to compression
-                fe_loading = loading_mode if loading_mode in ("compression", "tension", "shear") else "compression"
-                applied_strain = -0.01 if fe_loading == "compression" else 0.01
+                fe_supported = loading_mode in ("compression", "tension", "shear")
 
-                self.progress.emit("Assembling stiffness matrix (FE)...")
-                fe_solver = FESolver(mesh, material, porosity_field, ply_angles=cfg["angles"])
+                fe_solver = None
+                fe_field = None
+                fe_loading = None
+                if fe_supported:
+                    applied_strain = -0.01 if loading_mode == "compression" else 0.01
+                    fe_loading = loading_mode
 
-                if self._stop_requested:
-                    return
+                    self.progress.emit("Assembling stiffness matrix (FE)...")
+                    fe_solver = FESolver(mesh, material, porosity_field, ply_angles=cfg["angles"])
 
-                self.progress.emit("Solving FE system...")
-                fe_field: FieldResults = fe_solver.solve(
-                    loading=fe_loading,
-                    applied_strain=applied_strain,
-                    verbose=False,
-                )
+                    if self._stop_requested:
+                        return
 
-                if self._stop_requested:
-                    return
+                    self.progress.emit("Solving FE system...")
+                    fe_field = fe_solver.solve(
+                        loading=fe_loading,
+                        applied_strain=applied_strain,
+                        verbose=False,
+                    )
 
-                self.progress.emit("Recovering FE stresses...")
+                    if self._stop_requested:
+                        return
+
+                    self.progress.emit("Recovering FE stresses...")
+                else:
+                    self.progress.emit(
+                        f"Skipping FE solve (mode '{loading_mode}' not supported "
+                        f"by FE BCs; empirical results only)."
+                    )
 
                 self.progress.emit("Analysis complete.")
 
@@ -169,6 +242,10 @@ if HAS_PYQT6:
                     "fe_solver": fe_solver,
                     "fe_field": fe_field,
                     "fe_loading": fe_loading,
+                    "fe_skipped_reason": (
+                        None if fe_supported
+                        else f"FE solver does not support '{loading_mode}' boundary conditions"
+                    ),
                     "f_md": empirical.f_md,
                 }
 
@@ -561,36 +638,12 @@ if HAS_PYQT6:
 
         @staticmethod
         def _parse_layup(text: str) -> list:
-            """Parse a layup string like '[0/45/-45/90]_3s' to angle list."""
-            text = text.strip()
-            cleaned = text.replace("[", "").replace("]", "")
+            """Parse a layup string like '[0/45/-45/90]_3s' to angle list.
 
-            symmetric = cleaned.endswith("s")
-            if symmetric:
-                cleaned = cleaned[:-1]
-
-            repeat = 1
-            if "_" in cleaned:
-                parts = cleaned.rsplit("_", 1)
-                cleaned = parts[0]
-                try:
-                    repeat = int(parts[1])
-                except ValueError:
-                    repeat = 1
-
-            sep = "/" if "/" in cleaned else ","
-            try:
-                angles = [float(a.strip()) for a in cleaned.split(sep) if a.strip()]
-            except ValueError:
-                angles = [0, 45, -45, 90]
-                repeat = 3
-                symmetric = True
-
-            angles = angles * repeat
-            if symmetric:
-                angles = angles + list(reversed(angles))
-
-            return angles
+            Raises ValueError on malformed input rather than silently
+            falling back to a default — see issue #9.
+            """
+            return parse_layup(text)
 
         # ----------------------------------------------------------
         # Actions
@@ -778,7 +831,14 @@ if HAS_PYQT6:
             comp_fs = emp["compression"]["judd_wright"]["failure_stress"]
             lines.append(f"  Knockdown = {comp_kd:.3f}, Failure stress = {comp_fs:.0f} MPa")
 
-            if fe_field is not None:
+            if fe_field is None:
+                fe_skipped_reason = result.get("fe_skipped_reason")
+                if fe_skipped_reason:
+                    lines.append("")
+                    lines.append("-" * 70)
+                    lines.append(f"FE solve skipped: {fe_skipped_reason}.")
+                    lines.append("Empirical results above use this loading mode directly.")
+            else:
                 lines.append("")
                 lines.append("-" * 70)
                 lines.append("FINITE ELEMENT ANALYSIS RESULTS")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = ["setuptools>=68.0", "wheel"]
-build-backend = "setuptools.backends._legacy:_Backend"
+build-backend = "setuptools.build_meta"
 
 [project]
 name = "porosity-fe"
@@ -42,9 +42,9 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-gui = ["PyQt6>=6.4.0"]
+gui = ["PyQt6>=6.5.0"]
 dev = ["pytest>=7.0.0"]
-all = ["PyQt6>=6.4.0", "pytest>=7.0.0"]
+all = ["PyQt6>=6.5.0", "pytest>=7.0.0"]
 
 [project.urls]
 Homepage = "https://github.com/elhajjar1/PorosityFE"
@@ -56,6 +56,10 @@ porosity-fe = "porosity_gui:main"
 
 [tool.setuptools]
 py-modules = ["porosity_fe_analysis", "porosity_gui"]
+packages = ["validation"]
+
+[tool.setuptools.package-data]
+validation = ["datasets/*.json", "schemas/*.json"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = [
     "numpy>=1.20.0",
     "scipy>=1.7.0",
     "matplotlib>=3.4.0",
+    "jsonschema>=4.0.0",
 ]
 
 [project.optional-dependencies]
@@ -52,10 +53,11 @@ Repository = "https://github.com/elhajjar1/PorosityFE"
 Issues = "https://github.com/elhajjar1/PorosityFE/issues"
 
 [project.scripts]
-porosity-fe = "porosity_gui:main"
+porosity-fe = "porosity_gui:launch"
+validate_porosity = "validate_porosity_cli:main"
 
 [tool.setuptools]
-py-modules = ["porosity_fe_analysis", "porosity_gui"]
+py-modules = ["porosity_fe_analysis", "porosity_gui", "validate_porosity_cli"]
 packages = ["validation"]
 
 [tool.setuptools.package-data]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-numpy>=1.20.0
-scipy>=1.7.0
-matplotlib>=3.4.0
-PyQt6>=6.5.0
-pytest>=7.0.0
+numpy==2.4.4
+scipy==1.17.1
+matplotlib==3.10.9
+jsonschema==4.26.0
+PyQt6==6.11.0

--- a/tests/test_porosity_fe.py
+++ b/tests/test_porosity_fe.py
@@ -265,6 +265,27 @@ class TestPorosityField:
         Vp = pf.local_porosity(np.array([10.0]), np.array([5.0]), np.array([1.0]))
         assert Vp[0] <= 1.0
 
+    def test_negative_Vp_raises(self):
+        with pytest.raises(ValueError, match=r"finite fraction in \[0, 1\]"):
+            PorosityField(self.material, -0.01, distribution='uniform')
+
+    def test_Vp_above_one_raises_with_percent_hint(self):
+        with pytest.raises(ValueError, match=r"Did you pass a percent\?"):
+            PorosityField(self.material, 3.0, distribution='uniform')
+
+    def test_nan_Vp_raises(self):
+        with pytest.raises(ValueError, match=r"finite fraction"):
+            PorosityField(self.material, float('nan'), distribution='uniform')
+
+    def test_inf_Vp_raises(self):
+        with pytest.raises(ValueError, match=r"finite fraction"):
+            PorosityField(self.material, float('inf'), distribution='uniform')
+
+    def test_Vp_boundary_zero_and_one_accepted(self):
+        # Both boundaries should be accepted (no exception)
+        PorosityField(self.material, 0.0, distribution='uniform')
+        PorosityField(self.material, 1.0, distribution='uniform')
+
     def test_effective_porosity_profile_shape(self):
         pf = PorosityField(self.material, 0.03, distribution='uniform')
         z, Vp = pf.effective_porosity_profile(nz=50)

--- a/tests/test_porosity_fe.py
+++ b/tests/test_porosity_fe.py
@@ -1219,3 +1219,182 @@ class TestVoidInclusions:
         # than elements far from the void
         assert results.max_failure_index > 0
         assert np.any(np.isfinite(results.stress_global))
+
+
+# ============================================================
+# Coverage backfill (#12): layup-scaling helpers, linear-model
+# saturation, CLT degradation boundaries, CLI smoke, GUI parser.
+# ============================================================
+
+
+class TestEmpiricalLayupScaling:
+    """Direct unit tests for _matrix_dominated_fraction and _layup_scale."""
+
+    def test_f_md_pure_zero(self):
+        assert EmpiricalSolver._matrix_dominated_fraction([0] * 8) == 0.0
+
+    def test_f_md_pure_ninety(self):
+        assert EmpiricalSolver._matrix_dominated_fraction([90] * 8) == 1.0
+
+    def test_f_md_off_axis_only(self):
+        assert EmpiricalSolver._matrix_dominated_fraction([45, -45, 45, -45]) == 0.5
+
+    def test_f_md_qi_layup_is_0p4(self):
+        # Documented QI calibration coupon -> 0.4 under the binning rule.
+        # See the comment above _F_MD_REF in porosity_fe_analysis.py and
+        # the README "Empirical Strength Knockdown" section.
+        layup = [0, 45, 90, -45, 0, 0, -45, 90, 45, 0]
+        assert abs(EmpiricalSolver._matrix_dominated_fraction(layup) - 0.4) < 1e-12
+
+    def test_f_md_empty_returns_qi_default(self):
+        assert EmpiricalSolver._matrix_dominated_fraction([]) == 0.5
+        assert EmpiricalSolver._matrix_dominated_fraction(None) == 0.5
+
+    def test_f_md_threshold_band_at_10_and_80_degrees(self):
+        # 10° -> still binned as 0° (fiber-dominated)
+        assert EmpiricalSolver._matrix_dominated_fraction([10]) == 0.0
+        # 80° -> binned as 90° (matrix-dominated)
+        assert EmpiricalSolver._matrix_dominated_fraction([80]) == 1.0
+        # 11° -> off-axis bin
+        assert EmpiricalSolver._matrix_dominated_fraction([11]) == 0.5
+
+    def _solver_with_layup(self, ply_angles):
+        material = MATERIALS['T800_epoxy']
+        pf = PorosityField(material, 0.03, distribution='uniform')
+        mesh = CompositeMesh(pf, material, nx=4, ny=3, nz=4)
+        return EmpiricalSolver(mesh, material, ply_angles=ply_angles)
+
+    def test_layup_scale_unity_at_reference(self):
+        # f_md = 0.5 -> scale = 1.0 -> alpha_eff == alpha_QI
+        solver = self._solver_with_layup([45, -45, 45, -45])
+        for mode, alpha_qi in EmpiricalSolver._JUDD_WRIGHT_ALPHA_QI.items():
+            assert abs(solver.JUDD_WRIGHT_ALPHA[mode] - alpha_qi) < 1e-12
+
+    def test_layup_scale_floor_for_ud(self):
+        # f_md = 0.0 -> hits 0.15 floor for non-ILSS modes, 0.80 for ILSS.
+        solver = self._solver_with_layup([0] * 8)
+        for mode in ('compression', 'tension', 'shear'):
+            expected = EmpiricalSolver._JUDD_WRIGHT_ALPHA_QI[mode] * 0.15
+            assert abs(solver.JUDD_WRIGHT_ALPHA[mode] - expected) < 1e-12
+        ilss_expected = EmpiricalSolver._JUDD_WRIGHT_ALPHA_QI['ilss'] * 0.80
+        assert abs(solver.JUDD_WRIGHT_ALPHA['ilss'] - ilss_expected) < 1e-12
+
+    def test_layup_scale_above_reference(self):
+        # Pure 90 -> f_md = 1.0 -> scale = 2.0
+        solver = self._solver_with_layup([90] * 8)
+        for mode, alpha_qi in EmpiricalSolver._JUDD_WRIGHT_ALPHA_QI.items():
+            assert abs(solver.JUDD_WRIGHT_ALPHA[mode] - alpha_qi * 2.0) < 1e-12
+
+
+class TestEmpiricalLinearSaturation:
+    """The linear knockdown clips to 0 once Vp >= 1/beta."""
+
+    def setup_method(self):
+        material = MATERIALS['T800_epoxy']
+        pf = PorosityField(material, 0.03, distribution='uniform')
+        mesh = CompositeMesh(pf, material, nx=4, ny=3, nz=4)
+        self.solver = EmpiricalSolver(mesh, material)
+
+    def test_linear_clips_to_zero_at_full_porosity(self):
+        for mode in ('compression', 'tension', 'shear', 'ilss'):
+            assert self.solver._linear(1.0, mode) == 0.0
+
+    def test_linear_monotone_decreasing_until_saturation(self):
+        prev = 1.0
+        for vp in (0.0, 0.01, 0.05, 0.10, 0.18, 0.20):
+            kd = self.solver._linear(vp, 'compression')
+            assert kd <= prev + 1e-12
+            assert 0.0 <= kd <= 1.0
+            prev = kd
+
+    def test_linear_internal_clip_tolerates_fp_overshoot(self):
+        # FE element-mean averaging can produce 1 + ~1e-15.
+        kd = self.solver._linear(1.0 + 1e-15, 'compression')
+        assert kd == 0.0
+
+    def test_internal_clip_rejects_nan(self):
+        with pytest.raises(ValueError, match="non-finite"):
+            self.solver._judd_wright(float('nan'), 'compression')
+
+
+class TestCLTDegradation:
+    """Boundary tests for compute_degraded_clt_moduli (#12)."""
+
+    def setup_method(self):
+        from porosity_fe_analysis import compute_degraded_clt_moduli, \
+            compute_degraded_clt_flexural_modulus
+        self.compute_degraded_clt_moduli = compute_degraded_clt_moduli
+        self.compute_degraded_clt_flexural_modulus = compute_degraded_clt_flexural_modulus
+        self.material = MATERIALS['T800_epoxy']
+        self.layup = [0, 45, 90, -45, 0, 0, -45, 90, 45, 0]
+
+    def test_pristine_at_zero_porosity(self):
+        deg = self.compute_degraded_clt_moduli(self.material, self.layup, Vp=0.0)
+        # At Vp=0, degraded should be very close to nearly-zero-Vp baseline.
+        baseline = self.compute_degraded_clt_moduli(self.material, self.layup, Vp=1e-9)
+        for key in ('Ex', 'Ey', 'Gxy'):
+            assert abs(deg[key] - baseline[key]) / baseline[key] < 1e-3
+
+    def test_moduli_decrease_with_porosity(self):
+        low = self.compute_degraded_clt_moduli(self.material, self.layup, Vp=0.01)
+        high = self.compute_degraded_clt_moduli(self.material, self.layup, Vp=0.10)
+        for key in ('Ex', 'Ey', 'Gxy'):
+            assert high[key] < low[key]
+
+    def test_flexural_modulus_decreases_with_porosity(self):
+        f_low = self.compute_degraded_clt_flexural_modulus(
+            self.material, self.layup, Vp=0.0
+        )['Ef_x']
+        f_high = self.compute_degraded_clt_flexural_modulus(
+            self.material, self.layup, Vp=0.05
+        )['Ef_x']
+        assert f_high < f_low
+
+
+class TestValidateCLISmoke:
+    """Smoke tests for the validate_porosity CLI entry point (#12)."""
+
+    def test_help_exits_zero(self):
+        from validate_porosity_cli import main
+        with pytest.raises(SystemExit) as exc:
+            main(['--help'])
+        assert exc.value.code == 0
+
+
+class TestLayupParser:
+    """parse_layup is a pure helper extracted in #9; tested here for #12."""
+
+    def setup_method(self):
+        from porosity_gui import parse_layup
+        self.parse_layup = parse_layup
+
+    def test_simple_slash_form(self):
+        assert self.parse_layup('[0/45/-45/90]') == [0.0, 45.0, -45.0, 90.0]
+
+    def test_repeat_and_symmetry(self):
+        out = self.parse_layup('[0/90]_2s')
+        # repeat then mirror: [0,90,0,90] -> [0,90,0,90,90,0,90,0]
+        assert out == [0.0, 90.0, 0.0, 90.0, 90.0, 0.0, 90.0, 0.0]
+
+    def test_comma_separator_alternative(self):
+        assert self.parse_layup('[90, 0, 90]') == [90.0, 0.0, 90.0]
+
+    def test_empty_raises(self):
+        with pytest.raises(ValueError, match="empty"):
+            self.parse_layup('')
+
+    def test_invalid_angle_token_raises(self):
+        with pytest.raises(ValueError, match="Invalid ply angle"):
+            self.parse_layup('[0/oops/90]')
+
+    def test_invalid_repeat_token_raises(self):
+        with pytest.raises(ValueError, match="Invalid repeat count"):
+            self.parse_layup('[0/45]_xyz')
+
+    def test_negative_repeat_raises(self):
+        with pytest.raises(ValueError, match=">= 1"):
+            self.parse_layup('[0/45]_-3')
+
+    def test_no_angles_raises(self):
+        with pytest.raises(ValueError, match="No ply angles"):
+            self.parse_layup('[]_3s')


### PR DESCRIPTION
Closes the documentation gap reported in issue #3: the README equations
KD = exp(-alpha * Vp) (Judd-Wright) and KD = (1 - Vp)^n (power law) had
no definitions, units, calibration guidance, or typical ranges. Users
defining custom materials had no reference for choosing values.

- README "Empirical Strength Knockdown" section now defines Vp as a
  fraction in [0, 1], explains alpha and n with literature context
  (Judd & Wright 1978, Mackenzie 1950, Rice 2005), tabulates the
  QI-calibrated coefficients (Elhajjar 2025), documents the f_md layup
  scaling with worked examples, states validity bounds (Vp <= ~5%), and
  gives a step-by-step calibration recipe (ASTM D2344/D7264/D3039/D6641).
- Add docstrings to EmpiricalSolver._judd_wright and ._power_law.
- Add a mode-meaning comment block above the QI coefficient dicts.
- Extend CONTRIBUTING.md "Adding New Porosity Models" with calibration
  and regression guidance.
- Fix Judd & Wright citation year (1986 -> 1978) in References, and add
  Mackenzie 1950 and Rice 2005 entries.