### PR TITLE
Parallelize 13-dataset validation suite with --jobs flag (#56)

### DIFF
--- a/tests/test_validation_database.py
+++ b/tests/test_validation_database.py
@@ -478,3 +478,56 @@ def test_per_dataset_mae_regression_pinned(key, _all_results):
     assert mae == pytest.approx(baseline, rel=0.10, abs=0.5), (
         f"{dataset}/{prop} MAE drifted: {mae:.3f} vs baseline {baseline:.3f}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Issue #56 — parallel per-dataset walk must be identical to the serial path
+# ---------------------------------------------------------------------------
+
+# Run the (slow) full serial walk exactly once and share it across the
+# parallelism tests so we don't duplicate the expensive computation.
+@pytest.fixture(scope="module")
+def serial_results():
+    from validation.validate_all import run_all_datasets
+    return run_all_datasets(n_jobs=1)
+
+
+def test_n_jobs_default_is_serial_path(serial_results):
+    """n_jobs=1 (default) must equal an explicit serial run — back-compat."""
+    from validation.validate_all import run_all_datasets
+    assert run_all_datasets() == serial_results
+
+
+def test_run_all_datasets_parallel_matches_serial(serial_results):
+    """run_all_datasets(n_jobs=2) must return a result *equal* to the serial
+    path: same keys, same order, same values (issue #56)."""
+    from validation.validate_all import run_all_datasets
+    parallel_results = run_all_datasets(n_jobs=2)
+    # Identical keys in identical (sorted) order.
+    assert list(parallel_results.keys()) == list(serial_results.keys())
+    # Deep-equal values (MAE floats, predicted lists, error dicts, skips).
+    assert parallel_results == serial_results
+
+
+def test_run_all_datasets_n_jobs_all_cores_matches_serial(serial_results):
+    """n_jobs=-1 (all cores) must also be identical to the serial path."""
+    from validation.validate_all import run_all_datasets
+    assert run_all_datasets(n_jobs=-1) == serial_results
+
+
+def test_resolve_n_jobs_contract():
+    """-1 and 0 map to os.cpu_count(); positive values pass through."""
+    import os
+    from validation.validate_all import _resolve_n_jobs
+    expected_all = os.cpu_count() or 1
+    assert _resolve_n_jobs(-1) == expected_all
+    assert _resolve_n_jobs(0) == expected_all
+    assert _resolve_n_jobs(1) == 1
+    assert _resolve_n_jobs(4) == 4
+
+
+def test_run_one_dataset_is_picklable():
+    """The ProcessPool worker must be a top-level (picklable) function."""
+    import pickle
+    from validation.validate_all import _run_one_dataset
+    assert pickle.loads(pickle.dumps(_run_one_dataset)) is _run_one_dataset

--- a/validate_porosity_cli.py
+++ b/validate_porosity_cli.py
@@ -126,6 +126,13 @@ def main(argv=None) -> int:
              'datasets) to the output directory',
     )
     parser.add_argument(
+        '--jobs', type=int, default=1, metavar='N',
+        help='Number of worker processes for the per-dataset validation '
+             'walk. 1 (default) runs serially (deterministic, unchanged '
+             'behaviour); N>1 parallelises across processes; -1 or 0 uses '
+             'all available CPU cores. Results are identical regardless of N.',
+    )
+    parser.add_argument(
         '--version', action='version',
         version=f'validate_porosity {_resolve_version()}',
     )
@@ -162,7 +169,7 @@ def main(argv=None) -> int:
         print()
 
     # Run predictions
-    results = run_all_datasets(datasets_dir=datasets_dir)
+    results = run_all_datasets(datasets_dir=datasets_dir, n_jobs=args.jobs)
 
     if not args.quiet:
         print(f"Loaded {len(results)} datasets. Generating report...")

--- a/validation/validate_all.py
+++ b/validation/validate_all.py
@@ -285,67 +285,130 @@ def summarize_mae(results: Dict[str, Any]) -> Dict[str, float]:
 
 
 import glob
+from concurrent.futures import ProcessPoolExecutor
 
 _MODULUS_PROPS = {'tensile_modulus', 'transverse_tensile_modulus',
                   'flexural_modulus', 'shear_modulus'}
 
 
-def run_all_datasets(datasets_dir: str = None) -> Dict[str, Any]:
-    """Run predictions for all datasets, return nested MAE results."""
+def _run_one_dataset(path: str):
+    """Compute the per-dataset MAE results for a single dataset JSON file.
+
+    Returns ``(name, dataset_results)`` where ``dataset_results`` has the same
+    shape the serial loop produced: either an ``{'error', 'error_type'}`` dict
+    on a load failure, or a ``{prop_key: {...}}`` mapping.
+
+    This is a *top-level* function (not a closure) so it is picklable and can
+    be dispatched to a ``ProcessPoolExecutor`` worker.  It contains zero
+    cross-dataset state, so running it in any order / any process yields
+    byte-identical results to the serial path (the pipeline is deterministic
+    and RNG-free).
+    """
+    name = os.path.basename(path).replace('.json', '')
+    try:
+        data = load_dataset(path)
+    except ValidationError as e:
+        logger.warning("Skipping dataset %s: %s", name, e)
+        return name, {
+            'error': str(e),
+            'error_type': type(e).__name__,
+        }
+
+    dataset_results = {}
+    for prop_key, prop_data in data['properties'].items():
+        vp = prop_data['void_content_pct']
+        exp = prop_data['normalized_values']
+        if prop_key in _UNSUPPORTED_STRENGTH_PROPS:
+            skip_msg = (
+                f"Skipping '{prop_key}' for dataset '{name}': no calibrated "
+                "EmpiricalSolver mode available (see issue #35)."
+            )
+            logger.warning(skip_msg)
+            dataset_results[prop_key] = {'skipped': skip_msg}
+            continue
+        try:
+            if prop_key in _MODULUS_PROPS:
+                pred = predict_modulus(data, prop_key, vp)
+            else:
+                pred = predict_strength(data, prop_key, vp)
+            mae = compute_mae(pred, exp)
+            dataset_results[prop_key] = {
+                'vp_pcts': list(vp),
+                'experimental': list(exp),
+                'predicted': pred,
+                'mae': mae,
+                'n_points': len(vp),
+            }
+        except Exception as e:
+            # logger.exception() captures the traceback so a downstream
+            # debug log (logging level DEBUG/INFO) shows *why* the
+            # property prediction failed, rather than just the bare
+            # string we surface in the JSON results (#19).
+            logger.exception("Prediction failed for %s/%s", name, prop_key)
+            dataset_results[prop_key] = {
+                'error': str(e),
+                'error_type': type(e).__name__,
+            }
+    return name, dataset_results
+
+
+def _resolve_n_jobs(n_jobs: int) -> int:
+    """Map the public ``n_jobs`` contract onto a concrete worker count.
+
+    ``n_jobs <= 0`` (covers ``-1`` and ``0``) means "use all cores".
+    ``os.cpu_count()`` can return ``None`` on exotic platforms; fall back to
+    ``1`` (serial) there so we never crash on a missing CPU count.
+    """
+    if n_jobs <= 0:
+        return os.cpu_count() or 1
+    return n_jobs
+
+
+def run_all_datasets(datasets_dir: str = None,
+                      n_jobs: int = 1) -> Dict[str, Any]:
+    """Run predictions for all datasets, return nested MAE results.
+
+    Parameters
+    ----------
+    datasets_dir:
+        Directory of dataset JSON files (defaults to the bundled
+        ``validation/datasets/``).
+    n_jobs:
+        Process-level parallelism for the per-dataset work.
+
+        * ``1`` (default) keeps the original *serial* code path verbatim —
+          zero behaviour change, fully deterministic, back-compatible.
+        * ``>1`` distributes per-dataset work across that many worker
+          processes via ``concurrent.futures.ProcessPoolExecutor``.
+        * ``-1`` or ``0`` uses ``os.cpu_count()`` workers.
+
+        Every ``(dataset)`` task is fully independent and the pipeline is
+        RNG-free, so the returned dict is identical (same keys, same values)
+        regardless of ``n_jobs``.  Results are always assembled in sorted
+        dataset order, so dict iteration order is deterministic too.
+    """
     if datasets_dir is None:
         datasets_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)),
                                     'datasets')
 
-    all_results = {}
-    for path in sorted(glob.glob(os.path.join(datasets_dir, '*.json'))):
-        name = os.path.basename(path).replace('.json', '')
-        try:
-            data = load_dataset(path)
-        except ValidationError as e:
-            logger.warning("Skipping dataset %s: %s", name, e)
-            all_results[name] = {
-                'error': str(e),
-                'error_type': type(e).__name__,
-            }
-            continue
+    paths = sorted(glob.glob(os.path.join(datasets_dir, '*.json')))
+    workers = _resolve_n_jobs(n_jobs)
 
-        dataset_results = {}
-        for prop_key, prop_data in data['properties'].items():
-            vp = prop_data['void_content_pct']
-            exp = prop_data['normalized_values']
-            if prop_key in _UNSUPPORTED_STRENGTH_PROPS:
-                skip_msg = (
-                    f"Skipping '{prop_key}' for dataset '{name}': no calibrated "
-                    "EmpiricalSolver mode available (see issue #35)."
-                )
-                logger.warning(skip_msg)
-                dataset_results[prop_key] = {'skipped': skip_msg}
-                continue
-            try:
-                if prop_key in _MODULUS_PROPS:
-                    pred = predict_modulus(data, prop_key, vp)
-                else:
-                    pred = predict_strength(data, prop_key, vp)
-                mae = compute_mae(pred, exp)
-                dataset_results[prop_key] = {
-                    'vp_pcts': list(vp),
-                    'experimental': list(exp),
-                    'predicted': pred,
-                    'mae': mae,
-                    'n_points': len(vp),
-                }
-            except Exception as e:
-                # logger.exception() captures the traceback so a downstream
-                # debug log (logging level DEBUG/INFO) shows *why* the
-                # property prediction failed, rather than just the bare
-                # string we surface in the JSON results (#19).
-                logger.exception("Prediction failed for %s/%s", name, prop_key)
-                dataset_results[prop_key] = {
-                    'error': str(e),
-                    'error_type': type(e).__name__,
-                }
-        all_results[name] = dataset_results
-    return all_results
+    if workers <= 1 or len(paths) <= 1:
+        # Serial path: byte-identical to the historical implementation.
+        return {name: res for name, res in (_run_one_dataset(p)
+                                            for p in paths)}
+
+    # Parallel path: dispatch independent per-dataset tasks across processes,
+    # then reassemble in sorted (== input) order so the result dict is
+    # deterministic and identical to the serial path.
+    by_name = {}
+    with ProcessPoolExecutor(max_workers=workers) as executor:
+        for name, dataset_results in executor.map(_run_one_dataset, paths):
+            by_name[name] = dataset_results
+    return {os.path.basename(p).replace('.json', ''):
+            by_name[os.path.basename(p).replace('.json', '')]
+            for p in paths}
 
 
 import matplotlib


### PR DESCRIPTION
Closes #56.

## Summary
- Lifted the per-dataset body of `run_all_datasets` into a top-level picklable `_run_one_dataset(path)`.
- New `n_jobs: int = 1` parameter. `n_jobs=1` (default) takes the **original serial code path verbatim** — zero behavior change, byte-identical, back-compatible. `n_jobs>1` dispatches datasets across `concurrent.futures.ProcessPoolExecutor`; `n_jobs=-1`/`0` → `os.cpu_count()`.
- Results reassembled in **sorted dataset order** so keys/iteration/values are identical regardless of worker count. RNG-free pipeline; `error`/`error_type`/`skipped` dict shapes preserved exactly.
- `--jobs N` flag added to `validate_porosity_cli.py` (default 1), wired to `run_all_datasets(n_jobs=...)`.

## Why this one is low-risk to merge first
Touches **only** `validation/validate_all.py`, `validate_porosity_cli.py`, and `tests/test_validation_database.py` — zero overlap with `porosity_fe_analysis.py` or the other open PRs (#72, #54, #58, #61, #63). No rebase contention.

## Verification (independently re-run on this branch)
`pytest tests/ -q` → **312 passed** (307 baseline + 5 new). Manual `--jobs 1` vs `--jobs 2`: identical MAE summary (7.06% property-weighted) and byte-identical detail report.

Platform note: default ProcessPool start method (fork on Linux, spawn on macOS/Windows); worker is a top-level function, so spawn-safe.

Generated with [Claude Code](https://claude.ai/code/session_01Ekic6cboH42CHtYqtp7biK)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ekic6cboH42CHtYqtp7biK)_