### PR TITLE
Add VTK/ParaView export for hex mesh + per-element FE fields (#61)

### DIFF
--- a/porosity_fe_analysis.py
+++ b/porosity_fe_analysis.py
@@ -3107,6 +3107,12 @@ class FieldResults:
         Maximum Tsai-Wu failure index across all Gauss points.
     knockdown : float
         Stiffness knockdown factor (modulus ratio: E_porous/E_pristine).
+    per_element_failure_index : np.ndarray or None
+        Shape (n_elem,) max-over-Gauss-point Tsai-Wu index per element.
+        Optional (defaults to ``None`` for back-compatibility with callers
+        that construct ``FieldResults`` directly); populated by
+        ``FESolver.solve`` and consumed by the VTK export so failure
+        hot-spots can be sliced in ParaView.
     """
     displacement: np.ndarray
     stress_global: np.ndarray
@@ -3115,6 +3121,7 @@ class FieldResults:
     strain_local: np.ndarray
     max_failure_index: float
     knockdown: float
+    per_element_failure_index: Optional[np.ndarray] = None
 
     def __repr__(self) -> str:
         n_nodes = self.displacement.shape[0] if self.displacement is not None else 0
@@ -3122,6 +3129,167 @@ class FieldResults:
         return (f"FieldResults(n_nodes={n_nodes}, n_elements={n_elem}, "
                 f"max_FI={self.max_failure_index:.4f}, "
                 f"knockdown={self.knockdown:.4f})")
+
+    def to_vtk(self, mesh: 'CompositeMesh', filename: str) -> None:
+        """Write the hex mesh and per-element FE fields to a legacy ASCII VTK
+        file (``UNSTRUCTURED_GRID``) for inspection in ParaView / VisIt / PyVista.
+
+        The writer is dependency-free: it emits the legacy VTK 3.0 ASCII
+        format by hand. The 8-node hex connectivity already stored in
+        ``mesh.elements`` follows the standard VTK hexahedron ordering
+        (bottom face CCW then top face CCW, see ``_NODE_COORDS_REF``), so the
+        cells are written verbatim with cell type 12 (``VTK_HEXAHEDRON``).
+
+        Point data
+        -----------
+        - ``displacement`` (3-vector), and the scalars ``porosity``,
+          ``stiffness_reduction``, ``ply_id`` if present on the mesh.
+
+        Cell data
+        ---------
+        - element-averaged ``von_mises`` and the six global stress
+          (``sigma_xx`` .. ``tau_xy``) and strain (``eps_xx`` .. ``gamma_xy``)
+          components (Gauss points reduced by mean),
+        - ``tsai_wu_index`` (max-over-GP per element, if available),
+        - ``Vp_elem`` (mean nodal porosity over the 8 corners),
+        - ``ply_id``, ``ply_angle_deg``, ``is_void`` and ``knockdown`` where
+          available.
+
+        Parameters
+        ----------
+        mesh : CompositeMesh
+            The mesh that produced these results (supplies geometry,
+            connectivity, porosity and ply metadata).
+        filename : str
+            Output ``.vtk`` file path.
+        """
+        nodes = np.asarray(mesh.nodes, dtype=float)
+        elements = np.asarray(mesh.elements, dtype=np.int64)
+        n_nodes = nodes.shape[0]
+        n_elem = elements.shape[0]
+
+        if elements.shape[1] != 8:
+            raise ValueError(
+                f"to_vtk only supports 8-node hexahedra; got connectivity "
+                f"of width {elements.shape[1]}."
+            )
+        if self.displacement is not None and \
+                self.displacement.shape[0] != n_nodes:
+            raise ValueError(
+                f"displacement has {self.displacement.shape[0]} rows but the "
+                f"mesh has {n_nodes} nodes; results do not match this mesh."
+            )
+
+        # Gauss-point-averaged global stress/strain -> (n_elem, 6)
+        sig = np.mean(self.stress_global, axis=1)
+        eps = np.mean(self.strain_global, axis=1)
+
+        # Element-averaged von Mises from the averaged stress tensor.
+        sxx, syy, szz = sig[:, 0], sig[:, 1], sig[:, 2]
+        tyz, txz, txy = sig[:, 3], sig[:, 4], sig[:, 5]
+        von_mises = np.sqrt(
+            0.5 * ((sxx - syy) ** 2 + (syy - szz) ** 2 + (szz - sxx) ** 2)
+            + 3.0 * (tyz ** 2 + txz ** 2 + txy ** 2)
+        )
+
+        def _fmt(values) -> str:
+            return "\n".join(repr(float(v)) for v in np.asarray(values).ravel())
+
+        def _fmt_xyz(rows) -> str:
+            return "\n".join(
+                f"{float(r[0])!r} {float(r[1])!r} {float(r[2])!r}"
+                for r in rows
+            )
+
+        lines = [
+            "# vtk DataFile Version 3.0",
+            "PorosityFE results (hex mesh + per-element fields)",
+            "ASCII",
+            "DATASET UNSTRUCTURED_GRID",
+            f"POINTS {n_nodes} float",
+        ]
+        lines.append(_fmt_xyz(nodes))
+
+        # CELLS: each line is "8 n0 n1 ... n7"; total size = n_elem * 9.
+        lines.append(f"CELLS {n_elem} {n_elem * 9}")
+        lines.append(
+            "\n".join(
+                "8 " + " ".join(str(int(i)) for i in conn) for conn in elements
+            )
+        )
+        lines.append(f"CELL_TYPES {n_elem}")
+        lines.append("\n".join("12" for _ in range(n_elem)))
+
+        # ---- POINT_DATA ----
+        lines.append(f"POINT_DATA {n_nodes}")
+        if self.displacement is not None:
+            disp = np.asarray(self.displacement, dtype=float)
+            lines.append("VECTORS displacement float")
+            lines.append(_fmt_xyz(disp))
+
+        def _point_scalar(name: str, arr) -> None:
+            arr = np.asarray(arr, dtype=float).ravel()
+            if arr.shape[0] != n_nodes:
+                return
+            lines.append(f"SCALARS {name} float 1")
+            lines.append("LOOKUP_TABLE default")
+            lines.append(_fmt(arr))
+
+        if getattr(mesh, 'porosity', None) is not None:
+            _point_scalar("porosity", mesh.porosity)
+        if getattr(mesh, 'stiffness_reduction', None) is not None:
+            _point_scalar("stiffness_reduction", mesh.stiffness_reduction)
+        if getattr(mesh, 'ply_ids', None) is not None:
+            _point_scalar("ply_id", mesh.ply_ids)
+
+        # ---- CELL_DATA ----
+        lines.append(f"CELL_DATA {n_elem}")
+
+        def _cell_scalar(name: str, arr) -> None:
+            arr = np.asarray(arr, dtype=float).ravel()
+            if arr.shape[0] != n_elem:
+                return
+            lines.append(f"SCALARS {name} float 1")
+            lines.append("LOOKUP_TABLE default")
+            lines.append(_fmt(arr))
+
+        _cell_scalar("von_mises", von_mises)
+        for idx, comp in enumerate(
+                ("sigma_xx", "sigma_yy", "sigma_zz",
+                 "tau_yz", "tau_xz", "tau_xy")):
+            _cell_scalar(comp, sig[:, idx])
+        for idx, comp in enumerate(
+                ("eps_xx", "eps_yy", "eps_zz",
+                 "gamma_yz", "gamma_xz", "gamma_xy")):
+            _cell_scalar(comp, eps[:, idx])
+
+        if self.per_element_failure_index is not None:
+            _cell_scalar("tsai_wu_index", self.per_element_failure_index)
+
+        # Element-averaged nodal porosity over the 8 corner nodes.
+        if getattr(mesh, 'porosity', None) is not None:
+            vp_elem = np.mean(
+                np.asarray(mesh.porosity, dtype=float)[elements], axis=1)
+            _cell_scalar("Vp_elem", vp_elem)
+        if getattr(mesh, 'elem_ply_ids', None) is not None:
+            _cell_scalar("ply_id", mesh.elem_ply_ids)
+        if getattr(mesh, 'ply_angles', None) is not None:
+            _cell_scalar("ply_angle_deg", mesh.ply_angles)
+        if getattr(mesh, 'void_elements', None) is not None:
+            is_void = np.zeros(n_elem, dtype=float)
+            void_idx = np.asarray(mesh.void_elements, dtype=np.int64).ravel()
+            if void_idx.size:
+                is_void[void_idx] = 1.0
+            _cell_scalar("is_void", is_void)
+
+        _cell_scalar(
+            "knockdown",
+            np.full(n_elem, float(self.knockdown), dtype=float))
+
+        with open(filename, 'w', encoding='utf-8') as f:
+            f.write("\n".join(lines))
+            f.write("\n")
+        print(f"Saved FE results (VTK): {filename}")
 
 
 class FESolver:
@@ -3270,8 +3438,10 @@ class FESolver:
                 stress_local[e, g] = T_sigma @ sig_g[g]
                 strain_local[e, g] = T_eps @ eps_g[g]
 
-        # 6. Evaluate Tsai-Wu at each GP
-        max_fi = self._evaluate_tsai_wu(stress_local)
+        # 6. Evaluate Tsai-Wu at each GP. per_elem_fi[e] is the max-over-GP
+        #    failure index for element e (0.0 for skipped void elements); the
+        #    scalar max_fi is its overall maximum.
+        max_fi, per_elem_fi = self._evaluate_tsai_wu(stress_local)
 
         # 7. Compute knockdown as average-stress ratio (porous / pristine)
         # Both numerator and denominator use the same 3D FE framework so that
@@ -3323,9 +3493,11 @@ class FESolver:
             strain_local=strain_local,
             max_failure_index=max_fi,
             knockdown=knockdown,
+            per_element_failure_index=per_elem_fi,
         )
 
-    def _evaluate_tsai_wu(self, stress_local: np.ndarray) -> float:
+    def _evaluate_tsai_wu(self, stress_local: np.ndarray
+                          ) -> Tuple[float, np.ndarray]:
         """Evaluate Tsai-Wu failure index at all Gauss points.
 
         Strengths are degraded per-element based on the element's average
@@ -3339,14 +3511,19 @@ class FESolver:
 
         Returns
         -------
-        float
-            Maximum Tsai-Wu failure index.
+        max_fi : float
+            Maximum Tsai-Wu failure index over all elements/Gauss points.
+        per_elem_fi : np.ndarray
+            Shape (n_elem,) max-over-Gauss-point Tsai-Wu index for each
+            element (0.0 for skipped void elements). Retained so the VTK
+            export can render the spatial distribution of failure hot-spots.
         """
         mat = self.material
         C_m_pristine = mat.get_isotropic_matrix_stiffness()
 
         max_fi = 0.0
         n_elem, n_gp, _ = stress_local.shape
+        per_elem_fi = np.zeros(n_elem, dtype=float)
         # Defense in depth: a single non-finite value in the porosity field
         # (e.g. from upstream NaN propagation) silently corrupts elem_Vp via
         # np.mean; clip + isfinite check stops it from reaching Tsai-Wu.
@@ -3452,26 +3629,55 @@ class FESolver:
                     f"mesh or check input bounds."
                 )
             elem_max = float(fi_per_gp.max())
+            per_elem_fi[e] = elem_max
             if elem_max > max_fi:
                 max_fi = elem_max
 
-        return float(max_fi)
+        return float(max_fi), per_elem_fi
 
     @staticmethod
-    def export_results(field_results: 'FieldResults', filename: str) -> None:
-        """Export FE results to a JSON file.
+    def export_results(field_results: 'FieldResults', filename: str,
+                       fmt: str = 'json',
+                       mesh: Optional['CompositeMesh'] = None) -> None:
+        """Export FE results to a JSON summary or a VTK field file.
 
-        Saves displacement statistics, stress/strain summaries, failure data,
-        and knockdown factor. Large arrays are summarized (min/max/mean/std)
+        With ``fmt='json'`` (the default, unchanged legacy behavior) this
+        saves displacement statistics, stress/strain summaries, failure data,
+        and knockdown factor; large arrays are summarized (min/max/mean/std)
         rather than stored in full.
+
+        With ``fmt='vtk'`` it delegates to :meth:`FieldResults.to_vtk` and
+        writes the full hex mesh plus per-element fields as a legacy ASCII
+        ``UNSTRUCTURED_GRID`` for ParaView / VisIt / PyVista. The richer
+        per-element/per-node API lives on ``FieldResults.to_vtk`` directly;
+        this ``fmt='vtk'`` path is a convenience shim for callers that
+        already hold an ``FESolver``.
 
         Parameters
         ----------
         field_results : FieldResults
             Results from FESolver.solve().
         filename : str
-            Output JSON file path.
+            Output file path (``.json`` or ``.vtk``).
+        fmt : str
+            ``'json'`` (default) or ``'vtk'``.
+        mesh : CompositeMesh, optional
+            Required when ``fmt='vtk'`` (supplies geometry/connectivity).
         """
+        fmt = str(fmt).lower()
+        if fmt == 'vtk':
+            if mesh is None:
+                raise ValueError(
+                    "export_results(fmt='vtk') requires the `mesh` argument "
+                    "(pass the CompositeMesh used by the solver)."
+                )
+            field_results.to_vtk(mesh, filename)
+            return
+        if fmt != 'json':
+            raise ValueError(
+                f"Unknown export format {fmt!r}. Use 'json' or 'vtk'."
+            )
+
         def _array_stats(arr: np.ndarray) -> dict:
             """Compute summary statistics for an array."""
             return {

--- a/tests/test_porosity_fe.py
+++ b/tests/test_porosity_fe.py
@@ -1721,6 +1721,184 @@ class TestFEExportResults:
         assert data['failure']['knockdown_factor'] > 0
 
 
+def _parse_legacy_vtk(path):
+    """Minimal legacy-ASCII VTK UNSTRUCTURED_GRID parser for test assertions.
+
+    Returns a dict with header, n_points, n_cells, the parsed point
+    coordinates, the cell connectivity, cell types, and the names of the
+    POINT_DATA / CELL_DATA arrays found.
+    """
+    with open(path, encoding='utf-8') as fh:
+        tokens = fh.read().split('\n')
+    lines = [ln.strip() for ln in tokens if ln.strip() != '']
+
+    info = {
+        'header': lines[0],
+        'point_data_arrays': [],
+        'cell_data_arrays': [],
+    }
+    i = 0
+    assert lines[2] == 'ASCII'
+    assert lines[3] == 'DATASET UNSTRUCTURED_GRID'
+
+    section = None  # None / 'point_data' / 'cell_data'
+    while i < len(lines):
+        ln = lines[i]
+        parts = ln.split()
+        if parts[0] == 'POINTS':
+            n_points = int(parts[1])
+            info['n_points'] = n_points
+            pts = []
+            for row in lines[i + 1:i + 1 + n_points]:
+                pts.append([float(v) for v in row.split()])
+            info['points'] = np.array(pts)
+            i += 1 + n_points
+            continue
+        if parts[0] == 'CELLS':
+            n_cells = int(parts[1])
+            info['n_cells'] = n_cells
+            info['cells_total_ints'] = int(parts[2])
+            conn = []
+            for row in lines[i + 1:i + 1 + n_cells]:
+                vals = [int(v) for v in row.split()]
+                assert vals[0] == 8  # hex8
+                conn.append(vals[1:])
+            info['cells'] = np.array(conn)
+            i += 1 + n_cells
+            continue
+        if parts[0] == 'CELL_TYPES':
+            n = int(parts[1])
+            types = [int(v) for v in lines[i + 1:i + 1 + n]]
+            info['cell_types'] = types
+            i += 1 + n
+            continue
+        if parts[0] == 'POINT_DATA':
+            section = 'point_data'
+            i += 1
+            continue
+        if parts[0] == 'CELL_DATA':
+            section = 'cell_data'
+            i += 1
+            continue
+        if parts[0] in ('SCALARS', 'VECTORS'):
+            name = parts[1]
+            if section == 'point_data':
+                info['point_data_arrays'].append(name)
+            elif section == 'cell_data':
+                info['cell_data_arrays'].append(name)
+            i += 1
+            continue
+        i += 1
+    return info
+
+
+class TestFEExportVTK:
+    """Issue #61: hex mesh + per-element fields written to legacy VTK."""
+
+    def _solve(self):
+        material = MATERIALS['T800_epoxy']
+        pf = PorosityField(material, 0.03, distribution='uniform')
+        mesh = CompositeMesh(pf, material, nx=3, ny=2, nz=2)
+        solver = FESolver(mesh, material, pf)
+        results = solver.solve(loading='compression', applied_strain=-0.001)
+        return mesh, results
+
+    def test_to_vtk_creates_file(self, tmp_path):
+        mesh, results = self._solve()
+        path = str(tmp_path / "fe_results.vtk")
+        results.to_vtk(mesh, path)
+        assert os.path.exists(path)
+        assert os.path.getsize(path) > 0
+
+    def test_to_vtk_header_and_counts(self, tmp_path):
+        mesh, results = self._solve()
+        path = str(tmp_path / "fe_results.vtk")
+        results.to_vtk(mesh, path)
+        info = _parse_legacy_vtk(path)
+        assert info['header'].startswith('# vtk DataFile Version')
+        assert info['n_points'] == mesh.n_nodes
+        assert info['n_cells'] == mesh.n_elements
+        # Each hex line is "8 n0..n7" -> 9 ints per cell.
+        assert info['cells_total_ints'] == mesh.n_elements * 9
+        # All cells must be VTK_HEXAHEDRON (type 12).
+        assert info['cell_types'] == [12] * mesh.n_elements
+
+    def test_to_vtk_geometry_matches_mesh(self, tmp_path):
+        mesh, results = self._solve()
+        path = str(tmp_path / "fe_results.vtk")
+        results.to_vtk(mesh, path)
+        info = _parse_legacy_vtk(path)
+        np.testing.assert_allclose(info['points'], mesh.nodes, rtol=1e-6)
+        np.testing.assert_array_equal(info['cells'], mesh.elements)
+
+    def test_to_vtk_has_expected_fields(self, tmp_path):
+        mesh, results = self._solve()
+        path = str(tmp_path / "fe_results.vtk")
+        results.to_vtk(mesh, path)
+        info = _parse_legacy_vtk(path)
+        assert 'displacement' in info['point_data_arrays']
+        assert 'porosity' in info['point_data_arrays']
+        for name in ('von_mises', 'sigma_xx', 'tau_xy',
+                     'tsai_wu_index', 'Vp_elem', 'is_void'):
+            assert name in info['cell_data_arrays'], name
+
+    def test_export_results_fmt_vtk(self, tmp_path):
+        mesh, results = self._solve()
+        path = str(tmp_path / "via_export.vtk")
+        FESolver.export_results(results, path, fmt='vtk', mesh=mesh)
+        info = _parse_legacy_vtk(path)
+        assert info['n_points'] == mesh.n_nodes
+        assert info['n_cells'] == mesh.n_elements
+
+    def test_export_results_vtk_requires_mesh(self, tmp_path):
+        _, results = self._solve()
+        path = str(tmp_path / "no_mesh.vtk")
+        with pytest.raises(ValueError):
+            FESolver.export_results(results, path, fmt='vtk')
+
+    def test_export_results_rejects_unknown_format(self, tmp_path):
+        _, results = self._solve()
+        path = str(tmp_path / "bad.xyz")
+        with pytest.raises(ValueError):
+            FESolver.export_results(results, path, fmt='nope')
+
+    def test_per_element_failure_index_populated(self):
+        mesh, results = self._solve()
+        assert results.per_element_failure_index is not None
+        assert results.per_element_failure_index.shape == (mesh.n_elements,)
+        assert np.all(results.per_element_failure_index >= 0)
+        # Scalar max must equal the per-element array's max.
+        np.testing.assert_allclose(
+            results.max_failure_index,
+            float(results.per_element_failure_index.max()))
+
+    def test_json_export_unchanged_back_compatible(self, tmp_path):
+        mesh, results = self._solve()
+        path = str(tmp_path / "fe_results.json")
+        # Default still JSON; explicit fmt='json' also works.
+        FESolver.export_results(results, path)
+        with open(path, encoding='utf-8') as f:
+            data = json.load(f)
+        assert 'displacement' in data
+        assert 'stress_global' in data
+        assert 'failure' in data
+
+    def test_to_vtk_meshio_roundtrip_if_available(self, tmp_path):
+        """If meshio happens to be importable, it must parse our file too.
+
+        meshio is NOT a project dependency; this test self-skips when it is
+        absent so it never forces the dependency.
+        """
+        meshio = pytest.importorskip("meshio")
+        mesh, results = self._solve()
+        path = str(tmp_path / "fe_results.vtk")
+        results.to_vtk(mesh, path)
+        m = meshio.read(path)
+        assert m.points.shape == (mesh.n_nodes, 3)
+        total_cells = sum(len(cb.data) for cb in m.cells)
+        assert total_cells == mesh.n_elements
+
+
 class TestReprMethods:
     def test_material_repr(self):
         mat = MATERIALS['T800_epoxy']


### PR DESCRIPTION
Closes #61.

## Summary
- `FieldResults.to_vtk(mesh, filename)` plus a convenience shim `FESolver.export_results(results, filename, fmt='vtk', mesh=mesh)`. **JSON remains the default `fmt` and is byte-for-byte back-compatible** (existing call signature unchanged).
- Hand-written legacy VTK 3.0 ASCII `UNSTRUCTURED_GRID`, `VTK_HEXAHEDRON` (type 12). Mesh connectivity already matches VTK hex ordering (verified vs `_NODE_COORDS_REF`) — written verbatim, no reordering.
- POINT_DATA: displacement vectors + porosity/stiffness_reduction/ply_id. CELL_DATA: element-avg von Mises, 6 stress + 6 strain components, per-element Tsai-Wu index, Vp_elem, ply angle/id, is_void, knockdown.
- **No new dependency** (pure numpy, ~130 LOC). Supporting change: `_evaluate_tsai_wu` now also returns a per-element FI array; new optional `FieldResults.per_element_failure_index` (defaults `None`, back-compatible).

## Verification (independently re-run on this branch)
`pytest tests/ -q` → **316 passed, 1 skipped** (307 baseline + 10 new `TestFEExportVTK`; skip = optional meshio round-trip when meshio absent). The existing Tsai-Wu / failure-index regression tests still pass, confirming the `_evaluate_tsai_wu` refactor is value-preserving.

⚠️ Merge-order note: the `_evaluate_tsai_wu` refactor is in the same function that open PR #72 vectorizes (#41). Whichever of #72 / this merges second needs a careful (mechanical) rebase of that function — flag for review.

Generated with [Claude Code](https://claude.ai/code/session_01Ekic6cboH42CHtYqtp7biK)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ekic6cboH42CHtYqtp7biK)_