### PR TITLE
Safe quick wins: sys.path hardening (#29), logging (#19), utf-8 I/O (#21)

### DIFF
--- a/tests/test_porosity_fe.py
+++ b/tests/test_porosity_fe.py
@@ -24,7 +24,8 @@ from porosity_fe_analysis import (MaterialProperties, MATERIALS, VoidGeometry, V
                                    _degraded_composite_stiffness,
                                    GlobalAssembler, BoundaryHandler, FESolver, FieldResults,
                                    compute_clt_effective_modulus, check_mesh_quality,
-                                   _build_provenance)
+                                   _build_provenance, load_results_from_json,
+                                   JSON_SCHEMA_VERSION, FORMAT_EMPIRICAL_SWEEP)
 
 
 class TestMaterialProperties:
@@ -2325,7 +2326,7 @@ class TestProvenanceInSaveResultsJson:
         )
         path = str(tmp_path / "prov_test.json")
         save_results_to_json(results, path)
-        with open(path) as f:
+        with open(path, encoding="utf-8") as f:
             data = json.load(f)
         prov = data['provenance']
         assert isinstance(prov['python_version'], str) and prov['python_version']
@@ -2339,9 +2340,31 @@ class TestProvenanceInSaveResultsJson:
         )
         path = str(tmp_path / "schema_test.json")
         save_results_to_json(results, path)
-        with open(path) as f:
+        with open(path, encoding="utf-8") as f:
             data = json.load(f)
         assert data['schema_version'] == '1.0'
+
+
+class TestJsonEncodingRoundTrip:
+    """Regression for #21: JSON I/O must be UTF-8 on every platform.
+
+    Without explicit encoding, Windows opens files in the locale code page
+    (cp1252) and silently mangles non-ASCII content. This locks the
+    round-trip with characters that are not representable in cp1252.
+    """
+
+    def test_non_ascii_round_trips_through_loader(self, tmp_path):
+        path = str(tmp_path / "ünïcode_µCT.json")
+        payload = {
+            "schema_version": JSON_SCHEMA_VERSION,
+            "format": FORMAT_EMPIRICAL_SWEEP,
+            "note": "µCT scan, σ₁c knockdown — café/naïve ✓",
+        }
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(payload, f, ensure_ascii=False, indent=2)
+
+        loaded = load_results_from_json(path)
+        assert loaded["note"] == "µCT scan, σ₁c knockdown — café/naïve ✓"
 
 
 class TestProvenanceInFEExportResults:
@@ -2355,7 +2378,7 @@ class TestProvenanceInFEExportResults:
         field_results = solver.solve(loading='compression', applied_strain=-0.001)
         path = str(tmp_path / "fe_prov_test.json")
         FESolver.export_results(field_results, path)
-        with open(path) as f:
+        with open(path, encoding="utf-8") as f:
             data = json.load(f)
         prov = data['provenance']
         assert isinstance(prov['python_version'], str) and prov['python_version']

--- a/validate_porosity_cli.py
+++ b/validate_porosity_cli.py
@@ -12,8 +12,10 @@ Usage:
 """
 
 import argparse
+import logging
 import os
 import sys
+from datetime import datetime, timezone
 
 
 def _resolve_version() -> str:
@@ -58,13 +60,46 @@ def _resolve_bundled_schema_dir() -> str:
     return os.path.join(here, 'validation', 'schemas')
 
 
+def _configure_debug_logging(output_dir: str) -> str:
+    """Attach a DEBUG file handler so a failed run leaves a diagnosable log.
+
+    Returns the path of the log file. The validation pipeline already calls
+    ``logger.exception(...)`` on swallowed errors (#19); without a handler at
+    DEBUG those tracebacks go nowhere.
+    """
+    os.makedirs(output_dir, exist_ok=True)
+    stamp = datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%SZ')
+    log_path = os.path.join(output_dir, f'validate_porosity_{stamp}.log')
+    handler = logging.FileHandler(log_path, encoding='utf-8')
+    handler.setLevel(logging.DEBUG)
+    handler.setFormatter(logging.Formatter(
+        '%(asctime)s %(levelname)s %(name)s: %(message)s'
+    ))
+    root = logging.getLogger()
+    root.setLevel(logging.DEBUG)
+    root.addHandler(handler)
+    # Third-party libraries emit a flood of DEBUG records that bury the
+    # validation-pipeline tracebacks this log exists to capture (#19).
+    for noisy in ('matplotlib', 'PIL', 'fontTools'):
+        logging.getLogger(noisy).setLevel(logging.WARNING)
+    return log_path
+
+
 def _ensure_validation_imports():
     """Make validation/ importable regardless of whether we're frozen."""
     if getattr(sys, 'frozen', False):
+        # The PyInstaller bundle dir is trusted (we built it), so prepending
+        # it is fine.
         base = sys._MEIPASS
-        sys.path.insert(0, base)
+        if base not in sys.path:
+            sys.path.insert(0, base)
     else:
-        sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+        # Append, not insert(0, ...): a file dropped next to this script
+        # must not be able to shadow a stdlib / site-packages module of the
+        # same name on import (#29).
+        here = os.path.dirname(os.path.abspath(__file__))
+        if here not in sys.path:
+            sys.path.append(here)
 
 
 def main(argv=None) -> int:
@@ -86,10 +121,19 @@ def main(argv=None) -> int:
         help='Suppress per-dataset progress output',
     )
     parser.add_argument(
+        '--debug', action='store_true',
+        help='Write a per-run DEBUG log (with tracebacks for any failed '
+             'datasets) to the output directory',
+    )
+    parser.add_argument(
         '--version', action='version',
         version=f'validate_porosity {_resolve_version()}',
     )
     args = parser.parse_args(argv)
+
+    debug_log_path = None
+    if args.debug:
+        debug_log_path = _configure_debug_logging(args.output_dir)
 
     _ensure_validation_imports()
 
@@ -146,6 +190,8 @@ def main(argv=None) -> int:
     print()
     print(f"Report: {plot_path}")
     print(f"Detail: {md_path}")
+    if debug_log_path is not None:
+        print(f"Debug log: {debug_log_path}")
     print()
     print(f"Datasets processed:  {n_datasets_ok} succeeded, "
           f"{n_datasets_err} failed")

--- a/validation/validate_all.py
+++ b/validation/validate_all.py
@@ -10,11 +10,15 @@ from typing import Dict, Any
 
 logger = logging.getLogger(__name__)
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+# Append (not insert(0, ...)) so a file dropped next to this script can't
+# shadow a stdlib / site-packages module of the same name on import (#29).
+# pip-installing the package makes this unnecessary; it only matters for
+# source-layout / direct `python validation/validate_all.py` runs.
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _REPO_ROOT not in sys.path:
+    sys.path.append(_REPO_ROOT)
 
 import jsonschema
-
-logger = logging.getLogger(__name__)
 
 
 class ValidationError(Exception):
@@ -30,8 +34,15 @@ _SCHEMA = None
 def _get_schema() -> Dict[str, Any]:
     global _SCHEMA
     if _SCHEMA is None:
-        with open(_SCHEMA_PATH, encoding='utf-8') as f:
-            _SCHEMA = json.load(f)
+        try:
+            with open(_SCHEMA_PATH, encoding='utf-8') as f:
+                _SCHEMA = json.load(f)
+        except (OSError, json.JSONDecodeError) as e:
+            logger.exception("Failed to load validation schema")
+            raise ValueError(
+                f"Failed to load validation schema from {_SCHEMA_PATH!r}: "
+                f"{type(e).__name__}: {e}"
+            ) from e
     return _SCHEMA
 
 
@@ -292,7 +303,10 @@ def run_all_datasets(datasets_dir: str = None) -> Dict[str, Any]:
             data = load_dataset(path)
         except ValidationError as e:
             logger.warning("Skipping dataset %s: %s", name, e)
-            all_results[name] = {'error': str(e)}
+            all_results[name] = {
+                'error': str(e),
+                'error_type': type(e).__name__,
+            }
             continue
 
         dataset_results = {}
@@ -326,7 +340,10 @@ def run_all_datasets(datasets_dir: str = None) -> Dict[str, Any]:
                 # property prediction failed, rather than just the bare
                 # string we surface in the JSON results (#19).
                 logger.exception("Prediction failed for %s/%s", name, prop_key)
-                dataset_results[prop_key] = {'error': str(e)}
+                dataset_results[prop_key] = {
+                    'error': str(e),
+                    'error_type': type(e).__name__,
+                }
         all_results[name] = dataset_results
     return all_results
 


### PR DESCRIPTION
## Summary
Safe-quick-win backlog batch — no physics changes, low risk.

- **#29** (sys.path hardening): append the repo root to `sys.path` instead of `insert(0, ...)` in `validate_porosity_cli.py` and `validation/validate_all.py`, so a file dropped next to the script can't shadow a stdlib/site-packages module on import. The trusted PyInstaller `_MEIPASS` branch keeps `insert(0)`. Also dedupes the doubled `logging.getLogger()` in `validate_all.py`.
- **#19** (logging): wrap the validation schema load in a helpful `ValueError` (with path + cause) instead of leaking a raw `JSONDecodeError` at import; capture `error_type` alongside `error` in the per-dataset / per-property result dicts; add a `--debug` flag to `validate_porosity` that writes a per-run DEBUG log (with tracebacks for any failed dataset) to the output dir, quieting noisy third-party loggers (matplotlib/PIL/fontTools).
- **#21** (utf-8 I/O): pass `encoding="utf-8"` on the three remaining bare `open()` reads in the test suite and add a non-ASCII JSON round-trip regression test. Production code in `porosity_fe_analysis.py` / `validate_all.py` already passed `encoding="utf-8"`.

## Already resolved (no code change)
- **#22**: every dict-lookup site flagged in the issue (`MATERIALS`, `VOID_SHAPES`, `cluster_location`, `PRISTINE_STRENGTH_KEY`, `distribution`) already has a helpful guard message in the current codebase. Recommend closing as fixed.

## Verification
- `pytest tests/` → **307 passed**, 3 unrelated mesh-distortion warnings.
- `validate_porosity --output-dir /tmp/vptest --debug --quiet` → 13/13 datasets succeeded; per-run debug log written; MAE summary unchanged (7.06% property-weighted).
- sys.path check: repo root now appended at the tail (index 8/9), not head; `validation.validate_all` + `porosity_fe_analysis` still import cleanly.

## Test plan
- [ ] CI green on this branch.
- [ ] Confirm `validate_porosity --debug` log captures a traceback when a dataset is deliberately corrupted.

https://claude.ai/code/session_01Ekic6cboH42CHtYqtp7biK

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ekic6cboH42CHtYqtp7biK)_