### PR TITLE
Finish PARTIAL quick-wins: JSON contract (#20), plots (#51/#53), reproducibility (#55), test coverage (#48)

### DIFF
--- a/app.py
+++ b/app.py
@@ -137,14 +137,18 @@ def build_export_payload(result: dict) -> dict:
 
 
 def write_results_json(filepath: str, payload: dict) -> None:
-    from porosity_fe_analysis import FORMAT_EMPIRICAL_SWEEP, JSON_SCHEMA_VERSION
+    from porosity_fe_analysis import (
+        FORMAT_EMPIRICAL_SWEEP, JSON_SCHEMA_VERSION,
+        _build_provenance, _json_default,
+    )
     envelope = {
         "schema_version": JSON_SCHEMA_VERSION,
         "format": FORMAT_EMPIRICAL_SWEEP,
+        "provenance": _build_provenance(),
         **payload,
     }
     with open(filepath, "w", encoding="utf-8") as f:
-        json.dump(envelope, f, indent=2)
+        json.dump(envelope, f, indent=2, default=_json_default)
 
 
 def write_results_csv(filepath: str, payload: dict) -> None:
@@ -170,13 +174,17 @@ def write_results_csv(filepath: str, payload: dict) -> None:
 
 
 def _serialise_payload_json(payload: dict) -> str:
-    from porosity_fe_analysis import FORMAT_EMPIRICAL_SWEEP, JSON_SCHEMA_VERSION
+    from porosity_fe_analysis import (
+        FORMAT_EMPIRICAL_SWEEP, JSON_SCHEMA_VERSION,
+        _build_provenance, _json_default,
+    )
     envelope = {
         "schema_version": JSON_SCHEMA_VERSION,
         "format": FORMAT_EMPIRICAL_SWEEP,
+        "provenance": _build_provenance(),
         **payload,
     }
-    return json.dumps(envelope, indent=2)
+    return json.dumps(envelope, indent=2, default=_json_default)
 
 
 def _serialise_payload_csv(payload: dict) -> str:
@@ -512,11 +520,15 @@ def plot_stress(result: dict, comp_name: str):
 
     finite_mask = np.isfinite(sv)
     if finite_mask.sum() >= 3:
-        vmin = np.percentile(sv[finite_mask], 5)
-        vmax = np.percentile(sv[finite_mask], 95)
+        # Symmetric range so RdBu_r's white midpoint is true σ=0; using raw
+        # 5/95 percentiles shifts the neutral color off zero and makes the
+        # sign visually misread (#51).
+        p5 = np.percentile(sv[finite_mask], 5)
+        p95 = np.percentile(sv[finite_mask], 95)
+        v = max(abs(p5), abs(p95)) or 1.0
         tcf = ax.tricontourf(cx[finite_mask], cz[finite_mask],
                              sv[finite_mask], levels=20, cmap="RdBu_r",
-                             vmin=vmin, vmax=vmax)
+                             vmin=-v, vmax=v)
         fig.colorbar(tcf, ax=ax, label=label)
     else:
         ax.text(0.5, 0.5, "Insufficient interior data for contour plot.",

--- a/porosity_fe_analysis.py
+++ b/porosity_fe_analysis.py
@@ -44,22 +44,75 @@ logger = logging.getLogger(__name__)
 # PLOT STYLE — applied once at import time
 # ============================================================
 
-def _apply_plot_style():
-    """Set shared rcParams for all plots: fonts, DPI, line widths, grid."""
+# Axis / colorbar label text, centralized so the Streamlit app and the
+# static-PNG path cannot drift apart on units (#53).
+LABELS = {
+    'porosity_pct': 'Porosity (%)',
+    'x_mm': 'x (mm)',
+    'z_mm': 'z (mm)',
+    'stiffness_retention_pct': 'Stiffness Retention (%)',
+    'knockdown_factor': 'Knockdown Factor (-)',
+    'scf': 'Stress Concentration Factor (-)',
+}
+
+
+def _apply_plot_style(preset: str = 'default'):
+    """Set shared rcParams for all plots: fonts, DPI, colormap, grid.
+
+    ``preset='publication'`` bumps font sizes and emits vector PDF for
+    paper figures; ``'default'`` is the screen/README raster style (#53).
+    """
     import matplotlib
-    matplotlib.rcParams.update({
+    base = {
         'font.family': 'sans-serif',
         'font.size': 11,
         'axes.titlesize': 14,
         'axes.labelsize': 12,
+        'legend.fontsize': 9,
         'lines.linewidth': 1.5,
         'axes.grid': True,
         'grid.alpha': 0.3,
+        'image.cmap': 'viridis',
         'savefig.dpi': 300,
         'savefig.bbox': 'tight',
-    })
+    }
+    if preset == 'publication':
+        base.update({
+            'font.size': 13,
+            'axes.titlesize': 16,
+            'axes.labelsize': 14,
+            'legend.fontsize': 11,
+            'savefig.format': 'pdf',
+        })
+    matplotlib.rcParams.update(base)
 
 _apply_plot_style()
+
+
+try:
+    import importlib.metadata as _ilm
+    __version__ = _ilm.version("porosity-fe")
+except Exception:
+    # Source checkout that isn't pip-installed. Keep in sync with
+    # pyproject.toml on each release.
+    __version__ = "1.2.0"
+
+
+def _json_default(o):
+    """json.dump ``default=`` hook: make numpy scalars/arrays serializable.
+
+    The science payload is already float()-wrapped, but user-supplied
+    fields (e.g. ndarray ply_angles) would otherwise raise TypeError (#20).
+    """
+    if isinstance(o, np.generic):
+        return o.item()
+    if isinstance(o, np.ndarray):
+        return o.tolist()
+    if isinstance(o, (datetime.datetime, datetime.date)):
+        return o.isoformat()
+    raise TypeError(
+        f"Object of type {type(o).__name__} is not JSON serializable"
+    )
 
 # ============================================================
 # SECTION 1: MATERIAL PROPERTIES AND CONSTANTS
@@ -393,7 +446,8 @@ class PorosityField:
     def __init__(self, material: MaterialProperties, void_volume_fraction: float,
                  distribution: str = 'uniform', void_shape: Union[str, Tuple] = 'spherical',
                  cluster_location: str = 'midplane',
-                 discrete_voids: Optional[List[VoidGeometry]] = None):
+                 discrete_voids: Optional[List[VoidGeometry]] = None,
+                 seed: Optional[int] = None):
         if void_volume_fraction is None:
             raise ValueError("void_volume_fraction is None; expected a finite float in [0, 1].")
         if not isinstance(void_volume_fraction, (int, float, np.floating, np.integer)):
@@ -433,6 +487,10 @@ class PorosityField:
         self.distribution = distribution
         self.cluster_location = cluster_location
         self.discrete_voids = discrete_voids or []
+        # The pipeline is RNG-free today; `seed` is recorded into provenance
+        # so a future stochastic void-placement mode has a determinism
+        # contract to honor (#55).
+        self.seed = seed
         self.Lz = material.total_thickness
 
         # Resolve void shape
@@ -1223,7 +1281,7 @@ class FEVisualizer:
         field = np.where(dist < 0, 0, 1.0 + (scf_max - 1) * np.exp(-dist / max(void_geometry.radii)))
 
         im = ax.contourf(X, Y, field, levels=30, cmap='plasma')
-        plt.colorbar(im, ax=ax, label='Stress Concentration Factor')
+        plt.colorbar(im, ax=ax, label=LABELS['scf'])
         ax.set_xlabel('x (mm)', fontsize=12)
         ax.set_ylabel('y (mm)', fontsize=12)
         ax.set_title(f'SCF Field (aspect ratio={void_geometry.aspect_ratio:.1f})',
@@ -1260,7 +1318,7 @@ class FEVisualizer:
                            alpha=0.7, linewidth=1.5)
 
             ax.set_xlabel('Porosity (%)', fontsize=11)
-            ax.set_ylabel('Knockdown Factor', fontsize=11)
+            ax.set_ylabel(LABELS['knockdown_factor'], fontsize=11)
             ax.set_title(mode.upper(), fontsize=13, fontweight='bold')
             ax.grid(True, alpha=0.3)
             ax.set_ylim(0, 1.1)
@@ -1286,7 +1344,7 @@ class FEVisualizer:
             axes[0].bar(x + i * width, vals, width, label=model.replace('_', ' ').title())
         axes[0].set_xticks(x + width)
         axes[0].set_xticklabels([c.replace('_', '\n') for c in configs], fontsize=8)
-        axes[0].set_ylabel('Knockdown Factor')
+        axes[0].set_ylabel(LABELS['knockdown_factor'])
         axes[0].set_title('Compression', fontsize=14, fontweight='bold')
         axes[0].legend(fontsize=8)
         axes[0].grid(True, alpha=0.3, axis='y')
@@ -1297,7 +1355,7 @@ class FEVisualizer:
             axes[1].bar(x + i * width, vals, width, label=model.replace('_', ' ').title())
         axes[1].set_xticks(x + width)
         axes[1].set_xticklabels([c.replace('_', '\n') for c in configs], fontsize=8)
-        axes[1].set_ylabel('Knockdown Factor')
+        axes[1].set_ylabel(LABELS['knockdown_factor'])
         axes[1].set_title('ILSS', fontsize=14, fontweight='bold')
         axes[1].legend(fontsize=8)
         axes[1].grid(True, alpha=0.3, axis='y')
@@ -3101,7 +3159,7 @@ class FESolver:
             **results_data,
         }
         with open(filename, 'w', encoding='utf-8') as f:
-            json.dump(output, f, indent=2)
+            json.dump(output, f, indent=2, default=_json_default)
         print(f"Saved FE results: {filename}")
 
 
@@ -3112,7 +3170,8 @@ class FESolver:
 def compare_configurations(void_volume_fraction: float,
                            material_name: str = 'T800_epoxy',
                            applied_stress: float = -1500.0,
-                           configs: Optional[Dict] = None) -> Dict:
+                           configs: Optional[Dict] = None,
+                           seed: Optional[int] = None) -> Dict:
     """Main analysis function — loops through porosity configurations."""
     if material_name not in MATERIALS:
         raise ValueError(
@@ -3130,7 +3189,8 @@ def compare_configurations(void_volume_fraction: float,
 
     for name, config in configs.items():
         print(f"\n  Configuration: {name}")
-        porosity_field = PorosityField(material, void_volume_fraction, **config)
+        porosity_field = PorosityField(material, void_volume_fraction,
+                                       seed=seed, **config)
         mesh = CompositeMesh(porosity_field, material, nx=30, ny=10, nz=12)
 
         empirical = EmpiricalSolver(mesh, material)
@@ -3171,20 +3231,20 @@ FORMAT_FE_FIELDS = "porosity-fe.fe-fields"
 _KNOWN_FORMATS = {FORMAT_EMPIRICAL_SWEEP, FORMAT_FE_FIELDS}
 
 
-def _build_provenance() -> dict:
+def _build_provenance(seed: Optional[int] = None) -> dict:
     """Return a provenance metadata dict for JSON output reproducibility.
 
-    Captures software versions, platform, timestamp, and optional git commit
-    so that any JSON output can be traced back to the exact environment used.
+    Captures software versions, platform, timestamp, optional git commit,
+    and the run ``seed`` so that any JSON output can be traced back to the
+    exact environment used (#55).
     """
     try:
         import importlib.metadata as _ilm
         pfe_version: Optional[str] = _ilm.version("porosity-fe")
     except Exception:
-        # Fall back to the module-level attribute when not installed via pip
-        pfe_version = getattr(
-            sys.modules.get("porosity_fe_analysis"), "__version__", None
-        )
+        # Source checkout not pip-installed: use the importable module
+        # attribute (defined at the top of this file).
+        pfe_version = __version__
 
     vi = sys.version_info
     python_version = f"{vi.major}.{vi.minor}.{vi.micro}"
@@ -3210,17 +3270,23 @@ def _build_provenance() -> dict:
         "scipy_version": _pkg_version("scipy"),
         "matplotlib_version": _pkg_version("matplotlib"),
         "timestamp_utc": datetime.datetime.utcnow().isoformat() + "Z",
-        "seed": None,
+        "seed": seed,
         "git_commit": git_commit,
     }
 
 
 def save_results_to_json(results: Dict, filename: str):
     """Export numerical results to JSON."""
+    # All configs in a sweep share one seed; record it iff unambiguous.
+    seeds = {
+        getattr(d.get('porosity_field'), 'seed', None)
+        for d in results.values() if isinstance(d, dict)
+    }
+    seed = seeds.pop() if len(seeds) == 1 else None
     output = {
         'schema_version': JSON_SCHEMA_VERSION,
         'format': FORMAT_EMPIRICAL_SWEEP,
-        'provenance': _build_provenance(),
+        'provenance': _build_provenance(seed=seed),
     }
     for name, data in results.items():
         if name in ('schema_version', 'format'):
@@ -3246,7 +3312,7 @@ def save_results_to_json(results: Dict, filename: str):
         output[name] = entry
 
     with open(filename, 'w', encoding='utf-8') as f:
-        json.dump(output, f, indent=2)
+        json.dump(output, f, indent=2, default=_json_default)
     print(f"Saved: {filename}")
 
 

--- a/tests/test_porosity_fe.py
+++ b/tests/test_porosity_fe.py
@@ -746,6 +746,82 @@ class TestAnalysisPipeline:
             load_results_from_json(str(path))
 
 
+class TestResultsSchemaAndReproducibility:
+    """#20 (output JSON Schema, numpy serialization) and #55 (__version__,
+    seed provenance, determinism contract)."""
+
+    _SCHEMA_PATH = os.path.join(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+        'validation', 'schemas', 'porosity_results_schema.json')
+
+    def _one_config_results(self):
+        return compare_configurations(
+            0.03, configs={'uniform_spherical':
+                           POROSITY_CONFIGS['uniform_spherical']})
+
+    def test_exported_file_validates_against_results_schema(self, tmp_path):
+        import jsonschema
+        with open(self._SCHEMA_PATH, encoding='utf-8') as f:
+            schema = json.load(f)
+        path = str(tmp_path / "schema_check.json")
+        save_results_to_json(self._one_config_results(), path)
+        with open(path, encoding='utf-8') as f:
+            doc = json.load(f)
+        jsonschema.validate(instance=doc, schema=schema)  # raises on drift
+
+    def test_module_has_importable_version(self):
+        import porosity_fe_analysis as pfa
+        assert isinstance(pfa.__version__, str) and pfa.__version__
+
+    def test_provenance_records_version_and_seed(self, tmp_path):
+        results = compare_configurations(
+            0.03, seed=4242,
+            configs={'uniform_spherical':
+                     POROSITY_CONFIGS['uniform_spherical']})
+        path = str(tmp_path / "prov.json")
+        save_results_to_json(results, path)
+        with open(path, encoding='utf-8') as f:
+            prov = json.load(f)['provenance']
+        assert prov['porosity_fe_version']  # no longer silently None
+        assert prov['seed'] == 4242
+
+    def test_pipeline_is_byte_deterministic(self, tmp_path):
+        """Locks in current determinism so any future RNG introduction is
+        forced to expose a seed (#55)."""
+        p1, p2 = str(tmp_path / "r1.json"), str(tmp_path / "r2.json")
+        save_results_to_json(self._one_config_results(), p1)
+        save_results_to_json(self._one_config_results(), p2)
+        with open(p1, encoding='utf-8') as f:
+            d1 = json.load(f)
+        with open(p2, encoding='utf-8') as f:
+            d2 = json.load(f)
+        # Two back-to-back runs in one process differ only by timestamp.
+        d1['provenance'].pop('timestamp_utc')
+        d2['provenance'].pop('timestamp_utc')
+        assert d1 == d2
+
+    def test_json_default_handles_numpy_and_ndarray(self, tmp_path):
+        from porosity_fe_analysis import _json_default
+        assert _json_default(np.float64(1.5)) == 1.5
+        assert _json_default(np.int64(7)) == 7
+        assert _json_default(np.array([1.0, 2.0])) == [1.0, 2.0]
+        # End-to-end: an ndarray smuggled into the payload must not raise.
+        # Replace the nested dicts with shallow copies — `config` aliases the
+        # shared POROSITY_CONFIGS entry, so mutating it in place would poison
+        # global state for other tests.
+        results = self._one_config_results()
+        entry = dict(results['uniform_spherical'])
+        entry['config'] = {**entry['config'],
+                           'ply_angles': np.array([0.0, 90.0, 45.0])}
+        results = {'uniform_spherical': entry}
+        path = str(tmp_path / "np.json")
+        save_results_to_json(results, path)  # would TypeError pre-#20
+        with open(path, encoding='utf-8') as f:
+            doc = json.load(f)
+        assert doc['uniform_spherical']['config']['ply_angles'] == [
+            0.0, 90.0, 45.0]
+
+
 class TestIntegration:
     """End-to-end test with reduced parameters for speed."""
 
@@ -1431,12 +1507,39 @@ class TestBoundaryHandler:
             assert abs(constrained[3 * int(nid)] - expected_disp) < 1e-10
 
     def test_tension_bcs(self):
-        constrained, F = self.handler.tension_bcs(applied_strain=0.01)
+        strain = 0.01
+        constrained, F = self.handler.tension_bcs(applied_strain=strain)
         assert len(constrained) > 0
+        assert len(F) == self.mesh.n_dof
+        # x_min: ux pinned to 0
+        for nid in self.mesh.nodes_on_face('x_min'):
+            assert constrained[3 * int(nid)] == 0.0
+        # x_max: ux = +strain * Lx (positive => tension, not compression)
+        expected = strain * self.mesh.L_x
+        assert expected > 0.0
+        for nid in self.mesh.nodes_on_face('x_max'):
+            assert abs(constrained[3 * int(nid)] - expected) < 1e-12
+        # y_min: uy pinned to 0 (symmetry)
+        for nid in self.mesh.nodes_on_face('y_min'):
+            assert constrained[3 * int(nid) + 1] == 0.0
 
     def test_shear_bcs(self):
-        constrained, F = self.handler.shear_bcs(applied_strain=0.01)
+        gamma = 0.01
+        constrained, F = self.handler.shear_bcs(applied_strain=gamma)
         assert len(constrained) > 0
+        assert len(F) == self.mesh.n_dof
+        nodes = self.mesh.nodes
+        # All four side faces must prescribe BOTH ux and uy to the pure-shear
+        # field u = gamma/2 * y, v = gamma/2 * x. A regression that swapped
+        # ux/uy on a face, or left a face traction-free, fails here.
+        for face in ('x_min', 'x_max', 'y_min', 'y_max'):
+            face_nodes = self.mesh.nodes_on_face(face)
+            assert len(face_nodes) > 0
+            for nid in face_nodes:
+                nid = int(nid)
+                x_n, y_n = float(nodes[nid, 0]), float(nodes[nid, 1])
+                assert abs(constrained[3 * nid] - (gamma / 2.0) * y_n) < 1e-12
+                assert abs(constrained[3 * nid + 1] - (gamma / 2.0) * x_n) < 1e-12
 
     def test_apply_penalty(self):
         import scipy.sparse

--- a/tests/test_validation_database.py
+++ b/tests/test_validation_database.py
@@ -406,3 +406,75 @@ def test_predict_strength_raises_for_transverse_tensile():
 
     with pytest.raises(ValueError, match='transverse_tensile_strength'):
         predict_strength(dataset, 'transverse_tensile_strength', [1.0, 2.0, 3.0])
+
+
+# ---------------------------------------------------------------------------
+# Issue #48 (item 3) — regression-pin per-dataset/property MAE
+#
+# The pipeline is RNG-free and deterministic (#55), so these baselines are
+# stable. Tolerance is rel=10% OR abs=0.5 (whichever is larger) so tiny-MAE
+# entries don't go flaky while real model drift on any dataset fails CI.
+# Regenerate with: python -c "from validation.validate_all import
+# run_all_datasets as r; ..." (see PR for the one-liner) only on an
+# intentional model change, and call it out in the PR.
+# ---------------------------------------------------------------------------
+
+_MAE_BASELINES = {
+    ('almeida_1994', 'ilss'): 6.897,
+    ('bowles_1992', 'ilss'): 3.019,
+    ('elhajjar_2025', 'compression_strength'): 5.643,
+    ('elhajjar_2025', 'tensile_strength'): 4.331,
+    ('ghiorse_1993', 'flexural_modulus'): 16.284,
+    ('ghiorse_1993', 'ilss'): 10.155,
+    ('jeong_1997', 'ilss'): 4.156,
+    ('liu_2006', 'flexural_modulus'): 7.707,
+    ('liu_2006', 'ilss'): 1.987,
+    ('liu_2006', 'tensile_modulus'): 1.808,
+    ('liu_2006', 'tensile_strength'): 1.581,
+    ('liu_2018', 'tensile_modulus'): 0.864,
+    ('liu_2018', 'tensile_strength'): 5.26,
+    ('liu_2018', 'transverse_tensile_modulus'): 3.286,
+    ('olivier_1995', 'flexural_modulus'): 10.55,
+    ('olivier_1995', 'ilss'): 1.554,
+    ('olivier_1995', 'tensile_strength'): 15.667,
+    ('stamopoulos_2016', 'flexural_modulus'): 2.314,
+    ('stamopoulos_2016', 'ilss'): 2.523,
+    ('stamopoulos_2016', 'shear_modulus'): 15.387,
+    ('stamopoulos_2016', 'shear_strength'): 4.353,
+    ('stamopoulos_2016', 'transverse_tensile_modulus'): 1.022,
+    ('tang_1987', 'flexural_modulus'): 7.933,
+    ('tang_1987', 'ilss'): 8.374,
+    ('tang_1987', 'tensile_strength'): 10.923,
+    ('wang_2022', 'tensile_modulus'): 1.336,
+    ('wang_2022', 'tensile_strength'): 12.801,
+    ('wen_2023', 'compression_strength'): 17.236,
+    ('wen_2023', 'ilss'): 5.704,
+    ('wen_2023', 'shear_strength'): 22.644,
+    ('wen_2023', 'tensile_strength'): 6.583,
+    ('zhang_peek_2025', 'transverse_tensile_modulus'): 5.96,
+}
+
+
+@pytest.fixture(scope="module")
+def _all_results():
+    """run_all_datasets is expensive (~30s); compute once for all 32 cases."""
+    import warnings
+    from validation.validate_all import run_all_datasets
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        return run_all_datasets()
+
+
+@pytest.mark.parametrize("key", sorted(_MAE_BASELINES),
+                         ids=lambda k: f"{k[0]}:{k[1]}")
+def test_per_dataset_mae_regression_pinned(key, _all_results):
+    dataset, prop = key
+    baseline = _MAE_BASELINES[key]
+    assert dataset in _all_results, f"dataset {dataset!r} missing from results"
+    ds = _all_results[dataset]
+    assert 'error' not in ds, f"{dataset} errored: {ds.get('error')}"
+    assert prop in ds, f"{dataset!r} missing property {prop!r}"
+    mae = ds[prop]['mae']
+    assert mae == pytest.approx(baseline, rel=0.10, abs=0.5), (
+        f"{dataset}/{prop} MAE drifted: {mae:.3f} vs baseline {baseline:.3f}"
+    )

--- a/validation/schemas/porosity_results_schema.json
+++ b/validation/schemas/porosity_results_schema.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Porosity Analysis Results",
+  "description": "Output contract for save_results_to_json / FESolver.export_results / the Streamlit exporters. The envelope (schema_version, format, provenance) is validated strictly so consumers can detect version/contract drift; the science payload is intentionally permissive so adding result fields is not a breaking schema change.",
+  "type": "object",
+  "required": ["schema_version", "format", "provenance"],
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "pattern": "^[0-9]+\\.[0-9]+$"
+    },
+    "format": {
+      "type": "string",
+      "enum": ["porosity-fe.empirical-sweep", "porosity-fe.fe-fields"]
+    },
+    "provenance": {
+      "type": "object",
+      "required": [
+        "porosity_fe_version",
+        "python_version",
+        "platform",
+        "numpy_version",
+        "scipy_version",
+        "timestamp_utc",
+        "seed",
+        "git_commit"
+      ],
+      "properties": {
+        "porosity_fe_version": {"type": ["string", "null"]},
+        "python_version": {"type": "string"},
+        "platform": {"type": "string"},
+        "numpy_version": {"type": ["string", "null"]},
+        "scipy_version": {"type": ["string", "null"]},
+        "matplotlib_version": {"type": ["string", "null"]},
+        "timestamp_utc": {"type": "string"},
+        "seed": {"type": ["integer", "null"]},
+        "git_commit": {"type": ["string", "null"]}
+      }
+    }
+  },
+  "additionalProperties": true
+}

--- a/validation/validate_all.py
+++ b/validation/validate_all.py
@@ -399,7 +399,9 @@ def generate_master_report(results: Dict[str, Any], output_dir: str = None):
     ax.grid(True, alpha=0.3, axis='y')
     plt.tight_layout()
     plot_path = os.path.join(output_dir, 'validation_master_report.png')
-    plt.savefig(plot_path, dpi=200, bbox_inches='tight')
+    # dpi=300 to match every other static PNG in the project (#53);
+    # bbox/dpi defaults also come from porosity_fe_analysis._apply_plot_style.
+    plt.savefig(plot_path, dpi=300, bbox_inches='tight')
     plt.close(fig)
 
     md_lines = ['# Master Validation Report', '']


### PR DESCRIPTION
## Summary
Closes the residual scope of the five PARTIAL issues from the triage sweep. Low risk, no physics changes — envelope/serialization, plot cosmetics, provenance plumbing, and test depth.

- **#20** — `_json_default()` added and wired into every `json.dump` (`save_results_to_json`, `FESolver.export_results`, both `app.py` exporters) so numpy scalars/ndarrays in the payload (e.g. user `ply_angles`) serialize instead of raising `TypeError`. New `validation/schemas/porosity_results_schema.json` strictly validates the envelope contract (`schema_version` / `format` enum / `provenance` required keys) while staying permissive on the science payload; a test validates a fresh export against it.
- **#51** — local stress contour in `app.py` now uses symmetric `vmin/vmax = ±max(|p5|,|p95|)` so `RdBu_r`'s white midpoint is true σ=0 (was 5/95 percentiles → sign visually misread). The `RdYlGn`/`hot_r` swaps were already done.
- **#53** — `_apply_plot_style()` gains `image.cmap='viridis'`, `legend.fontsize`, and an opt-in `'publication'` preset; axis/colorbar text centralized in a `LABELS` dict with the missing units applied (`Knockdown Factor (-)`, `Stress Concentration Factor (-)`); `validate_all.py` report DPI aligned 200→300.
- **#55** — importable `__version__` via `importlib.metadata` (provenance no longer records a null version); `seed=` added to `PorosityField` and `compare_configurations`, echoed into the `provenance` block; `app.py` exporters now emit provenance; new byte-determinism regression test locks in current reproducibility.
- **#48** — `test_tension_bcs` / `test_shear_bcs` deepened with per-DOF index+value asserts (a swapped ux/uy or traction-free face now fails); all **32** per-dataset/property validation MAEs regression-pinned (`rel=10%` or `abs=0.5`) behind a module-scoped fixture so `run_all_datasets` runs once.

## Out of scope (noted for follow-up)
- #55 item 4: `include_raw` / sibling `.npz` raw-array dump for `export_results` (a feature, not a quick win).
- #53: the full 25-call-site inline `fontsize=`/`dpi=` sweep (cosmetic; the drift-causing inconsistencies are fixed).

## Verification
- `pytest tests/` → **344 passed**, 3 pre-existing unrelated mesh-distortion warnings.
- Smoke: `__version__`=1.2.0 importable; `rcParams['image.cmap']`=viridis; `app._serialise_payload_json` now carries a provenance block and validates against the new results schema.
- MAE baselines regenerated from current `master` HEAD (deterministic, RNG-free pipeline per #55).

## Test plan
- [ ] CI green across the ubuntu/macOS/windows × py3.10–3.13 matrix.
- [ ] Confirm the determinism test stays stable across CI runners (different BLAS) — tolerance is exact-equality modulo `timestamp_utc`; if a runner's BLAS perturbs knockdowns this may need loosening to a numeric comparison.

https://claude.ai/code/session_01Ekic6cboH42CHtYqtp7biK

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ekic6cboH42CHtYqtp7biK)_