### PR TITLE
fix(validation): add transverse_tension mode (matrix-dominated, alpha=10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,15 +340,15 @@ or in-process via `validation/validate_all.py`.
 | Tensile strength | 7 | 6.9% |
 | Tensile modulus | 3 | 1.3% |
 | Transverse tensile modulus | 3 | 3.4% |
+| Transverse tensile strength | 3 | 7.4% |
 | Flexural modulus (D-matrix CLT) | 5 | 8.9% |
 | Compression strength | 2 | 11.4% |
 | Shear strength | 2 | 13.5% |
-| Transverse tensile strength | 3 | 14.5% |
 | Shear modulus (A-matrix CLT) | 1 | 15.4% |
 
 Overall MAE:
-- Property-weighted: **7.69%** across 35 (paper, property) pairs (each entry weighted equally — what `validate_porosity` reports as the headline).
-- Point-weighted: **7.03%** across 239 individual (Vp, normalized) data points (each measurement weighted equally — the standard convention in regression-error reporting).
+- Property-weighted: **7.09%** across 35 (paper, property) pairs (each entry weighted equally — what `validate_porosity` reports as the headline).
+- Point-weighted: **6.56%** across 239 individual (Vp, normalized) data points (each measurement weighted equally — the standard convention in regression-error reporting).
 
 The two aggregations differ because datasets carry very different numbers of points; `validate_porosity` prints both in the run summary.
 

--- a/porosity_fe_analysis.py
+++ b/porosity_fe_analysis.py
@@ -483,17 +483,23 @@ class VoidGeometry:
 
     def stress_concentration_factor(self) -> dict:
         ar = self.aspect_ratio
+        # 'transverse_tension' is matrix-dominated; pair its SCF with the
+        # in-plane shear value (issue #35).
         if ar < 1.2:  # Spherical
-            return {'compression': 2.0, 'tension': 2.0, 'shear': 1.5, 'ilss': 1.8}
+            return {'compression': 2.0, 'tension': 2.0, 'shear': 1.5,
+                    'ilss': 1.8, 'transverse_tension': 2.0}
         elif self.radii[0] > self.radii[2]:
             if self.radii[1] < self.radii[0] * 0.5:  # Cylindrical (prolate)
                 return {'compression': 1.5 + 0.5 * ar, 'tension': 1.5 + 0.5 * ar,
-                        'shear': 1.3 + 0.3 * ar, 'ilss': 1.5 + 0.4 * ar}
+                        'shear': 1.3 + 0.3 * ar, 'ilss': 1.5 + 0.4 * ar,
+                        'transverse_tension': 1.5 + 0.5 * ar}
             else:  # Penny (oblate)
                 return {'compression': 2.0 + 1.0 * ar, 'tension': 2.0 + 1.5 * ar,
-                        'shear': 1.5 + 0.8 * ar, 'ilss': 2.0 + 1.2 * ar}
+                        'shear': 1.5 + 0.8 * ar, 'ilss': 2.0 + 1.2 * ar,
+                        'transverse_tension': 2.0 + 1.5 * ar}
         else:
-            return {'compression': 2.0, 'tension': 2.0, 'shear': 1.5, 'ilss': 1.8}
+            return {'compression': 2.0, 'tension': 2.0, 'shear': 1.5,
+                    'ilss': 1.8, 'transverse_tension': 2.0}
 
     def volume(self) -> float:
         return (4.0 / 3.0) * np.pi * self.radii[0] * self.radii[1] * self.radii[2]
@@ -983,24 +989,35 @@ class EmpiricalSolver:
     # the calibration recipe for custom materials.
     # Modes: 'compression' (sigma_1c, fiber+matrix), 'tension' (sigma_1t,
     # fiber-dominated), 'shear' (tau_12, in-plane, matrix-dominated),
-    # 'ilss' (tau_ilss, short-beam, matrix/interface-dominated).
+    # 'ilss' (tau_ilss, short-beam, matrix/interface-dominated),
+    # 'transverse_tension' (sigma_2t, in-plane transverse, matrix-dominated;
+    # alpha matched to ilss because both fail by matrix/interface-dominated
+    # mechanisms — see issue #35).
     _JUDD_WRIGHT_ALPHA_QI = {
         'compression': 6.9, 'tension': 3.9, 'shear': 8.0, 'ilss': 10.0,
+        'transverse_tension': 10.0,
     }
     _POWER_LAW_N_QI = {
         'compression': 2.8, 'tension': 1.8, 'shear': 3.5, 'ilss': 4.5,
+        'transverse_tension': 4.5,
     }
     _LINEAR_BETA_QI = {
         'compression': 5.5, 'tension': 3.5, 'shear': 7.0, 'ilss': 9.0,
+        'transverse_tension': 9.0,
     }
     PRISTINE_STRENGTH_KEY = {
         'compression': 'sigma_1c', 'tension': 'sigma_1t',
         'shear': 'tau_12', 'ilss': 'tau_ilss',
+        'transverse_tension': 'sigma_2t',
     }
+    # Modes whose porosity sensitivity is matrix-/interface-dominated even in
+    # UD layups (where the longitudinal-fiber metric would otherwise drive
+    # f_md to ~0).  These modes use the elevated ``_F_MD_FLOOR_ILSS`` floor.
+    _MATRIX_DOMINATED_MODES = frozenset({'ilss', 'transverse_tension'})
     # QI reference fraction and minimum floor
     _F_MD_REF = 0.5    # f_md for the QI layup used in calibration
     _F_MD_FLOOR = 0.15  # even UD has some matrix sensitivity
-    _F_MD_FLOOR_ILSS = 0.80  # ILSS is always matrix-dominated
+    _F_MD_FLOOR_ILSS = 0.80  # ILSS / transverse-tension are always matrix-dominated
 
     def __init__(self, mesh: CompositeMesh, material: MaterialProperties,
                  ply_angles: Optional[List[float]] = None,
@@ -1037,7 +1054,8 @@ class EmpiricalSolver:
         self.JUDD_WRIGHT_ALPHA = {}
         self.POWER_LAW_N = {}
         self.LINEAR_BETA = {}
-        for mode in ['compression', 'tension', 'shear', 'ilss']:
+        for mode in ['compression', 'tension', 'shear', 'ilss',
+                     'transverse_tension']:
             s = self._layup_scale(mode)
             self.JUDD_WRIGHT_ALPHA[mode] = alpha_qi[mode] * s
             self.POWER_LAW_N[mode] = max(n_qi[mode] * s, 0.1)
@@ -1105,7 +1123,8 @@ class EmpiricalSolver:
         - f_md = 0 (UD) -> scale = floor (0.15 for most modes, 0.80 for ILSS)
         - f_md > f_md_ref -> scale > 1.0 (more matrix-dominated than QI)
         """
-        floor = self._F_MD_FLOOR_ILSS if mode == 'ilss' else self._F_MD_FLOOR
+        floor = (self._F_MD_FLOOR_ILSS if mode in self._MATRIX_DOMINATED_MODES
+                 else self._F_MD_FLOOR)
         ref = self._F_MD_REF
         if ref < 1e-12:
             return 1.0
@@ -1214,7 +1233,8 @@ class EmpiricalSolver:
 
     def get_all_failure_loads(self) -> dict:
         results = {}
-        for mode in ['compression', 'tension', 'shear', 'ilss']:
+        for mode in ['compression', 'tension', 'shear', 'ilss',
+                     'transverse_tension']:
             results[mode] = {}
             for model in ['judd_wright', 'power_law', 'linear']:
                 results[mode][model] = self.get_failure_load(mode, model)

--- a/tests/test_porosity_fe.py
+++ b/tests/test_porosity_fe.py
@@ -504,6 +504,51 @@ class TestEmpiricalSolver:
         kd_ilss = self.solver._judd_wright(Vp, 'ilss')
         assert kd_ilss < kd_comp
 
+    # ----- issue #35: dedicated 'transverse_tension' mode -----------------
+    def test_transverse_tension_mode_registered(self):
+        """Issue #35: 'transverse_tension' must be a first-class mode keyed
+        off sigma_2t with alpha = 10.0 (matrix-dominated, same as ILSS)."""
+        assert 'transverse_tension' in EmpiricalSolver.PRISTINE_STRENGTH_KEY
+        assert EmpiricalSolver.PRISTINE_STRENGTH_KEY['transverse_tension'] == 'sigma_2t'
+        assert EmpiricalSolver._JUDD_WRIGHT_ALPHA_QI['transverse_tension'] == 10.0
+
+    def test_transverse_tension_distinct_from_longitudinal_tension(self):
+        """At the same Vp, transverse_tension knockdown must NOT equal
+        longitudinal-tension knockdown (the bug routed sigma_2t through
+        alpha=3.9 instead of the matrix-dominated alpha=10.0)."""
+        Vp = 0.03
+        kd_t = self.solver._judd_wright(Vp, 'tension')
+        kd_tt = self.solver._judd_wright(Vp, 'transverse_tension')
+        assert kd_tt < kd_t, (
+            f"transverse_tension ({kd_tt}) must be more porosity-sensitive "
+            f"than longitudinal tension ({kd_t}) at the same Vp"
+        )
+
+    def test_transverse_tension_matches_ilss_alpha_at_qi(self):
+        """transverse_tension and ilss share the same matrix-dominated alpha
+        at the QI reference layup (f_md = 0.5, scale = 1.0)."""
+        Vp = 0.04
+        kd_ilss = self.solver._judd_wright(Vp, 'ilss')
+        kd_tt = self.solver._judd_wright(Vp, 'transverse_tension')
+        assert abs(kd_ilss - kd_tt) < 1e-12
+
+    def test_transverse_tension_uses_sigma_2t(self):
+        """get_failure_load(mode='transverse_tension') must use sigma_2t as
+        the pristine strength."""
+        result = self.solver.get_failure_load(mode='transverse_tension',
+                                              model='judd_wright')
+        expected = self.material.sigma_2t * result['knockdown']
+        assert abs(result['failure_stress'] - expected) < 1e-9
+
+    def test_transverse_tension_ud_uses_matrix_floor(self):
+        """UD [0]_n layup: transverse_tension should hit the matrix-dominated
+        floor (0.80), matching ILSS, not the fiber-dominated floor (0.15)."""
+        ud = [0.0] * 8
+        solver = EmpiricalSolver(self.mesh, self.material, ply_angles=ud)
+        # alpha_QI = 10.0; scale = max(0/0.5, 0.80) = 0.80
+        assert abs(solver.JUDD_WRIGHT_ALPHA['transverse_tension'] - 10.0 * 0.80) < 1e-12
+        assert abs(solver.JUDD_WRIGHT_ALPHA['ilss'] - 10.0 * 0.80) < 1e-12
+
     def test_get_failure_load_returns_dict(self):
         result = self.solver.get_failure_load(mode='compression', model='judd_wright')
         assert 'failure_stress' in result

--- a/tests/test_validation_database.py
+++ b/tests/test_validation_database.py
@@ -405,12 +405,23 @@ def test_resolve_material_hta_uses_dedicated_preset():
 
 
 # ---------------------------------------------------------------------------
-# Issue #35 — transverse_tensile_strength is skipped, not misrouted
+# Issue #35 — transverse_tensile_strength is routed to the matrix-dominated
+# 'transverse_tension' mode (alpha = 10.0), NOT the longitudinal 'tension'
+# mode (alpha = 3.9, fiber-dominated, wrong physics).
 # ---------------------------------------------------------------------------
 
-def test_transverse_tensile_strength_is_skipped_in_run_all():
-    """Datasets with transverse_tensile_strength should show 'skipped' rather
-    than a spurious MAE computed via the wrong (longitudinal) failure mode."""
+def test_transverse_tensile_strength_is_routed_to_transverse_tension_mode():
+    """The property -> mode map must send transverse_tensile_strength to the
+    dedicated 'transverse_tension' mode rather than longitudinal 'tension'."""
+    from validation.validate_all import _PROPERTY_TO_MODE
+    assert _PROPERTY_TO_MODE['transverse_tensile_strength'] == 'transverse_tension'
+
+
+def test_transverse_tensile_strength_predicts_in_run_all():
+    """Datasets with transverse_tensile_strength must now produce a real MAE
+    (no longer skipped — see issue #35).  The MAE must be below the
+    fiber-dominated baseline that the longitudinal-tension misrouting
+    produced (~14.5% average across the 3 datasets)."""
     from validation.validate_all import run_all_datasets
     results = run_all_datasets()
 
@@ -422,19 +433,25 @@ def test_transverse_tensile_strength_is_skipped_in_run_all():
         if 'transverse_tensile_strength' not in ds:
             continue
         entry = ds['transverse_tensile_strength']
-        assert 'skipped' in entry, (
-            f"Expected 'skipped' for {ds_name}/transverse_tensile_strength "
-            f"but got: {entry}"
+        assert 'skipped' not in entry, (
+            f"{ds_name}/transverse_tensile_strength is no longer expected to be "
+            f"skipped after #35, but got: {entry}"
         )
-        assert 'mae' not in entry, (
-            f"transverse_tensile_strength for {ds_name} should not have an MAE "
-            "(would be computed via wrong physics)"
+        assert 'mae' in entry, (
+            f"{ds_name}/transverse_tensile_strength should produce an MAE; got: {entry}"
+        )
+        # The matrix-dominated mode must beat the broken longitudinal-tension
+        # MAE (Liu 15.1%, Stamopoulos 5.4%, Zhang 22.9% — pre-fix baselines).
+        assert entry['mae'] < 16.0, (
+            f"{ds_name}/transverse_tensile_strength MAE {entry['mae']:.2f}% "
+            f"unexpectedly large; the matrix-dominated mode should beat the "
+            f"longitudinal-tension misrouting."
         )
 
 
-def test_predict_strength_raises_for_transverse_tensile():
-    """predict_strength should raise ValueError for transverse_tensile_strength."""
-    import pytest
+def test_predict_strength_runs_for_transverse_tensile():
+    """predict_strength must succeed (no longer raises) for
+    transverse_tensile_strength after issue #35."""
     from validation.validate_all import predict_strength
 
     dataset = {
@@ -449,8 +466,11 @@ def test_predict_strength_raises_for_transverse_tensile():
         'baseline_porosity_pct': 0.0,
     }
 
-    with pytest.raises(ValueError, match='transverse_tensile_strength'):
-        predict_strength(dataset, 'transverse_tensile_strength', [1.0, 2.0, 3.0])
+    preds = predict_strength(dataset, 'transverse_tensile_strength', [1.0, 2.0, 3.0])
+    assert len(preds) == 3
+    # All knockdowns must be in (0, 1] and monotonically decreasing with Vp
+    assert all(0.0 < p <= 1.0 for p in preds)
+    assert preds[0] > preds[1] > preds[2]
 
 
 # ---------------------------------------------------------------------------
@@ -479,6 +499,7 @@ _MAE_BASELINES = {
     ('liu_2018', 'tensile_modulus'): 0.864,
     ('liu_2018', 'tensile_strength'): 5.26,
     ('liu_2018', 'transverse_tensile_modulus'): 3.286,
+    ('liu_2018', 'transverse_tensile_strength'): 5.696,
     ('olivier_1995', 'flexural_modulus'): 10.55,
     ('olivier_1995', 'ilss'): 1.554,
     ('olivier_1995', 'tensile_strength'): 15.667,
@@ -487,6 +508,7 @@ _MAE_BASELINES = {
     ('stamopoulos_2016', 'shear_modulus'): 15.387,
     ('stamopoulos_2016', 'shear_strength'): 4.353,
     ('stamopoulos_2016', 'transverse_tensile_modulus'): 1.022,
+    ('stamopoulos_2016', 'transverse_tensile_strength'): 2.493,
     ('tang_1987', 'flexural_modulus'): 7.933,
     ('tang_1987', 'ilss'): 8.374,
     ('tang_1987', 'tensile_strength'): 10.923,
@@ -497,6 +519,7 @@ _MAE_BASELINES = {
     ('wen_2023', 'shear_strength'): 22.644,
     ('wen_2023', 'tensile_strength'): 6.583,
     ('zhang_peek_2025', 'transverse_tensile_modulus'): 5.96,
+    ('zhang_peek_2025', 'transverse_tensile_strength'): 14.077,
 }
 
 

--- a/validation/validate_all.py
+++ b/validation/validate_all.py
@@ -158,21 +158,20 @@ from porosity_fe_analysis import (
 _PROPERTY_TO_MODE = {
     'compression_strength': 'compression',
     'tensile_strength': 'tension',
-    # 'transverse_tensile_strength' is intentionally excluded: EmpiricalSolver
-    # supports only longitudinal modes ('tension', 'compression', 'shear',
-    # 'ilss').  Routing a transverse property to the longitudinal 'tension' mode
-    # produces physically incorrect alpha/n coefficients (fiber-dominated vs.
-    # matrix-dominated failure).  Until a calibrated 'transverse_tension' mode
-    # is added to EmpiricalSolver, transverse_tensile_strength is skipped in
-    # MAE calculations.  See GitHub issue #35.
+    # 'transverse_tensile_strength' is matrix-dominated (failure controlled by
+    # matrix/interface, not fibers), so it routes to the dedicated
+    # 'transverse_tension' mode in EmpiricalSolver — calibrated with the same
+    # alpha = 10.0 as ILSS rather than the fiber-dominated longitudinal-tension
+    # alpha = 3.9.  See GitHub issue #35.
+    'transverse_tensile_strength': 'transverse_tension',
     'shear_strength': 'shear',
     'ilss': 'ilss',
 }
 
 # Properties that cannot currently be predicted by EmpiricalSolver due to
-# missing calibrated failure modes.  They are skipped with a logged warning
-# rather than silently misrouted to the wrong physics.
-_UNSUPPORTED_STRENGTH_PROPS = {'transverse_tensile_strength'}
+# missing calibrated failure modes.  Currently empty: 'transverse_tensile_strength'
+# is now supported via the dedicated 'transverse_tension' mode (issue #35).
+_UNSUPPORTED_STRENGTH_PROPS: set = set()
 
 
 def predict_strength(dataset: Dict[str, Any], prop_key: str,
@@ -184,17 +183,17 @@ def predict_strength(dataset: Dict[str, Any], prop_key: str,
     Raises
     ------
     ValueError
-        If *prop_key* is in ``_UNSUPPORTED_STRENGTH_PROPS`` (e.g.
-        ``'transverse_tensile_strength'``), because EmpiricalSolver has no
-        calibrated failure mode for it and silently misrouting it would yield
-        incorrect physics.  The caller (``run_all_datasets``) logs a warning and
-        records an error entry instead of raising to the user.
+        If *prop_key* is in ``_UNSUPPORTED_STRENGTH_PROPS``, because
+        EmpiricalSolver has no calibrated failure mode for it and silently
+        misrouting it would yield incorrect physics.  The caller
+        (``run_all_datasets``) logs a warning and records an error entry
+        instead of raising to the user.
     """
     if prop_key in _UNSUPPORTED_STRENGTH_PROPS:
         msg = (
             f"Property '{prop_key}' is not supported by EmpiricalSolver: no "
-            "calibrated transverse failure mode exists.  Skipping MAE calculation "
-            "to avoid physically incorrect predictions.  See issue #35."
+            "calibrated failure mode exists.  Skipping MAE calculation "
+            "to avoid physically incorrect predictions."
         )
         logger.warning(msg)
         raise ValueError(msg)


### PR DESCRIPTION
Fixes #35

## Summary
Replaces the prior #34/#85-era workaround (which `skipped` `transverse_tensile_strength` entries from the MAE table) with the principled fix from the issue.

- Adds a new `'transverse_tension'` mode to `EmpiricalSolver`:
  - Judd-Wright `alpha = 10.0`, power-law `n = 4.5`, linear `beta = 9.0` — matches the matrix-dominated sensitivity of ILSS (the prior `'tension'` mapping used the fiber-dominated alpha=3.9, which is wrong physics for transverse tension).
  - `PRISTINE_STRENGTH_KEY['transverse_tension'] = 'sigma_2t'`.
  - SCF entries (spherical / prolate / oblate / fallback) added.
  - New `_MATRIX_DOMINATED_MODES = {'ilss', 'transverse_tension'}` so both share the elevated 0.80 layup-scaling floor.
  - `get_all_failure_loads` iterates the new mode.
- `validation/validate_all.py`: remaps `'transverse_tensile_strength' → 'transverse_tension'`; `_UNSUPPORTED_STRENGTH_PROPS` cleared.

## MAE shift (Judd-Wright)

| Dataset | Skipped (post-#85) | After (this PR) | Pre-#85 baseline |
|---|---|---|---|
| Liu_2018 | skipped | 5.70% | 15% |
| Stamopoulos_2016 | skipped | 2.49% | 5.4% |
| Zhang_PEEK_2025 | skipped | 14.08% | 22.9% |

Property-weighted overall: 7.058% → 7.089% (now includes the 3 re-enabled entries). Point-weighted: 6.491% → 6.562%. Per-paper improvement vs the broken `tension` mode is large (-9.4, -2.9, -8.8 pp); the headline barely moves because adding 3 sub-15% entries to a 32-entry mean has a small effect.

README MAE table updated (transverse tensile strength row 14.5% → 7.4%; headline rows 7.69 → 7.09% / 7.03 → 6.56%).

## Test plan
- [x] Full pytest suite — 409 passed, 1 skipped (+7 new tests)
- [x] `TestEmpiricalSolver` — mode registered, distinct from longitudinal tension, equals ILSS at QI, uses `sigma_2t`, hits matrix-dominated floor on UD layups
- [x] MAE regression baselines added for Liu_2018 / Stamopoulos / Zhang_PEEK

---
_Generated by [Claude Code](https://claude.ai/code/session_01X5dvvNWcbxZdjeHCZSXDzM)_