### PR TITLE
Add CSV export (#30) and fix four GUI threading bugs (#17)

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,8 @@ validate_porosity --quiet            # suppress progress output
 | `porosity_knockdown_curves.png` | Knockdown vs porosity curves |
 | `porosity_analysis_results_*.json` | Numerical results (JSON) |
 
+The GUI's **File → Export Results** menu writes the active run's empirical knockdown table to either JSON or CSV — the format is picked from the file extension you type in the save dialog (`.json` or `.csv`). CSV files include the analysis configuration as `#`-prefixed comment lines at the top (which pandas, Excel, and MATLAB all ignore by default), followed by a flat `mode,model,failure_stress_MPa,knockdown` table.
+
 ## Inputs and Conventions
 
 ### Void volume fraction `Vp`

--- a/porosity_gui.py
+++ b/porosity_gui.py
@@ -13,6 +13,7 @@ Usage
 
 from __future__ import annotations
 
+import csv
 import dataclasses
 import json
 import sys
@@ -110,6 +111,70 @@ def _check_pyqt6() -> None:
             "  pip install PyQt6\n"
             "Or run the analysis script directly: python porosity_fe_analysis.py"
         )
+
+
+# ======================================================================
+# Result export helpers (module-level so they're testable without Qt)
+# ======================================================================
+
+def build_export_payload(result: dict) -> dict:
+    """Flatten an analysis result into the export payload structure.
+
+    Shared by the JSON and CSV writers so both formats describe the same
+    fields. ``result`` is the dict produced by ``AnalysisWorker`` and stored
+    on the main window as ``self._result``.
+    """
+    cfg = result["config"]
+    emp = result["empirical"]
+    payload = {
+        "config": {
+            "material": cfg["material_name"],
+            "n_plies": cfg["n_plies"],
+            "t_ply": cfg["t_ply"],
+            "Vp_percent": cfg["Vp"],
+            "distribution": cfg["distribution"],
+            "void_shape": cfg["void_shape"],
+            "mesh": f"{cfg['nx']}x{cfg['ny']}x{cfg['nz']}",
+        },
+        "empirical": {},
+    }
+    for mode in emp:
+        payload["empirical"][mode] = {}
+        for model in emp[mode]:
+            r = emp[mode][model]
+            payload["empirical"][mode][model] = {
+                "failure_stress_MPa": r["failure_stress"],
+                "knockdown": r["knockdown"],
+            }
+    return payload
+
+
+def write_results_json(filepath: str, payload: dict) -> None:
+    with open(filepath, "w", encoding="utf-8") as f:
+        json.dump(payload, f, indent=2)
+
+
+def write_results_csv(filepath: str, payload: dict) -> None:
+    """Write the export payload as a flat CSV.
+
+    Configuration metadata is written as comment lines prefixed with ``#``;
+    pandas (``read_csv(comment='#')``) and most CSV viewers handle this
+    cleanly, while Excel ignores the comments and treats the table as data.
+    """
+    with open(filepath, "w", encoding="utf-8", newline="") as f:
+        # Config preamble as comment lines
+        for key, value in payload["config"].items():
+            f.write(f"# {key}: {value}\n")
+        writer = csv.writer(f)
+        writer.writerow(["mode", "model", "failure_stress_MPa", "knockdown"])
+        for mode in payload["empirical"]:
+            for model in payload["empirical"][mode]:
+                r = payload["empirical"][mode][model]
+                writer.writerow([
+                    mode, model,
+                    r["failure_stress_MPa"],
+                    r["knockdown"],
+                ])
 
 
 # ======================================================================
@@ -1270,7 +1335,7 @@ if HAS_PYQT6:
                     canvas.draw()
 
         def _on_export(self) -> None:
-            """Export results to JSON."""
+            """Export results to JSON or CSV."""
             if self._result is None:
                 QMessageBox.information(
                     self, "No Results",
@@ -1278,43 +1343,30 @@ if HAS_PYQT6:
                 )
                 return
 
-            filepath, _ = QFileDialog.getSaveFileName(
+            filepath, selected_filter = QFileDialog.getSaveFileName(
                 self, "Export Results", "porosity_results.json",
-                "JSON Files (*.json);;All Files (*)"
+                "JSON Files (*.json);;CSV Files (*.csv);;All Files (*)"
             )
-            if filepath:
-                try:
-                    result = self._result
-                    cfg = result["config"]
-                    emp = result["empirical"]
+            if not filepath:
+                return
+            try:
+                payload = build_export_payload(self._result)
+                # Pick the format from the file extension, falling back to the
+                # selected filter (so a user who types "results.csv" gets CSV
+                # even when the JSON filter is active).
+                lower = filepath.lower()
+                if lower.endswith(".csv"):
+                    write_results_csv(filepath, payload)
+                elif lower.endswith(".json"):
+                    write_results_json(filepath, payload)
+                elif "csv" in (selected_filter or "").lower():
+                    write_results_csv(filepath, payload)
+                else:
+                    write_results_json(filepath, payload)
 
-                    output = {
-                        "config": {
-                            "material": cfg["material_name"],
-                            "n_plies": cfg["n_plies"],
-                            "t_ply": cfg["t_ply"],
-                            "Vp_percent": cfg["Vp"],
-                            "distribution": cfg["distribution"],
-                            "void_shape": cfg["void_shape"],
-                            "mesh": f"{cfg['nx']}x{cfg['ny']}x{cfg['nz']}",
-                        },
-                        "empirical": {},
-                    }
-                    for mode in emp:
-                        output["empirical"][mode] = {}
-                        for model in emp[mode]:
-                            r = emp[mode][model]
-                            output["empirical"][mode][model] = {
-                                "failure_stress_MPa": r["failure_stress"],
-                                "knockdown": r["knockdown"],
-                            }
-
-                    with open(filepath, "w", encoding="utf-8") as f:
-                        json.dump(output, f, indent=2)
-
-                    self.statusBar().showMessage(f"Results exported to {filepath}")
-                except Exception as e:
-                    QMessageBox.critical(self, "Export Error", str(e))
+                self.statusBar().showMessage(f"Results exported to {filepath}")
+            except Exception as e:
+                QMessageBox.critical(self, "Export Error", str(e))
 
         def _on_about(self) -> None:
             """Show about dialog."""

--- a/porosity_gui.py
+++ b/porosity_gui.py
@@ -16,9 +16,13 @@ from __future__ import annotations
 import csv
 import dataclasses
 import json
+import logging
 import sys
+import threading
 import traceback
 from typing import Optional
+
+logger = logging.getLogger(__name__)
 
 try:
     from PyQt6.QtWidgets import (
@@ -193,10 +197,18 @@ if HAS_PYQT6:
         def __init__(self, config: dict) -> None:
             super().__init__()
             self.config = config
-            self._stop_requested = False
+            # threading.Event has built-in memory-fence semantics; a plain
+            # bool can be missed by the worker if the write hasn't propagated
+            # across cores before the next checkpoint read.
+            self._stop_event = threading.Event()
 
         def request_stop(self) -> None:
-            self._stop_requested = True
+            self._stop_event.set()
+
+        @property
+        def _stop_requested(self) -> bool:
+            """Back-compat accessor for the six checkpoint reads in run()."""
+            return self._stop_event.is_set()
 
         def run(self) -> None:
             try:
@@ -716,13 +728,26 @@ if HAS_PYQT6:
 
         def _on_run(self) -> None:
             """Run the porosity analysis in a background thread."""
+            # Guard against re-entry: a fast double-click on Run could land a
+            # second call while the previous worker is still alive. Without
+            # this guard, the new AnalysisWorker would overwrite self._worker
+            # and the prior thread would be orphaned (request_stop() can only
+            # reach the latest worker).
+            if self._worker is not None and self._worker.isRunning():
+                return
+
+            # Disable the button *before* parsing widgets so a double-click
+            # during _build_config() can't start a second analysis. _build_config
+            # iterates many widgets and can take long enough on slower hardware
+            # for a fast user to click twice.
+            self.run_btn.setEnabled(False)
             try:
                 config = self._build_config()
             except Exception as e:
+                self.run_btn.setEnabled(True)
                 QMessageBox.critical(self, "Configuration Error", str(e))
                 return
 
-            self.run_btn.setEnabled(False)
             self.stop_btn.setEnabled(True)
             self.stop_btn.setVisible(True)
             self.statusBar().showMessage("Running analysis...")
@@ -814,10 +839,27 @@ if HAS_PYQT6:
             self._stop_progress()
 
             if self._worker is not None:
-                self._worker.request_stop()
-                if self._worker.isRunning():
-                    self._worker.terminate()
-                    self._worker.wait(2000)
+                worker = self._worker
+                worker.request_stop()
+                if worker.isRunning():
+                    worker.terminate()
+                    worker.wait(2000)
+                    if worker.isRunning():
+                        # terminate() is advisory — if the worker is wedged in
+                        # a C extension (numpy/scipy can sit in BLAS calls), it
+                        # may keep running. Surface this rather than pretending
+                        # the analysis was cleanly stopped.
+                        logger.error(
+                            "AnalysisWorker did not terminate within 2s; "
+                            "thread state remains running."
+                        )
+                        QMessageBox.warning(
+                            self, "Stop Incomplete",
+                            "The analysis worker did not terminate within "
+                            "the 2-second grace period — it may still be "
+                            "consuming CPU. Please restart the application "
+                            "if this keeps happening."
+                        )
                 self._worker = None
 
             self.run_btn.setEnabled(True)
@@ -829,6 +871,24 @@ if HAS_PYQT6:
         def _on_progress(self, msg: str) -> None:
             """Update status bar with progress message."""
             self.statusBar().showMessage(msg)
+
+        def closeEvent(self, event) -> None:
+            """Ensure the worker thread exits before the window closes.
+
+            Without this override, closing the window mid-analysis terminates
+            the QApplication event loop while the QThread keeps running until
+            its solve completes — the Python process keeps consuming CPU
+            even though the UI is gone.
+            """
+            worker = getattr(self, "_worker", None)
+            if worker is not None and worker.isRunning():
+                worker.request_stop()
+                # Give the cooperative checkpoints a chance to fire before
+                # falling back to terminate(). 2s matches _on_stop's grace.
+                if not worker.wait(2000):
+                    worker.terminate()
+                    worker.wait()  # no timeout — must finish before close
+            event.accept()
 
         # ----------------------------------------------------------
         # Results formatting

--- a/tests/test_porosity_fe.py
+++ b/tests/test_porosity_fe.py
@@ -1617,3 +1617,76 @@ class TestLayupParser:
     def test_no_angles_raises(self):
         with pytest.raises(ValueError, match="No ply angles"):
             self.parse_layup('[]_3s')
+
+
+class TestExportHelpers:
+    """Module-level CSV / JSON writers extracted for issue #30."""
+
+    @staticmethod
+    def _sample_result():
+        return {
+            "config": {
+                "material_name": "T800_epoxy",
+                "n_plies": 24,
+                "t_ply": 0.183,
+                "Vp": 3.0,
+                "distribution": "uniform",
+                "void_shape": "spherical",
+                "nx": 30, "ny": 10, "nz": 12,
+            },
+            "empirical": {
+                "compression": {
+                    "judd_wright": {"failure_stress": 1234.5, "knockdown": 0.823},
+                    "power_law": {"failure_stress": 1300.0, "knockdown": 0.867},
+                },
+                "ilss": {
+                    "judd_wright": {"failure_stress": 67.0, "knockdown": 0.744},
+                },
+            },
+        }
+
+    def test_build_export_payload_shape(self):
+        from porosity_gui import build_export_payload
+        payload = build_export_payload(self._sample_result())
+        assert payload["config"]["material"] == "T800_epoxy"
+        assert payload["config"]["mesh"] == "30x10x12"
+        assert payload["empirical"]["compression"]["judd_wright"]["knockdown"] == 0.823
+
+    def test_write_results_json_round_trips(self, tmp_path):
+        from porosity_gui import build_export_payload, write_results_json
+        path = str(tmp_path / "out.json")
+        write_results_json(path, build_export_payload(self._sample_result()))
+        with open(path, encoding="utf-8") as f:
+            data = json.load(f)
+        assert data["empirical"]["compression"]["judd_wright"]["knockdown"] == 0.823
+
+    def test_write_results_csv_header_and_rows(self, tmp_path):
+        from porosity_gui import build_export_payload, write_results_csv
+        path = str(tmp_path / "out.csv")
+        write_results_csv(path, build_export_payload(self._sample_result()))
+        with open(path, encoding="utf-8") as f:
+            lines = f.read().splitlines()
+        # First N lines are #-prefixed config; then the header; then rows.
+        comment_lines = [l for l in lines if l.startswith("#")]
+        data_lines = [l for l in lines if not l.startswith("#")]
+        assert any("material: T800_epoxy" in l for l in comment_lines)
+        assert any("Vp_percent: 3.0" in l for l in comment_lines)
+        assert data_lines[0] == "mode,model,failure_stress_MPa,knockdown"
+        # Three (mode, model) rows in the sample → header + 3 = 4 lines.
+        assert len(data_lines) == 4
+        assert "compression,judd_wright,1234.5,0.823" in data_lines
+
+    def test_write_results_csv_round_trips_via_csv_module(self, tmp_path):
+        import csv as _csv
+        from porosity_gui import build_export_payload, write_results_csv
+        path = str(tmp_path / "out.csv")
+        write_results_csv(path, build_export_payload(self._sample_result()))
+        with open(path, encoding="utf-8", newline="") as f:
+            # Skip comment lines exactly the way pandas read_csv(comment='#') would.
+            rows = [r for r in _csv.reader(f) if r and not r[0].startswith("#")]
+        assert rows[0] == ["mode", "model", "failure_stress_MPa", "knockdown"]
+        # All non-header rows should parse to four columns; numeric ones finite.
+        for row in rows[1:]:
+            assert len(row) == 4
+            float(row[2])
+            float(row[3])


### PR DESCRIPTION
## Summary

Two unrelated GUI fixes that landed on the branch after PR #26 merged.

- **#30 — CSV export** (`fbceead`). The GUI's *File → Export Results* dialog now offers both JSON and CSV filters; the format is picked from the typed extension (or the selected filter as a fallback). CSV layout: `#`-prefixed config metadata at the top, then a flat `mode,model,failure_stress_MPa,knockdown` table — readable by pandas (`read_csv(comment='#')`), Excel, and MATLAB without preprocessing. Payload-build, JSON-write, and CSV-write are factored into module-level `build_export_payload` / `write_results_json` / `write_results_csv` helpers so they're testable without PyQt6.

- **#17 — GUI threading** (`dd92d77`). Four bugs in `porosity_gui.py`:
  1. **`closeEvent` missing.** Closing the window mid-analysis orphaned the QThread; the QApplication exited while the worker kept consuming CPU. Override now requests a cooperative stop, waits up to 2s, then falls back to `terminate()` + unbounded `wait()` so the process exits cleanly.
  2. **`_stop_requested` was a plain `bool`.** A Stop pressed micro-seconds before a checkpoint could be missed because the write hadn't propagated across cores. Switched to `threading.Event` (built-in memory fence). A back-compat `_stop_requested` property keeps the six existing checkpoint reads working unchanged.
  3. **Run-button race.** `_build_config()` ran before `run_btn.setEnabled(False)`, so a fast double-click could start a second `AnalysisWorker` that overwrote `self._worker` (orphaning the first). Now disables the button first and guards against reentry when a worker is still running.
  4. **`terminate()` unverified.** `_on_stop` called `terminate()` + `wait(2000)` without checking whether the thread actually died. Now logs an error and surfaces a `QMessageBox.warning` when `wait()` returns with `isRunning()` still true.

## Test plan

- [x] 255 tests pass locally (`pytest tests/ -v`) — 4 new CSV-export round-trip tests added.
- [x] `porosity_gui.py` parses (`python -c "import ast; ast.parse(...)"`).
- [ ] CI matrix passes (Ubuntu/macOS/Windows × Python 3.10/3.11/3.12/3.13).
- [ ] Manual GUI smoke test: open, run analysis, **File → Export Results**, type `results.csv`, confirm CSV opens in Excel / pandas with `mode,model,failure_stress_MPa,knockdown` columns.
- [ ] Manual GUI smoke test: open, run a long analysis, click Stop, confirm `_on_stop` returns promptly; close window mid-run and confirm Python process exits.

No unit tests for the threading fixes — all four are integration-level and CI installs PyQt6 *after* pytest (plus the sandbox lacks `libEGL.so.1`). The behavior changes are small and localized to `porosity_gui.py`.

https://claude.ai/code/session_01EGeTTcpbtS65jLuLAHFmeh

---
_Generated by [Claude Code](https://claude.ai/code/session_01EGeTTcpbtS65jLuLAHFmeh)_