### PR TITLE
Fix six issues: penny Eshelby (#32), inverted elements (#33), strain rotation (#38), MAE aggregation (#36), version drift (#45), GUI install error (#46)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,71 @@
 
 All notable changes to PorosityFE will be documented in this file.
 
+## [1.2.0] - 2026-05-11
+
+### Fixed
+- **FE: penny / oblate voids were silently routed to the prolate Eshelby
+  formula** because `ar = max/min ≥ 1` made the oblate branch unreachable.
+  `_mt_effective_stiffness` now detects the axis of symmetry, uses the
+  correct g-function branch (prolate vs oblate), and permutes the Voigt
+  tensor to align with the actual void axis. Penny-shaped voids
+  (`VOID_SHAPES['penny']`) now produce physically-correct anisotropy
+  with through-disk degradation exceeding in-plane degradation. (#32)
+- **FE: stiffness assembly now rejects inverted elements** (non-positive
+  `det(J)`) at quadrature time rather than letting a wrong-sign block
+  silently corrupt the assembled global K. (#33)
+- **FE: engineering strain in post-processing is now rotated with
+  `strain_transformation_3d`** (was `stress_transformation_3d`), so
+  `FieldResults.strain_local` shear components are no longer off by 2x.
+  Stress / Tsai-Wu paths were already correct and are unchanged. (#38)
+- **GUI: `porosity-fe` console script** now prints a friendly stderr
+  message and exits non-zero when PyQt6 is missing, instead of leaking
+  a Python traceback. Error text mentions the discoverable
+  `pip install porosity-fe[gui]` form. (#46)
+
+### Added
+- **CSV export** alongside the existing JSON export in the GUI's
+  *File → Export Results* menu. Format is picked from the typed
+  extension (`.csv` / `.json`) or the selected filter. CSV layout:
+  `#`-prefixed config metadata, then a flat
+  `mode,model,failure_stress_MPa,knockdown` table. (#30)
+- **`EmpiricalSolver` constructor overrides** for `judd_wright_alpha`,
+  `power_law_n`, and `linear_beta` — partial-merge with QI defaults,
+  layup-scaled the same way, replacing the documented subclass
+  workaround. (#16)
+- **Input validation** on `MaterialProperties`, `CompositeMesh`,
+  `VoidGeometry`, and `Hex8Element` constructors (positive moduli /
+  strengths, Poisson ratios in `(-1, 0.5)`, positive geometry, fraction
+  range on `node_porosities`). (#13)
+- **Validation reporting** now publishes both property-weighted and
+  point-weighted MAE — the published 7.7% is the property-weighted form;
+  point-weighted is ~7.0%. (#36) New `summarize_mae()` helper exposes
+  both for downstream tools.
+- **GUI threading hardening**: `closeEvent` waits for the worker to
+  exit; `_stop_requested` uses `threading.Event` for cross-core memory
+  fences; the Run button is disabled before `_build_config` runs;
+  `_on_stop` warns when the worker doesn't terminate within 2s. (#17)
+- **Numerical-stability guards** in Mori-Tanaka inversion (pinv
+  fallback + finite check) and Tsai-Wu evaluation (strength-floor clamp,
+  non-finite check, fp clip on `elem_Vp`). (#14)
+- **Error-message polish** on bad material / void-shape / mode /
+  cluster_location names; UTF-8 encoding on all file I/O; floating-point
+  noise clip on `Vp ≈ 1.0`; string `Vp` rejected with `TypeError`. (#21, #22, #23)
+- **PyInstaller spec parity**: `PorosityFE.spec` now mirrors
+  `ValidatePorosity.spec`'s dataset bundling and adds commonly-missed
+  hidden imports (`PyQt6.sip`, `PyQt6.QtSvg`,
+  `scipy.sparse.csgraph._validation`, `scipy.special.cython_special`). (#24)
+- **Documentation**: README "Inputs and Conventions" section clarifies
+  Vp as a fraction in [0, 1] with do/don't table; "Defining a custom
+  material" worked example; per-ply vs. specimen-average porosity behavior
+  for empirical vs. FE paths. (#1, #2, #4)
+
+### Changed
+- **Version source of truth**: `validate_porosity --version` now reads
+  from `importlib.metadata` with a hard-coded fallback. Version aligned
+  across `pyproject.toml`, `CHANGELOG.md`, `CITATION.cff`, README BibTeX,
+  and `PorosityFE.spec`. (#45)
+
 ## [1.1.1] - 2026-04-19
 
 ### Changed

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: "If you use this software, please cite it as below."
 type: software
 title: "PorosityFE: Porosity-Degraded Composite Laminate Analysis"
-version: 1.0.0
-date-released: 2026-04-03
+version: 1.2.0
+date-released: 2026-05-11
 url: "https://github.com/elhajjar1/PorosityFE"
 repository-code: "https://github.com/elhajjar1/PorosityFE"
 license: MIT

--- a/PorosityFE.spec
+++ b/PorosityFE.spec
@@ -112,8 +112,8 @@ app = BUNDLE(
     info_plist={
         'CFBundleName': 'Porosity FE Analysis',
         'CFBundleDisplayName': 'Porosity FE Analysis',
-        'CFBundleShortVersionString': '1.0.0',
-        'CFBundleVersion': '1.0.0',
+        'CFBundleShortVersionString': '1.2.0',
+        'CFBundleVersion': '1.2.0',
         'NSHighResolutionCapable': True,
         'LSMinimumSystemVersion': '10.15',
     },

--- a/README.md
+++ b/README.md
@@ -348,7 +348,11 @@ or in-process via `validation/validate_all.py`.
 | Transverse tensile strength | 3 | 14.5% |
 | Shear modulus (A-matrix CLT) | 1 | 15.4% |
 
-Overall MAE: **7.7%** across 35 (paper, property) pairs.
+Overall MAE:
+- Property-weighted: **7.69%** across 35 (paper, property) pairs (each entry weighted equally — what `validate_porosity` reports as the headline).
+- Point-weighted: **7.03%** across 239 individual (Vp, normalized) data points (each measurement weighted equally — the standard convention in regression-error reporting).
+
+The two aggregations differ because datasets carry very different numbers of points; `validate_porosity` prints both in the run summary.
 
 ## Limitations
 
@@ -372,7 +376,7 @@ If you use PorosityFE in your research, please cite:
   title = {{PorosityFE}: Porosity-Degraded Composite Laminate Analysis},
   year = {2026},
   url = {https://github.com/elhajjar1/PorosityFE},
-  version = {1.0.0}
+  version = {1.2.0}
 }
 ```
 

--- a/porosity_fe_analysis.py
+++ b/porosity_fe_analysis.py
@@ -1645,6 +1645,13 @@ def _mt_effective_stiffness(C_m: np.ndarray, Vp: float,
     Standalone Eshelby-tensor-based Mori-Tanaka calculation for use inside
     Hex8Element.
 
+    The Eshelby tensor is computed in a canonical frame (symmetry axis along
+    x_1) and then permuted to align with the actual void axis. The previous
+    implementation used ``ar = max/min`` as the aspect ratio, which is
+    always >= 1, leaving the ``else: # Oblate`` branch unreachable — oblate
+    voids (penny shape) were silently routed to the prolate formulas. See
+    issue #32.
+
     Parameters
     ----------
     C_m : np.ndarray
@@ -1666,19 +1673,55 @@ def _mt_effective_stiffness(C_m: np.ndarray, Vp: float,
     if Vp > 0.99:
         return np.zeros((6, 6))
 
-    ar = max(void_shape_radii) / min(void_shape_radii)
     nu = nu_m
+    r = list(void_shape_radii)
+    sphere_tol = 0.01
 
-    # Build Eshelby tensor
     S = np.zeros((6, 6))
-    if abs(ar - 1.0) < 0.01:  # Sphere
+
+    if (max(r) - min(r)) / max(r) < sphere_tol:
+        # All three radii within 1% — treat as sphere.
         S[0, 0] = S[1, 1] = S[2, 2] = (7 - 5 * nu) / (15 * (1 - nu))
         S[0, 1] = S[0, 2] = S[1, 0] = S[1, 2] = S[2, 0] = S[2, 1] = \
             (5 * nu - 1) / (15 * (1 - nu))
         S[3, 3] = S[4, 4] = S[5, 5] = (4 - 5 * nu) / (15 * (1 - nu))
-    elif ar > 1.0:  # Prolate
-        g = ar / (ar**2 - 1)**1.5 * (ar * np.sqrt(ar**2 - 1) - np.arccosh(ar))
-        a2 = ar**2
+    else:
+        # Axisymmetric: find the symmetry axis (the radius that differs
+        # from the other two equal radii).
+        def _close(a, b):
+            return abs(a - b) / max(a, b) < sphere_tol
+
+        if _close(r[1], r[2]):
+            idx_axis = 0  # a_1 is the unique axis
+        elif _close(r[0], r[2]):
+            idx_axis = 1
+        elif _close(r[0], r[1]):
+            idx_axis = 2
+        else:
+            # Triaxial: no axisymmetric closed form. Approximate by
+            # treating the largest axis as the symmetry axis (prolate
+            # fallback). Documented limitation; acceptable because the
+            # default VOID_SHAPES are all axisymmetric.
+            idx_axis = r.index(max(r))
+
+        a_axis = r[idx_axis]
+        a_eq = r[(idx_axis + 1) % 3]  # equatorial radius
+        alpha = a_axis / a_eq
+        a2 = alpha ** 2
+
+        # g-function with correct branch:
+        #   prolate (alpha > 1): cosh-based form
+        #   oblate  (alpha < 1): arccos-based form
+        # The S-tensor formulas below are identical in structure for both;
+        # only the g-function and the sign of (alpha^2 - 1) differ.
+        if alpha > 1.0:
+            g = alpha / (a2 - 1) ** 1.5 * (
+                alpha * np.sqrt(a2 - 1) - np.arccosh(alpha))
+        else:
+            g = alpha / (1 - a2) ** 1.5 * (
+                np.arccos(alpha) - alpha * np.sqrt(1 - a2))
+
+        # Eshelby tensor in canonical frame (symmetry axis along x_1).
         S[0, 0] = (1.0 / (2 * (1 - nu))) * (
             1 - 2 * nu + (3 * a2 - 1) / (a2 - 1) - (1 - 2 * nu + 3 * a2 / (a2 - 1)) * g)
         S[1, 1] = S[2, 2] = (3.0 / (8 * (1 - nu))) * a2 / (a2 - 1) + \
@@ -1694,25 +1737,19 @@ def _mt_effective_stiffness(C_m: np.ndarray, Vp: float,
         S[4, 4] = S[5, 5] = (1.0 / (4 * (1 - nu))) * (
             1 - 2 * nu - (a2 + 1) / (a2 - 1) -
             0.5 * (1 - 2 * nu - 3 * (a2 + 1) / (a2 - 1)) * g)
-    else:  # Oblate
-        p = 1.0 / ar
-        g_ob = p / (p**2 - 1)**1.5 * (np.arccos(1.0 / p) - (1.0 / p) * np.sqrt(1 - 1.0 / p**2))
-        a2 = ar**2
-        S[0, 0] = (1.0 / (2 * (1 - nu))) * (
-            1 - 2 * nu + (3 * a2 - 1) / (a2 - 1) - (1 - 2 * nu + 3 * a2 / (a2 - 1)) * g_ob)
-        S[1, 1] = S[2, 2] = (3.0 / (8 * (1 - nu))) * a2 / (a2 - 1) + \
-            (1.0 / (4 * (1 - nu))) * (1 - 2 * nu - 9.0 / (4 * (a2 - 1))) * g_ob
-        S[0, 1] = S[0, 2] = -(1.0 / (2 * (1 - nu))) * a2 / (a2 - 1) + \
-            (1.0 / (4 * (1 - nu))) * (3 * a2 / (a2 - 1) - (1 - 2 * nu)) * g_ob
-        S[1, 0] = S[2, 0] = -(1.0 / (2 * (1 - nu))) * 1.0 / (a2 - 1) + \
-            (1.0 / (4 * (1 - nu))) * (3.0 / (a2 - 1) - (1 - 2 * nu)) * g_ob
-        S[1, 2] = S[2, 1] = (1.0 / (4 * (1 - nu))) * (
-            a2 / (2 * (a2 - 1)) - (1 - 2 * nu + 3.0 / (4 * (a2 - 1))) * g_ob)
-        S[3, 3] = (1.0 / (4 * (1 - nu))) * (
-            a2 / (2 * (a2 - 1)) + (1 - 2 * nu - 3.0 / (4 * (a2 - 1))) * g_ob)
-        S[4, 4] = S[5, 5] = (1.0 / (4 * (1 - nu))) * (
-            1 - 2 * nu - (a2 + 1) / (a2 - 1) -
-            0.5 * (1 - 2 * nu - 3 * (a2 + 1) / (a2 - 1)) * g_ob)
+
+        # Permute the Voigt tensor to align the symmetry axis with the
+        # actual unique-radius axis. For a swap x_1 <-> x_k the Voigt
+        # permutation is:
+        #   x_1 <-> x_2: [1, 0, 2, 4, 3, 5]
+        #   x_1 <-> x_3: [2, 1, 0, 5, 4, 3]
+        if idx_axis != 0:
+            if idx_axis == 1:
+                perm = [1, 0, 2, 4, 3, 5]
+            else:
+                perm = [2, 1, 0, 5, 4, 3]
+            P = np.eye(6)[perm]
+            S = P @ S @ P.T
 
     I6 = np.eye(6)
     inner = I6 - (1 - Vp) * S

--- a/porosity_fe_analysis.py
+++ b/porosity_fe_analysis.py
@@ -2065,6 +2065,14 @@ class Hex8Element:
         """Element stiffness matrix (24x24) via 2x2x2 Gauss quadrature.
 
         Ke = sum over GPs of: B^T @ C_bar @ B * |J| * w
+
+        Raises
+        ------
+        ValueError
+            If the Jacobian determinant is non-positive at any Gauss point —
+            this signals a degenerate or inverted element whose contribution
+            would corrupt the assembled global stiffness with a wrong-sign
+            block. Catching here makes failures legible instead of silent.
         """
         Ke = np.zeros((24, 24))
         for gp_idx in range(len(self._gauss_weights)):
@@ -2074,6 +2082,15 @@ class Hex8Element:
             C_bar = self._degraded_stiffness(xi, eta, zeta)
             J = self.jacobian(xi, eta, zeta)
             detJ = np.linalg.det(J)
+            if not np.isfinite(detJ) or detJ <= 0.0:
+                raise ValueError(
+                    f"Element has non-positive Jacobian determinant "
+                    f"(detJ={detJ!r}) at Gauss point "
+                    f"(xi={xi}, eta={eta}, zeta={zeta}). The element is "
+                    f"degenerate or has inverted node ordering — its "
+                    f"contribution would silently corrupt the assembled "
+                    f"stiffness."
+                )
             with np.errstate(over='ignore', invalid='ignore', divide='ignore'):
                 Ke_contrib = (B.T @ C_bar @ B) * detJ * w
             # Protect against overflow in void elements
@@ -2129,13 +2146,20 @@ class Hex8Element:
 
     @property
     def volume(self) -> float:
-        """Element volume via Gauss quadrature."""
+        """Element volume via Gauss quadrature.
+
+        Uses ``abs(det(J))`` so an inverted-but-otherwise-valid element
+        still reports a sensible (positive) volume. ``stiffness_matrix``
+        rejects inverted elements at assembly time, so the negative-volume
+        case is only reachable via direct ``.volume`` lookup on a degenerate
+        element constructed manually.
+        """
         vol = 0.0
         for gp_idx in range(len(self._gauss_weights)):
             xi, eta, zeta = self._gauss_points[gp_idx]
             w = self._gauss_weights[gp_idx]
             J = self.jacobian(xi, eta, zeta)
-            vol += np.linalg.det(J) * w
+            vol += abs(np.linalg.det(J)) * w
         return float(vol)
 
 
@@ -2633,13 +2657,17 @@ class FESolver:
             stress_global[e] = sig_g
             strain_global[e] = eps_g
 
-            # Transform to local coordinates
+            # Transform to local coordinates. Stress uses T_sigma; engineering
+            # strain (with gamma_ij = 2*eps_ij in slots 3-5) uses T_epsilon —
+            # T_sigma applied to engineering strain leaves the shear components
+            # off by 2x.
             ply_rad = np.radians(float(self.mesh.ply_angles[e]))
-            T_ply = stress_transformation_3d(ply_rad, axis='z')
+            T_sigma = stress_transformation_3d(ply_rad, axis='z')
+            T_eps = strain_transformation_3d(ply_rad, axis='z')
 
             for g in range(n_gp):
-                stress_local[e, g] = T_ply @ sig_g[g]
-                strain_local[e, g] = T_ply @ eps_g[g]
+                stress_local[e, g] = T_sigma @ sig_g[g]
+                strain_local[e, g] = T_eps @ eps_g[g]
 
         # 6. Evaluate Tsai-Wu at each GP
         max_fi = self._evaluate_tsai_wu(stress_local)

--- a/porosity_gui.py
+++ b/porosity_gui.py
@@ -112,8 +112,11 @@ def _check_pyqt6() -> None:
     if not HAS_PYQT6:
         raise ImportError(
             "Porosity FE GUI requires PyQt6. Install with:\n"
+            "  pip install porosity-fe[gui]\n"
+            "Or, if you already have the source checkout:\n"
             "  pip install PyQt6\n"
-            "Or run the analysis script directly: python porosity_fe_analysis.py"
+            "Or run the analysis script directly without the GUI:\n"
+            "  python porosity_fe_analysis.py"
         )
 
 
@@ -1471,5 +1474,20 @@ def launch() -> None:
         sys.exit(app.exec())
 
 
+def _console_main() -> int:
+    """Console-script wrapper around ``launch()``.
+
+    Catches the friendly ``ImportError`` from ``_check_pyqt6()`` and prints
+    it to stderr instead of leaking a Python traceback when a user runs
+    the ``porosity-fe`` command without the ``[gui]`` extra installed.
+    """
+    try:
+        launch()
+    except ImportError as e:
+        print(str(e), file=sys.stderr)
+        return 1
+    return 0
+
+
 if __name__ == "__main__":
-    launch()
+    sys.exit(_console_main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "porosity-fe"
-version = "1.0.0"
+version = "1.2.0"
 description = "Desktop application for porosity-degraded composite laminate analysis"
 readme = "README.md"
 license = {text = "MIT"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ Repository = "https://github.com/elhajjar1/PorosityFE"
 Issues = "https://github.com/elhajjar1/PorosityFE/issues"
 
 [project.scripts]
-porosity-fe = "porosity_gui:launch"
+porosity-fe = "porosity_gui:_console_main"
 validate_porosity = "validate_porosity_cli:main"
 
 [tool.setuptools]

--- a/tests/test_porosity_fe.py
+++ b/tests/test_porosity_fe.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 """Tests for porosity_fe_analysis.py"""
 
+import dataclasses
+
 import numpy as np
 import scipy.sparse
 import pytest
@@ -978,6 +980,38 @@ class TestHex8Element:
     def test_volume_unit_cube(self):
         assert abs(self.elem.volume - 1.0) < 1e-12
 
+    def test_inverted_element_rejected_at_assembly(self):
+        """Regression for #33: signed det(J) silently corrupting K."""
+        # Swap two adjacent nodes on the bottom face to invert the element.
+        inverted = self.node_coords.copy()
+        inverted[[0, 1]] = inverted[[1, 0]]
+        bad_elem = Hex8Element(
+            node_coords=inverted,
+            C_base=self.C_base,
+            ply_angle_deg=0.0,
+            node_porosities=np.full(8, 0.03),
+            void_shape_radii=(1, 1, 1),
+            nu_m=0.35,
+            C_m=self.C_m,
+        )
+        with pytest.raises(ValueError, match="non-positive Jacobian"):
+            bad_elem.stiffness_matrix()
+
+    def test_inverted_element_volume_still_positive(self):
+        """volume uses abs(det J); only stiffness_matrix raises."""
+        inverted = self.node_coords.copy()
+        inverted[[0, 1]] = inverted[[1, 0]]
+        bad_elem = Hex8Element(
+            node_coords=inverted,
+            C_base=self.C_base,
+            ply_angle_deg=0.0,
+            node_porosities=np.full(8, 0.03),
+            void_shape_radii=(1, 1, 1),
+            nu_m=0.35,
+            C_m=self.C_m,
+        )
+        assert bad_elem.volume > 0
+
     def test_stress_at_gauss_points_shape(self):
         u_elem = np.zeros(24)
         sig = self.elem.stress_at_gauss_points(u_elem)
@@ -1271,6 +1305,31 @@ class TestFESolver:
         solver = FESolver(self.mesh, self.material, self.pf)
         with pytest.raises(ValueError):
             solver.solve(loading='invalid')
+
+    def test_strain_local_uses_strain_transform_not_stress_transform(self):
+        """Regression for #38: engineering strain was rotated via T_sigma
+        (the stress transformation), which leaves the shear slots off by
+        a factor of 2. strain_local must equal T_epsilon @ strain_global
+        per (element, Gauss point) — within numerical noise."""
+        from porosity_fe_analysis import strain_transformation_3d
+        # 45-degree plies make the bug most visible (shear components dominate).
+        mat45 = dataclasses.replace(self.material, n_plies=4)
+        pf = PorosityField(mat45, 0.02, distribution='uniform')
+        mesh = CompositeMesh(pf, mat45, nx=3, ny=2, nz=4,
+                              ply_angles=[45.0, -45.0, -45.0, 45.0])
+        solver = FESolver(mesh, mat45, pf)
+        r = solver.solve(loading='compression', applied_strain=-0.001)
+        # Check transformation invariant on a handful of elements.
+        for e in [0, mesh.n_elements // 2, mesh.n_elements - 1]:
+            ply_rad = np.radians(float(mesh.ply_angles[e]))
+            T_eps = strain_transformation_3d(ply_rad, axis='z')
+            for g in range(8):
+                expected = T_eps @ r.strain_global[e, g]
+                np.testing.assert_allclose(
+                    r.strain_local[e, g], expected,
+                    rtol=1e-10, atol=1e-12,
+                    err_msg=f"strain_local mismatch at elem={e}, gp={g}",
+                )
 
     def test_higher_porosity_softer_response(self):
         """Higher porosity should produce softer material (lower stresses
@@ -1690,3 +1749,27 @@ class TestExportHelpers:
             assert len(row) == 4
             float(row[2])
             float(row[3])
+
+
+class TestConsoleMainWrapper:
+    """Regression for #46: porosity-fe console script must print a friendly
+    message + exit non-zero when PyQt6 is missing, instead of leaking a
+    Python traceback."""
+
+    def test_console_main_exits_zero_or_one(self):
+        """The wrapper must return an int exit code, not raise."""
+        from porosity_gui import _console_main, HAS_PYQT6
+        if HAS_PYQT6:
+            pytest.skip("PyQt6 present; missing-import path can't be exercised")
+        rc = _console_main()
+        assert rc == 1
+
+    def test_check_pyqt6_message_points_to_gui_extra(self):
+        """Error message must mention the [gui] extra so users know what
+        install command to run (not just `pip install PyQt6`)."""
+        from porosity_gui import _check_pyqt6, HAS_PYQT6
+        if HAS_PYQT6:
+            pytest.skip("PyQt6 present; error path can't be exercised")
+        with pytest.raises(ImportError) as exc:
+            _check_pyqt6()
+        assert "porosity-fe[gui]" in str(exc.value)

--- a/tests/test_porosity_fe.py
+++ b/tests/test_porosity_fe.py
@@ -870,6 +870,42 @@ class TestMTEffectiveStiffness:
             C_eff = _mt_effective_stiffness(self.C_m, Vp, (3, 3, 0.3), 0.35)
             assert np.all(np.isfinite(C_eff)), f"non-finite C_eff at Vp={Vp}"
 
+    def test_penny_void_anisotropy_along_short_axis(self):
+        """Regression for #32. A penny-shaped void (3, 3, 0.3) has its
+        symmetry axis along x_3 (the short axis), so the effective
+        stiffness should show LARGER degradation along the through-disk
+        direction (S[2,2]) than along the in-plane directions (S[0,0],
+        S[1,1]). The old code treated penny as a prolate cylinder along
+        x_1 and degraded the wrong axis."""
+        Vp = 0.05
+        C_eff = _mt_effective_stiffness(self.C_m, Vp, (3, 3, 0.3), 0.35)
+        # Through-thickness (x_3) component degrades more than in-plane (x_1, x_2)
+        deg_xx = (self.C_m[0, 0] - C_eff[0, 0]) / self.C_m[0, 0]
+        deg_yy = (self.C_m[1, 1] - C_eff[1, 1]) / self.C_m[1, 1]
+        deg_zz = (self.C_m[2, 2] - C_eff[2, 2]) / self.C_m[2, 2]
+        assert deg_zz > deg_xx, (
+            f"penny axis degradation {deg_zz:.4f} should exceed in-plane "
+            f"degradation {deg_xx:.4f} (the disk is perpendicular to x_3)"
+        )
+        # The two in-plane components should be approximately equal
+        # (transverse isotropy of an axisymmetric disk).
+        assert abs(deg_xx - deg_yy) < 1e-6
+
+    def test_prolate_cylindrical_anisotropy_transverse_to_long_axis(self):
+        """Regression for #32. (3, 1, 1) is a prolate cylindrical void
+        with its symmetry axis along x_1. Load flows easily along the
+        long axis (the void is thin in cross-section), but transverse
+        load has to bypass a long obstacle — so transverse degradation
+        (deg_yy, deg_zz) should exceed axial degradation (deg_xx)."""
+        Vp = 0.05
+        C_eff = _mt_effective_stiffness(self.C_m, Vp, (3, 1, 1), 0.35)
+        deg_xx = (self.C_m[0, 0] - C_eff[0, 0]) / self.C_m[0, 0]
+        deg_yy = (self.C_m[1, 1] - C_eff[1, 1]) / self.C_m[1, 1]
+        deg_zz = (self.C_m[2, 2] - C_eff[2, 2]) / self.C_m[2, 2]
+        assert deg_yy > deg_xx
+        # The two equatorial directions are equivalent (axisymmetric).
+        assert abs(deg_yy - deg_zz) < 1e-6
+
 
 class TestHex8Element:
     def setup_method(self):

--- a/tests/test_validation_database.py
+++ b/tests/test_validation_database.py
@@ -220,6 +220,34 @@ def test_compute_mae():
     assert abs(mae - expected) < 0.5
 
 
+def test_summarize_mae_returns_both_weightings():
+    """Regression for #36: summary must distinguish property- vs. point-weighted."""
+    from validation.validate_all import summarize_mae
+    # Two papers: paper_A has 1 property with 10 points and MAE 10%;
+    # paper_B has 1 property with 1 point and MAE 0%. Property-weighted
+    # average is 5%; point-weighted average should be (10*10 + 1*0)/11 ≈ 9.09%.
+    fake_results = {
+        'paper_A': {'tensile_strength': {'mae': 10.0, 'n_points': 10}},
+        'paper_B': {'tensile_strength': {'mae': 0.0, 'n_points': 1}},
+    }
+    s = summarize_mae(fake_results)
+    assert abs(s['property_weighted_mae'] - 5.0) < 1e-9
+    assert abs(s['point_weighted_mae'] - (10.0 * 10 + 0.0 * 1) / 11) < 1e-9
+    assert s['n_entries'] == 2
+    assert s['n_points'] == 11
+    assert s['best_mae'] == 0.0
+    assert s['worst_mae'] == 10.0
+
+def test_summarize_mae_handles_empty():
+    from validation.validate_all import summarize_mae
+    import math
+    s = summarize_mae({})
+    assert s['n_entries'] == 0
+    assert s['n_points'] == 0
+    assert math.isnan(s['property_weighted_mae'])
+    assert math.isnan(s['point_weighted_mae'])
+
+
 def test_run_all_produces_per_dataset_mae():
     from validation.validate_all import run_all_datasets
     results = run_all_datasets()

--- a/validate_porosity_cli.py
+++ b/validate_porosity_cli.py
@@ -16,6 +16,24 @@ import os
 import sys
 
 
+def _resolve_version() -> str:
+    """Return the package version from importlib.metadata when installed.
+
+    Falls back to a hard-coded string when running from a source checkout
+    that hasn't been pip-installed (e.g. during tests). The hard-coded
+    fallback must be kept in sync with pyproject.toml on each release.
+    """
+    try:
+        from importlib.metadata import PackageNotFoundError, version
+        try:
+            return version("porosity-fe")
+        except PackageNotFoundError:
+            pass
+    except ImportError:
+        pass
+    return "1.2.0"
+
+
 def _resolve_bundled_datasets_dir() -> str:
     """Return path to the bundled datasets directory.
 
@@ -68,7 +86,8 @@ def main(argv=None) -> int:
         help='Suppress per-dataset progress output',
     )
     parser.add_argument(
-        '--version', action='version', version='validate_porosity 1.0.0',
+        '--version', action='version',
+        version=f'validate_porosity {_resolve_version()}',
     )
     args = parser.parse_args(argv)
 
@@ -79,6 +98,7 @@ def main(argv=None) -> int:
         from validation.validate_all import (
             run_all_datasets,
             generate_master_report,
+            summarize_mae,
         )
     except ImportError as e:
         print(f"ERROR: Cannot import validation module: {e}", file=sys.stderr)
@@ -111,8 +131,6 @@ def main(argv=None) -> int:
                                                   output_dir=args.output_dir)
 
     # Print summary
-    import numpy as np
-    total_maes = []
     n_datasets_ok = 0
     n_datasets_err = 0
     for ds_name, ds_results in results.items():
@@ -122,9 +140,8 @@ def main(argv=None) -> int:
                 print(f"  [ERROR] {ds_name}: {ds_results['error']}")
             continue
         n_datasets_ok += 1
-        for prop, r in ds_results.items():
-            if 'mae' in r:
-                total_maes.append(r['mae'])
+
+    summary = summarize_mae(results)
 
     print()
     print(f"Report: {plot_path}")
@@ -132,11 +149,19 @@ def main(argv=None) -> int:
     print()
     print(f"Datasets processed:  {n_datasets_ok} succeeded, "
           f"{n_datasets_err} failed")
-    if total_maes:
-        print(f"Overall MAE:         {np.mean(total_maes):.2f}% "
-              f"(across {len(total_maes)} property-dataset pairs)")
-        print(f"Best MAE:            {np.min(total_maes):.2f}%")
-        print(f"Worst MAE:           {np.max(total_maes):.2f}%")
+    if summary['n_entries']:
+        print(
+            f"Overall MAE (property-weighted): "
+            f"{summary['property_weighted_mae']:.2f}%  "
+            f"(n={summary['n_entries']} paper-property entries)"
+        )
+        print(
+            f"Overall MAE (point-weighted):    "
+            f"{summary['point_weighted_mae']:.2f}%  "
+            f"(n={summary['n_points']} individual data points)"
+        )
+        print(f"Best MAE:            {summary['best_mae']:.2f}%")
+        print(f"Worst MAE:           {summary['worst_mae']:.2f}%")
 
     return 0
 

--- a/validation/validate_all.py
+++ b/validation/validate_all.py
@@ -170,6 +170,49 @@ def compute_mae(predicted, experimental) -> float:
     return float(np.mean(errs))
 
 
+def summarize_mae(results: Dict[str, Any]) -> Dict[str, float]:
+    """Aggregate per-(paper, property) MAE numbers into overall summary.
+
+    The property-weighted form gives each (paper, property) entry equal
+    weight — this is what the README headline traditionally reports. The
+    point-weighted form weights each individual (Vp, normalized) measurement
+    equally — the more standard convention in regression-error reporting.
+    They typically differ by ~0.5 percentage points because datasets carry
+    very different numbers of points. See issue #36.
+
+    Returns a dict with both numbers, the count of entries, and the
+    individual extremes.
+    """
+    per_entry_mae = []
+    per_entry_npts = []
+    for ds_results in results.values():
+        if 'error' in ds_results:
+            continue
+        for r in ds_results.values():
+            if 'mae' in r and 'n_points' in r:
+                per_entry_mae.append(r['mae'])
+                per_entry_npts.append(r['n_points'])
+    if not per_entry_mae:
+        return {
+            'property_weighted_mae': float('nan'),
+            'point_weighted_mae': float('nan'),
+            'n_entries': 0,
+            'n_points': 0,
+            'best_mae': float('nan'),
+            'worst_mae': float('nan'),
+        }
+    mae_arr = np.asarray(per_entry_mae, dtype=float)
+    npts_arr = np.asarray(per_entry_npts, dtype=float)
+    return {
+        'property_weighted_mae': float(np.mean(mae_arr)),
+        'point_weighted_mae': float(np.average(mae_arr, weights=npts_arr)),
+        'n_entries': int(mae_arr.size),
+        'n_points': int(npts_arr.sum()),
+        'best_mae': float(mae_arr.min()),
+        'worst_mae': float(mae_arr.max()),
+    }
+
+
 import glob
 
 _MODULUS_PROPS = {'tensile_modulus', 'transverse_tensile_modulus',
@@ -265,9 +308,30 @@ def generate_master_report(results: Dict[str, Any], output_dir: str = None):
     plt.savefig(plot_path, dpi=200, bbox_inches='tight')
     plt.close(fig)
 
-    md_lines = ['# Master Validation Report', '',
-                '| Dataset | Property | N points | MAE (%) |',
-                '|---|---|---|---|']
+    md_lines = ['# Master Validation Report', '']
+
+    # Overall MAE summary — report both aggregation forms (#36).
+    summary = summarize_mae(results)
+    if summary['n_entries']:
+        md_lines.extend([
+            '## Overall MAE',
+            '',
+            f"- Property-weighted: **{summary['property_weighted_mae']:.2f}%** "
+            f"(n={summary['n_entries']} paper-property entries)",
+            f"- Point-weighted:    **{summary['point_weighted_mae']:.2f}%** "
+            f"(n={summary['n_points']} individual data points)",
+            '',
+            '_The two aggregations weight datasets differently (entries vs. data points); '
+            'point-weighted is the standard convention in regression-error reporting._',
+            '',
+        ])
+
+    md_lines.extend([
+        '## Per-(dataset, property) breakdown',
+        '',
+        '| Dataset | Property | N points | MAE (%) |',
+        '|---|---|---|---|',
+    ])
     for ds_name, ds_results in sorted(results.items()):
         if 'error' in ds_results:
             md_lines.append(f"| {ds_name} | LOAD ERROR | - | - |")
@@ -291,12 +355,13 @@ if __name__ == "__main__":
     plot, md = generate_master_report(results)
     print(f"Plot: {plot}")
     print(f"Markdown: {md}")
-    total_maes = []
-    for ds_results in results.values():
-        if 'error' in ds_results:
-            continue
-        for r in ds_results.values():
-            if 'mae' in r:
-                total_maes.append(r['mae'])
-    if total_maes:
-        print(f"\nOverall MAE: {np.mean(total_maes):.2f}% (n={len(total_maes)})")
+    summary = summarize_mae(results)
+    if summary['n_entries']:
+        print(
+            f"\nOverall MAE (property-weighted): {summary['property_weighted_mae']:.2f}%  "
+            f"(n={summary['n_entries']} entries)"
+        )
+        print(
+            f"Overall MAE (point-weighted):    {summary['point_weighted_mae']:.2f}%  "
+            f"(n={summary['n_points']} points)"
+        )


### PR DESCRIPTION
## Summary

Six issues across two commits. All landed on the branch after PR #31 merged. No file overlap between the two commits; either could be cherry-picked independently if desired.

### Commit `0761a40` — three small correctness / UX fixes

- **#33 — FE: stiffness assembly accepts inverted elements.** `Hex8Element.stiffness_matrix` now raises `ValueError` when any Gauss-point `det(J)` is ≤ 0, instead of letting a negative-Jacobian element silently contribute a wrong-sign block to K. `Hex8Element.volume` uses `abs(det J)` so it still reports a sensible positive value when introspected on a degenerate element.
- **#38 — FE: engineering strain rotated with the wrong transformation.** Post-processing applied `stress_transformation_3d` to engineering strain, leaving the γ shear components off by 2×. Switched to `strain_transformation_3d`; `FieldResults.strain_local` now satisfies `strain_local == T_eps @ strain_global` per Gauss point. Stress / Tsai-Wu paths were already correct and are unchanged.
- **#46 — GUI: `porosity-fe` console script crashed on missing PyQt6.** Wrapped `launch()` in `_console_main()` that prints the friendly stderr message and exits non-zero instead of leaking a Python traceback. Error text now mentions the discoverable `pip install porosity-fe[gui]` form. `pyproject.toml` entry point updated.

### Commit `1a46bc6` — penny voids, MAE aggregation, version drift

- **#32 — FE: penny / oblate voids hit the prolate Eshelby formula.** `_mt_effective_stiffness` previously computed `ar = max/min ≥ 1`, leaving the `else: # Oblate` branch unreachable. Rewrote dispatch to detect the symmetry axis from sorted radii, use the correct g-function branch (prolate `cosh⁻¹` vs oblate `arccos`), and permute the Voigt tensor to align with the actual unique-radius axis. Two regression tests verify penny `(3, 3, 0.3)` shows through-disk degradation > in-plane degradation with transverse isotropy in plane, and prolate cylinder `(3, 1, 1)` shows transverse degradation > axial.
- **#36 — Validation: published 7.7% MAE is property-unweighted.** Added `summarize_mae()` helper that returns both property-weighted (each paper-property entry weighted equally; **7.69%**) and point-weighted (each measurement weighted equally; **7.03%**) forms. `validate_porosity` CLI prints both; the markdown report and README now show both. Two regression tests.
- **#45 — Build: version drift across 6 files + stale CHANGELOG.** Bumped to `1.2.0` across `pyproject.toml`, `CHANGELOG.md`, `CITATION.cff`, README BibTeX, and `PorosityFE.spec`. `validate_porosity --version` now reads from `importlib.metadata` with a hard-coded fallback. New `[1.2.0]` CHANGELOG section summarizes the post-1.1.1 work landed across PR #26, #31, and this PR.

### Note on #47

Filed by an agent in this session as "requirements.txt pins non-existent numpy / scipy versions". When picking it for a fix I ran `pip index versions` and confirmed both `numpy==2.4.4` and `scipy==1.17.1` exist on the index — the agent was reasoning from stale version knowledge. Commented on the issue recommending it be closed as not-planned; picked #46 as the replacement third fix in this batch.

## Test plan

- [x] 264 tests pass locally (`pytest tests/`) — +9 new tests across the six fixes.
- [x] End-to-end smoke: `validate_porosity --version` prints `1.2.0`; `summarize_mae` over the real datasets returns 7.69% property-weighted and 7.03% point-weighted (exactly matching the issue prediction).
- [x] `porosity_gui.py` and `porosity_fe_analysis.py` parse cleanly.
- [ ] CI matrix passes (Ubuntu/macOS/Windows × Python 3.10–3.13).
- [ ] Manual smoke: a penny-void analysis (`void_shape='penny'`) now produces a non-trivially different knockdown vs. the pre-fix value — verify on a real run if it shifts the headline FE knockdown by an amount the README needs to reflect.

https://claude.ai/code/session_01EGeTTcpbtS65jLuLAHFmeh

---
_Generated by [Claude Code](https://claude.ai/code/session_01EGeTTcpbtS65jLuLAHFmeh)_