### PR TITLE
fix(cli): pass --seed into compare_configurations so it reaches JSON provenance

### DIFF
--- a/porosity_fe_analysis.py
+++ b/porosity_fe_analysis.py
@@ -4051,6 +4051,7 @@ def main(argv: Optional[List[str]] = None) -> int:
                 Vp,
                 material_name=args.material,
                 applied_stress=args.applied_stress,
+                seed=args.seed,
             )
         except ValueError as exc:
             print(f"ERROR: bad input for Vp={Vp}: {exc}", file=sys.stderr)

--- a/tests/test_porosity_fe.py
+++ b/tests/test_porosity_fe.py
@@ -2719,6 +2719,22 @@ class TestCLIMain:
         assert data['format'] == FORMAT_EMPIRICAL_SWEEP
         assert 'uniform_spherical' in data
 
+    def test_seed_is_recorded_in_provenance(self, tmp_path, monkeypatch):
+        # Regression for #79: --seed must reach provenance, not be dropped.
+        import json
+        monkeypatch.setattr(porosity_fe_analysis, 'POROSITY_CONFIGS',
+                            _TINY_CONFIGS)
+        rc = porosity_fe_analysis.main([
+            '--vp', '0.03',
+            '--seed', '12345',
+            '--output-dir', str(tmp_path),
+            '--quiet',
+        ])
+        assert rc == 0
+        out_file = tmp_path / 'porosity_analysis_results_3pct.json'
+        payload = json.loads(out_file.read_text(encoding='utf-8'))
+        assert payload['provenance']['seed'] == 12345
+
     def test_default_cwd_when_no_output_dir(self, tmp_path, monkeypatch):
         monkeypatch.setattr(porosity_fe_analysis, 'POROSITY_CONFIGS',
                             _TINY_CONFIGS)


### PR DESCRIPTION
## Summary
- Fixes #79: `porosity-analyze --seed` was parsed but never threaded into the analysis call, so `PorosityField.seed` stayed `None` and every JSON file recorded `provenance.seed: null` regardless of `--seed`.
- The recording chain `compare_configurations(seed=) → PorosityField(seed=) → save_results_to_json → _build_provenance(seed=)` was already fully wired; the only break was the CLI→`compare_configurations` hand-off. One-line fix in `main()` (`porosity_fe_analysis.py:4054`) adds `seed=args.seed`.
- Adds regression test `TestCLIMain::test_seed_is_recorded_in_provenance` asserting `provenance.seed == 12345` for `--seed 12345`.

Note: seed recording is **data-driven** (collected off each `porosity_field.seed`), not a `save_results_to_json` kwarg — see the correction posted on #79.

## Test plan
- [x] New regression test passes (`pytest -k test_seed_is_recorded_in_provenance`)
- [x] `TestCLIMain` suite green (8 passed)
- [x] Full suite: **380 passed, 1 skipped** (skip = unrelated optional-`meshio` case), no regressions
- [ ] Manual: `porosity-analyze --vp 0.02 --seed 42` → confirm `provenance.seed == 42` in emitted JSON

https://claude.ai/code/session_01Ekic6cboH42CHtYqtp7biK

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ekic6cboH42CHtYqtp7biK)_