### PR TITLE
fix(plots): use colorblind-safe colormaps and symmetric stress range

### DIFF
--- a/app.py
+++ b/app.py
@@ -700,7 +700,7 @@ def plot_mesh(result: dict):
     Z = mesh.nodes[indices, 2].reshape(mesh.nz + 1, mesh.nx + 1)
     Sr = mesh.stiffness_reduction[indices].reshape(mesh.nz + 1, mesh.nx + 1)
 
-    im = ax.contourf(X, Z, Sr * 100, levels=20, cmap="viridis",
+    im = ax.contourf(X, Z, Sr * 100, levels=20, cmap="cividis",
                      vmin=max(0, Sr.min() * 100 - 1), vmax=100)
     fig.colorbar(im, ax=ax, label="Stiffness Retention (%)")
 

--- a/porosity_fe_analysis.py
+++ b/porosity_fe_analysis.py
@@ -1611,7 +1611,7 @@ class FEVisualizer:
         else:
             kd = mesh.stiffness_reduction[start:end].reshape(ny1, nx1)
 
-        im = ax.contourf(X, Y, kd, levels=20, cmap='viridis')
+        im = ax.contourf(X, Y, kd, levels=20, cmap='cividis')
         plt.colorbar(im, ax=ax, label='Stiffness Retention (fraction)')
         ax.set_xlabel('x (mm)', fontsize=12)
         ax.set_ylabel('y (mm)', fontsize=12)
@@ -1642,7 +1642,7 @@ class FEVisualizer:
         scf_max = scf['compression']
         field = np.where(dist < 0, 0, 1.0 + (scf_max - 1) * np.exp(-dist / max(void_geometry.radii)))
 
-        im = ax.contourf(X, Y, field, levels=30, cmap='plasma')
+        im = ax.contourf(X, Y, field, levels=30, cmap='magma')
         plt.colorbar(im, ax=ax, label=LABELS['scf'])
         ax.set_xlabel('x (mm)', fontsize=12)
         ax.set_ylabel('y (mm)', fontsize=12)


### PR DESCRIPTION
Fixes #51

## Summary
- Stiffness retention midplane (`porosity_fe_analysis.py`): `viridis` → `cividis` (better grayscale-printable, fully colorblind-safe)
- GUI Mesh tab stiffness (`app.py`): `viridis` → `cividis`
- SCF field (`porosity_fe_analysis.py`): `plasma` → `magma` (perceptually uniform, better dark-band detail)
- Stress tricontourf (`app.py`): already symmetric (`v = max(|p5|, |p95|)`, `vmin=-v, vmax=v`) from prior work — no change required

A prior commit had already replaced the original `RdYlGn` / `hot_r` with `viridis` / `plasma`; this PR refines to the most colorblind-friendly and grayscale-stable choices specifically called out in the issue.

## Test plan
- [x] Full pytest suite — 386 passed, 1 skipped
- [x] No tests reference colormap strings (no test updates needed)

---
_Generated by [Claude Code](https://claude.ai/code/session_01X5dvvNWcbxZdjeHCZSXDzM)_