### PR TITLE
Add Monte Carlo / LHS uncertainty propagation (#63)

### DIFF
--- a/porosity_fe_analysis.py
+++ b/porosity_fe_analysis.py
@@ -237,6 +237,73 @@ class MaterialProperties:
         C_m[3, 3] = C_m[4, 4] = C_m[5, 5] = mu
         return C_m
 
+    # Fields a UQ driver is allowed to perturb. Geometry (t_ply, n_plies) and
+    # Poisson ratios are excluded by default: the empirical knockdown models
+    # only consume strengths/moduli, and perturbing a bounded Poisson ratio or
+    # an integer ply count is rarely the intent. Callers may still target any
+    # of these via an explicit `covs`/`spec` key if needed.
+    PERTURBABLE_FIELDS = (
+        'E11', 'E22', 'E33', 'G12', 'G13', 'G23',
+        'sigma_1c', 'sigma_1t', 'sigma_2t', 'sigma_2c', 'tau_12', 'tau_ilss',
+        'matrix_modulus', 'fiber_modulus', 'fiber_volume_fraction',
+    )
+
+    def _perturbed_value(self, name: str, unit_draw: float,
+                         dist: str, params) -> float:
+        """Map one unit draw (a standard-normal or U(0,1) variate) to a
+        perturbed value of field ``name``.
+
+        ``dist`` is one of:
+          - ``'lognormal'`` (default): multiplicative truncated-lognormal so a
+            positive quantity stays positive. ``params`` is the coefficient of
+            variation (CoV, std/mean of the underlying value). ``unit_draw`` is
+            a standard-normal variate.
+          - ``'normal'``: additive Gaussian. ``params`` is the CoV; the std is
+            ``cov * |nominal|``. ``unit_draw`` is a standard-normal variate.
+          - ``'uniform'``: ``params`` is the fractional half-width ``h``; the
+            value is drawn uniformly on ``nominal * [1 - h, 1 + h]``.
+            ``unit_draw`` is a U(0, 1) variate.
+        """
+        nominal = float(getattr(self, name))
+        if dist == 'lognormal':
+            cov = float(params)
+            if cov <= 0.0:
+                return nominal
+            # Median-preserving lognormal with the requested CoV.
+            sigma_ln = np.sqrt(np.log1p(cov * cov))
+            return float(nominal * np.exp(sigma_ln * unit_draw))
+        if dist == 'normal':
+            cov = float(params)
+            if cov <= 0.0:
+                return nominal
+            return float(nominal + cov * abs(nominal) * unit_draw)
+        if dist == 'uniform':
+            h = float(params)
+            if h <= 0.0:
+                return nominal
+            return float(nominal * (1.0 - h + 2.0 * h * unit_draw))
+        raise ValueError(
+            f"Unknown distribution {dist!r} for field {name!r}. "
+            f"Use one of 'lognormal', 'normal', 'uniform'."
+        )
+
+    def perturb(self, draws: Dict[str, float],
+                spec: Dict[str, Tuple[str, float]]) -> "MaterialProperties":
+        """Return a new ``MaterialProperties`` with the fields in ``spec``
+        perturbed using the per-field unit draws in ``draws``.
+
+        ``spec`` maps ``field -> (distribution, params)`` (see
+        :meth:`_perturbed_value`). ``draws`` maps the same field names to a
+        single unit variate. Fields absent from ``spec`` are left at nominal.
+        The returned dataclass is re-validated by ``__post_init__``.
+        """
+        updates = {}
+        for name, (dist, params) in spec.items():
+            updates[name] = self._perturbed_value(
+                name, float(draws[name]), dist, params)
+        from dataclasses import replace as _dc_replace
+        return _dc_replace(self, **updates)
+
     def __repr__(self) -> str:
         return (f"MaterialProperties(E11={self.E11}, E22={self.E22}, "
                 f"G12={self.G12}, nu12={self.nu12}, "
@@ -1106,6 +1173,299 @@ class EmpiricalSolver:
             for model in ['judd_wright', 'power_law', 'linear']:
                 results[mode][model] = self.get_failure_load(mode, model)
         return results
+
+
+# ============================================================
+# SECTION 6b: UNCERTAINTY PROPAGATION (MONTE CARLO / LHS)
+# ============================================================
+
+# Default percentiles reported by the UQ helpers (a 5%/50%/95% band, the
+# spread an A-/B-basis workflow typically wants to see first).
+_UQ_DEFAULT_PERCENTILES = (5.0, 50.0, 95.0)
+_UQ_METHODS = ('monte_carlo', 'lhs')
+# Distributions that consume a standard-normal unit draw vs. a U(0,1) draw.
+_UQ_NORMAL_DISTS = ('lognormal', 'normal')
+_UQ_UNIFORM_DISTS = ('uniform',)
+
+
+def _normalize_uq_spec(material: 'MaterialProperties',
+                       covs: Optional[Dict[str, float]],
+                       spec: Optional[Dict[str, Tuple[str, float]]]
+                       ) -> "OrderedDict":
+    """Resolve the user-facing uncertainty description into a canonical
+    ``OrderedDict{field: (dist, params)}``.
+
+    ``covs`` is the convenience form: ``{field: cov}`` -> truncated-lognormal
+    with that coefficient of variation. ``spec`` is the explicit form:
+    ``{field: (dist, params)}``. They may both be given (``spec`` wins on a
+    field collision). Fields with a non-positive CoV are dropped so a
+    zero-CoV request is exactly the deterministic pipeline.
+    """
+    resolved: "OrderedDict" = OrderedDict()
+    valid = set(MaterialProperties.PERTURBABLE_FIELDS)
+
+    def _check_field(name: str) -> None:
+        if name not in valid:
+            raise ValueError(
+                f"Unknown / non-perturbable material field {name!r}. "
+                f"Use one of {sorted(valid)}."
+            )
+
+    for name, cov in (covs or {}).items():
+        _check_field(name)
+        cov = float(cov)
+        if not np.isfinite(cov) or cov < 0.0:
+            raise ValueError(
+                f"CoV for {name!r} must be a finite non-negative number, "
+                f"got {cov!r}."
+            )
+        if cov > 0.0:
+            resolved[name] = ('lognormal', cov)
+
+    for name, ds in (spec or {}).items():
+        _check_field(name)
+        if not (isinstance(ds, (tuple, list)) and len(ds) == 2):
+            raise ValueError(
+                f"spec[{name!r}] must be a (distribution, params) pair, "
+                f"got {ds!r}."
+            )
+        dist, params = ds
+        if dist not in _UQ_NORMAL_DISTS + _UQ_UNIFORM_DISTS:
+            raise ValueError(
+                f"spec[{name!r}] has unknown distribution {dist!r}. "
+                f"Use one of {sorted(_UQ_NORMAL_DISTS + _UQ_UNIFORM_DISTS)}."
+            )
+        params = float(params)
+        if not np.isfinite(params) or params < 0.0:
+            raise ValueError(
+                f"spec[{name!r}] params must be a finite non-negative "
+                f"number, got {params!r}."
+            )
+        if params > 0.0:
+            resolved[name] = (dist, params)
+        else:
+            resolved.pop(name, None)
+    return resolved
+
+
+def _draw_unit_samples(n_vars: int, n_samples: int, method: str,
+                       rng: np.random.Generator) -> np.ndarray:
+    """Return an ``(n_samples, n_vars)`` array of U(0, 1) variates.
+
+    ``method='monte_carlo'`` uses ``rng.random``; ``method='lhs'`` uses
+    ``scipy.stats.qmc.LatinHypercube`` seeded from the same ``rng`` so the
+    whole helper is reproducible from a single seed.
+    """
+    if n_vars == 0:
+        return np.empty((n_samples, 0))
+    if method == 'monte_carlo':
+        return rng.random((n_samples, n_vars))
+    if method == 'lhs':
+        from scipy.stats import qmc
+        sampler = qmc.LatinHypercube(d=n_vars, seed=rng)
+        return sampler.random(n=n_samples)
+    raise ValueError(
+        f"Unknown sampling method {method!r}. Use one of {sorted(_UQ_METHODS)}."
+    )
+
+
+def _unit_to_draw(u: np.ndarray, dist: str) -> np.ndarray:
+    """Map U(0, 1) variates to the unit variate the target distribution
+    expects: a standard normal for normal/lognormal, the U(0,1) untouched
+    (clipped off the 0/1 endpoints) for uniform."""
+    if dist in _UQ_NORMAL_DISTS:
+        from scipy.stats import norm
+        return norm.ppf(np.clip(u, 1e-12, 1.0 - 1e-12))
+    return u
+
+
+def propagate_uncertainty(void_volume_fraction: float,
+                          material: Union[str, 'MaterialProperties'] = 'T800_epoxy',
+                          mode: str = 'compression',
+                          model: str = 'judd_wright',
+                          *,
+                          covs: Optional[Dict[str, float]] = None,
+                          spec: Optional[Dict[str, Tuple[str, float]]] = None,
+                          vp_cov: float = 0.0,
+                          n_samples: int = 1000,
+                          method: str = 'monte_carlo',
+                          seed: Optional[int] = None,
+                          percentiles: Tuple[float, ...] = _UQ_DEFAULT_PERCENTILES,
+                          ply_angles: Optional[List[float]] = None,
+                          config: Optional[Dict] = None) -> Dict:
+    """Propagate input uncertainty through ``EmpiricalSolver.get_failure_load``.
+
+    Perturbs uncertain ``MaterialProperties`` fields (and, optionally, the
+    specimen-average porosity ``Vp``) and reports summary statistics of the
+    knockdown and failure stress. The base deterministic pipeline is
+    untouched; this is a strictly additive wrapper.
+
+    Parameters
+    ----------
+    void_volume_fraction : float
+        Nominal mean porosity fraction in [0, 1].
+    material : str or MaterialProperties
+        A ``MATERIALS`` preset name or an explicit dataclass instance.
+    mode, model : str
+        Forwarded to :meth:`EmpiricalSolver.get_failure_load`.
+    covs : dict, optional
+        Convenience uncertainty spec ``{field: cov}`` -> truncated-lognormal
+        with that coefficient of variation (std/mean).
+    spec : dict, optional
+        Explicit uncertainty spec ``{field: (dist, params)}`` where ``dist``
+        is ``'lognormal'`` / ``'normal'`` (params = CoV) or ``'uniform'``
+        (params = fractional half-width). Wins over ``covs`` on a collision.
+    vp_cov : float
+        CoV of the mean porosity itself (truncated-lognormal, clipped to
+        [0, 1]). 0.0 (default) holds Vp fixed at ``void_volume_fraction``.
+    n_samples : int
+        Number of draws.
+    method : {'monte_carlo', 'lhs'}
+        ``'monte_carlo'`` -> ``numpy.random.default_rng``;
+        ``'lhs'`` -> ``scipy.stats.qmc.LatinHypercube`` (both seeded from
+        ``seed`` so results are reproducible).
+    seed : int, optional
+        Seed for ``numpy.random.default_rng``. Echoed into the result. With a
+        fixed seed the summary is bit-for-bit reproducible.
+    percentiles : tuple of float
+        Percentiles to report (default 5/50/95).
+    ply_angles : list of float, optional
+        Forwarded to ``EmpiricalSolver`` (layup scaling).
+    config : dict, optional
+        Forwarded to ``PorosityField`` (distribution / void_shape / ...).
+
+    Returns
+    -------
+    dict
+        ``{'failure_stress': {'mean','std','min','max','percentiles': {...}},
+        'knockdown': {... same ...}, 'nominal': {...},
+        'samples': {'failure_stress': np.ndarray, 'knockdown': np.ndarray},
+        'seed', 'n_samples', 'method', 'mode', 'model', 'spec', 'vp_cov'}``.
+    """
+    if isinstance(material, str):
+        if material not in MATERIALS:
+            raise ValueError(
+                f"Unknown material {material!r}. "
+                f"Available presets: {sorted(MATERIALS)}."
+            )
+        material_name = material
+        mat = MATERIALS[material]
+    else:
+        material_name = getattr(material, '__class__', type(material)).__name__
+        mat = material
+
+    if not isinstance(n_samples, (int, np.integer)) or n_samples <= 0:
+        raise ValueError(
+            f"n_samples must be a positive integer, got {n_samples!r}."
+        )
+    if method not in _UQ_METHODS:
+        raise ValueError(
+            f"Unknown sampling method {method!r}. "
+            f"Use one of {sorted(_UQ_METHODS)}."
+        )
+    vp_cov = float(vp_cov)
+    if not np.isfinite(vp_cov) or vp_cov < 0.0:
+        raise ValueError(
+            f"vp_cov must be a finite non-negative number, got {vp_cov!r}."
+        )
+    pcts = tuple(float(p) for p in percentiles)
+    if any((not np.isfinite(p)) or p < 0.0 or p > 100.0 for p in pcts):
+        raise ValueError(
+            f"percentiles must lie in [0, 100], got {percentiles!r}."
+        )
+
+    resolved = _normalize_uq_spec(mat, covs, spec)
+    field_names = list(resolved.keys())
+    # The porosity variable, if active, is the last sampling dimension.
+    sample_vp = vp_cov > 0.0
+    n_vars = len(field_names) + (1 if sample_vp else 0)
+
+    config = config or {}
+
+    import contextlib
+    import io
+
+    def _build_solver(material_obj: 'MaterialProperties',
+                      vp_value: float) -> 'EmpiricalSolver':
+        # CompositeMesh prints a banner on construction; the sampling loop
+        # builds one mesh per draw, so silence it (additive: we do not touch
+        # CompositeMesh itself).
+        with contextlib.redirect_stdout(io.StringIO()):
+            pf = PorosityField(material_obj, vp_value, **config)
+            msh = CompositeMesh(pf, material_obj, nx=4, ny=3, nz=3,
+                                ply_angles=ply_angles)
+            return EmpiricalSolver(msh, material_obj, ply_angles=ply_angles)
+
+    # Deterministic nominal (no perturbation): the mean must land near this.
+    nominal = _build_solver(mat, float(void_volume_fraction)).get_failure_load(
+        mode, model)
+
+    rng = np.random.default_rng(seed)
+    unit = _draw_unit_samples(n_vars, int(n_samples), method, rng)
+
+    fs_samples = np.empty(int(n_samples), dtype=float)
+    kd_samples = np.empty(int(n_samples), dtype=float)
+
+    # Pre-compute per-field column index and the unit-variate mapping.
+    col_for_field = {name: i for i, name in enumerate(field_names)}
+    vp_col = len(field_names) if sample_vp else None
+    nominal_vp = float(void_volume_fraction)
+    if sample_vp:
+        sigma_ln_vp = np.sqrt(np.log1p(vp_cov * vp_cov))
+
+    for s in range(int(n_samples)):
+        draws = {}
+        for name in field_names:
+            dist, _ = resolved[name]
+            u = unit[s, col_for_field[name]]
+            draws[name] = float(_unit_to_draw(np.array([u]), dist)[0])
+        sampled_mat = mat.perturb(draws, resolved) if field_names else mat
+
+        if sample_vp:
+            z = float(_unit_to_draw(np.array([unit[s, vp_col]]),
+                                    'lognormal')[0])
+            vp_value = nominal_vp * np.exp(sigma_ln_vp * z)
+            vp_value = float(np.clip(vp_value, 0.0, 1.0))
+        else:
+            vp_value = nominal_vp
+
+        res = _build_solver(sampled_mat, vp_value).get_failure_load(mode, model)
+        fs_samples[s] = res['failure_stress']
+        kd_samples[s] = res['knockdown']
+
+    def _summary(arr: np.ndarray) -> Dict:
+        return {
+            'mean': float(np.mean(arr)),
+            'std': float(np.std(arr)),
+            'min': float(np.min(arr)),
+            'max': float(np.max(arr)),
+            'percentiles': {
+                f'p{p:g}': float(np.percentile(arr, p)) for p in pcts
+            },
+        }
+
+    return {
+        'failure_stress': _summary(fs_samples),
+        'knockdown': _summary(kd_samples),
+        'nominal': {
+            'failure_stress': float(nominal['failure_stress']),
+            'knockdown': float(nominal['knockdown']),
+        },
+        'samples': {
+            'failure_stress': fs_samples,
+            'knockdown': kd_samples,
+        },
+        'seed': seed,
+        'n_samples': int(n_samples),
+        'method': method,
+        'mode': mode,
+        'model': model,
+        'material': material_name,
+        'void_volume_fraction': float(void_volume_fraction),
+        'vp_cov': vp_cov,
+        'percentiles': list(pcts),
+        'spec': {k: list(v) for k, v in resolved.items()},
+    }
 
 
 # ============================================================

--- a/tests/test_porosity_fe.py
+++ b/tests/test_porosity_fe.py
@@ -25,7 +25,8 @@ from porosity_fe_analysis import (MaterialProperties, MATERIALS, VoidGeometry, V
                                    GlobalAssembler, BoundaryHandler, FESolver, FieldResults,
                                    compute_clt_effective_modulus, check_mesh_quality,
                                    _build_provenance, load_results_from_json,
-                                   JSON_SCHEMA_VERSION, FORMAT_EMPIRICAL_SWEEP)
+                                   JSON_SCHEMA_VERSION, FORMAT_EMPIRICAL_SWEEP,
+                                   propagate_uncertainty)
 
 import porosity_fe_analysis
 
@@ -2558,3 +2559,131 @@ class TestCLIMain:
         ])
         assert rc == 0
         assert (tmp_path / 'porosity_analysis_results_2p5pct.json').exists()
+
+
+class TestMaterialPropertiesPerturb:
+    """Unit tests for the MaterialProperties.perturb sampling primitive."""
+
+    def test_zero_draw_lognormal_is_identity(self):
+        m = MATERIALS['T800_epoxy']
+        out = m.perturb({'sigma_1c': 0.0}, {'sigma_1c': ('lognormal', 0.08)})
+        # exp(sigma_ln * 0) == 1 -> nominal preserved.
+        assert out.sigma_1c == pytest.approx(m.sigma_1c)
+        # Untouched fields are copied through.
+        assert out.E22 == m.E22
+
+    def test_returns_new_instance_validated(self):
+        m = MATERIALS['T800_epoxy']
+        out = m.perturb({'E22': 1.5}, {'E22': ('lognormal', 0.05)})
+        assert out is not m
+        assert out.E22 > m.E22  # positive draw -> larger modulus
+        assert isinstance(out, MaterialProperties)
+
+    def test_unknown_distribution_rejected(self):
+        m = MATERIALS['T800_epoxy']
+        with pytest.raises(ValueError, match="Unknown distribution"):
+            m.perturb({'sigma_1c': 0.1}, {'sigma_1c': ('weibull', 0.1)})
+
+
+class TestPropagateUncertainty:
+    """Monte Carlo / LHS uncertainty propagation around get_failure_load."""
+
+    _N = 32  # tiny sample count keeps the suite fast
+
+    def test_result_keys_and_shapes(self):
+        r = propagate_uncertainty(
+            0.02, 'T800_epoxy', covs={'sigma_1c': 0.08, 'E22': 0.05},
+            n_samples=self._N, seed=42)
+        for key in ('failure_stress', 'knockdown', 'nominal', 'samples',
+                    'seed', 'n_samples', 'method', 'mode', 'model', 'spec'):
+            assert key in r
+        for stat_key in ('mean', 'std', 'min', 'max', 'percentiles'):
+            assert stat_key in r['failure_stress']
+            assert stat_key in r['knockdown']
+        assert set(r['failure_stress']['percentiles']) == {'p5', 'p50', 'p95'}
+        assert r['samples']['failure_stress'].shape == (self._N,)
+        assert r['samples']['knockdown'].shape == (self._N,)
+        # Echoed metadata.
+        assert r['seed'] == 42
+        assert r['n_samples'] == self._N
+        assert r['method'] == 'monte_carlo'
+
+    def test_same_seed_is_reproducible(self):
+        kw = dict(covs={'sigma_1c': 0.08, 'E22': 0.05},
+                  n_samples=self._N, seed=123)
+        r1 = propagate_uncertainty(0.02, 'T800_epoxy', **kw)
+        r2 = propagate_uncertainty(0.02, 'T800_epoxy', **kw)
+        np.testing.assert_array_equal(r1['samples']['failure_stress'],
+                                      r2['samples']['failure_stress'])
+        assert r1['failure_stress']['mean'] == r2['failure_stress']['mean']
+        assert r1['failure_stress']['std'] == r2['failure_stress']['std']
+
+    def test_different_seed_differs(self):
+        kw = dict(covs={'sigma_1c': 0.08}, n_samples=self._N)
+        r1 = propagate_uncertainty(0.02, 'T800_epoxy', seed=1, **kw)
+        r2 = propagate_uncertainty(0.02, 'T800_epoxy', seed=2, **kw)
+        assert r1['failure_stress']['mean'] != r2['failure_stress']['mean']
+
+    def test_mean_near_deterministic_nominal(self):
+        # With a modest CoV the MC mean should be within a few % of the
+        # deterministic single-point prediction.
+        r = propagate_uncertainty(
+            0.02, 'T800_epoxy', covs={'sigma_1c': 0.05},
+            n_samples=256, seed=7)
+        nominal = r['nominal']['failure_stress']
+        assert r['failure_stress']['mean'] == pytest.approx(nominal, rel=0.05)
+
+    def test_zero_cov_gives_zero_std(self):
+        r = propagate_uncertainty(
+            0.02, 'T800_epoxy', covs={'sigma_1c': 0.0, 'E22': 0.0},
+            n_samples=self._N, seed=9)
+        assert r['failure_stress']['std'] == 0.0
+        assert r['knockdown']['std'] == 0.0
+        assert r['failure_stress']['mean'] == pytest.approx(
+            r['nominal']['failure_stress'])
+        assert r['spec'] == {}  # all-zero CoV collapses to deterministic
+
+    def test_lhs_method_runs_and_is_reproducible(self):
+        kw = dict(covs={'sigma_1c': 0.08}, n_samples=self._N, seed=42,
+                  method='lhs')
+        r1 = propagate_uncertainty(0.02, 'T800_epoxy', **kw)
+        r2 = propagate_uncertainty(0.02, 'T800_epoxy', **kw)
+        assert r1['method'] == 'lhs'
+        assert r1['failure_stress']['std'] > 0.0
+        np.testing.assert_array_equal(r1['samples']['failure_stress'],
+                                      r2['samples']['failure_stress'])
+
+    def test_explicit_spec_and_vp_cov(self):
+        r = propagate_uncertainty(
+            0.02, 'T800_epoxy',
+            spec={'sigma_1c': ('uniform', 0.1)},
+            vp_cov=0.15, n_samples=self._N, seed=3)
+        assert r['failure_stress']['std'] > 0.0
+        assert r['vp_cov'] == 0.15
+        assert r['spec'] == {'sigma_1c': ['uniform', 0.1]}
+
+    def test_percentile_ordering(self):
+        r = propagate_uncertainty(
+            0.02, 'T800_epoxy', covs={'sigma_1c': 0.08},
+            n_samples=128, seed=11)
+        p = r['failure_stress']['percentiles']
+        assert p['p5'] <= p['p50'] <= p['p95']
+        fs = r['failure_stress']
+        assert fs['min'] <= p['p5']
+        assert p['p95'] <= fs['max']
+
+    def test_unknown_material_rejected(self):
+        with pytest.raises(ValueError, match="Unknown material"):
+            propagate_uncertainty(0.02, 'not_a_material',
+                                  covs={'sigma_1c': 0.08}, n_samples=4)
+
+    def test_unknown_method_rejected(self):
+        with pytest.raises(ValueError, match="Unknown sampling method"):
+            propagate_uncertainty(0.02, 'T800_epoxy',
+                                  covs={'sigma_1c': 0.08}, n_samples=4,
+                                  method='sobol')
+
+    def test_non_perturbable_field_rejected(self):
+        with pytest.raises(ValueError, match="non-perturbable"):
+            propagate_uncertainty(0.02, 'T800_epoxy',
+                                  covs={'not_a_field': 0.1}, n_samples=4)


### PR DESCRIPTION
Closes #63.

## Summary
New module-level `propagate_uncertainty(void_volume_fraction, material='T800_epoxy', mode='compression', model='judd_wright', *, covs=None, spec=None, vp_cov=0.0, n_samples=1000, method='monte_carlo', seed=None, percentiles=(5,50,95), ...)` returning `{failure_stress, knockdown}` each with mean/std/min/max/percentiles, plus `nominal`, raw `samples`, and echoed `seed/n_samples/method/...`.

- Uncertainty via convenience `covs={field: cov}` (truncated-lognormal) or explicit `spec={field: (dist, params)}` (`lognormal`/`normal`/`uniform`).
- Both `monte_carlo` (`numpy.random.default_rng(seed)`) and `lhs` (`scipy.stats.qmc.LatinHypercube`); single seed → bit-for-bit reproducible for both.
- Added `MaterialProperties.perturb(draws, spec)` + `PERTURBABLE_FIELDS` as the sampling primitive.
- **Strictly additive**: no change to `get_failure_load`/`compare_configurations` signatures, defaults, or the deterministic pipeline. Zero CoV collapses exactly to deterministic (std==0).

## Scoped out
Closed-form sensitivities (issue #65); a `uq=` flag on `compare_configurations`/`save_results_to_json`; `*_cov` dataclass preset fields (CoVs passed at call time, no schema change).

## Verification (independently re-run on this branch)
`pytest tests/ -q` → **321 passed** (307 baseline + 14 new). Tests cover reproducibility, seed-divergence, mean≈nominal, std==0 at zero CoV, LHS path, percentile ordering, input validation.

Note: shares `porosity_fe_analysis.py` / `tests/test_porosity_fe.py` with #58, #61, open PR #72 — purely additive, mechanical rebases.

Generated with [Claude Code](https://claude.ai/code/session_01Ekic6cboH42CHtYqtp7biK)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ekic6cboH42CHtYqtp7biK)_