### PR TITLE
feat(perf): parallelize compare_configurations sweep with --jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 All notable changes to PorosityFE will be documented in this file.
 
+## [Unreleased]
+
+### Added
+- **`--jobs N` flag on the `porosity-fe` CLI** parallelises the per-
+  configuration sweep in `compare_configurations` over a
+  `concurrent.futures.ProcessPoolExecutor`. `N=1` (default) preserves
+  the deterministic serial path byte-for-byte; `N>1` dispatches the
+  `(Vp, config)` calls across worker processes; `0`/`-1` resolve to
+  `os.cpu_count()`. Results are deterministically re-assembled by
+  `(Vp, name)` so the returned dict is independent of `N`. Measured
+  ~2x wall-clock speedup on the 5-Vp × 5-config sweep with 4 workers
+  on a 4-core box. (#52)
+- **`n_jobs` kwarg on `compare_configurations`** exposes the same knob
+  to library callers (including a future GUI batch sweep).
+- **Top-level `_analyze_one(Vp, name, config, material, applied_stress,
+  seed)` helper** factors the per-configuration build/solve out of the
+  inner loop so it can be pickled to a worker process. The returned
+  `(Vp, name, result_dict)` tuple includes the mesh / porosity_field /
+  empirical_solver instances (all three pickle cleanly today; no
+  rebuild on the main process is needed).
+
 ## [1.2.0] - 2026-05-11
 
 ### Fixed

--- a/porosity_fe_analysis.py
+++ b/porosity_fe_analysis.py
@@ -21,6 +21,7 @@ Dependencies:
 """
 
 import argparse
+import concurrent.futures
 import datetime
 import json
 import logging
@@ -3823,20 +3824,118 @@ class FESolver:
 # SECTION 8: ANALYSIS PIPELINE
 # ============================================================
 
+def _analyze_one(Vp: float,
+                 name: str,
+                 config: Dict,
+                 material_name: str,
+                 applied_stress: float,
+                 seed: Optional[int] = None) -> Tuple[float, str, Dict]:
+    """Build PorosityField/CompositeMesh/EmpiricalSolver for one (Vp, config).
+
+    Top-level (picklable) helper so this can be dispatched to a
+    :class:`concurrent.futures.ProcessPoolExecutor` from
+    :func:`compare_configurations` for a ~Nx speedup on the 5 x 5 sweep
+    (#52). Each call is fully independent — no shared mutable state — so
+    the result of the parallel execution is order-invariant.
+
+    The returned dict has the exact shape that the existing serial path
+    produces, so the assembly / ranking / plot / JSON code downstream is
+    unchanged.
+
+    Parameters
+    ----------
+    Vp : float
+        Void volume fraction in [0, 1].
+    name : str
+        Configuration name (key in ``POROSITY_CONFIGS``).
+    config : dict
+        Porosity-field constructor kwargs.
+    material_name : str
+        Material preset name. Resolved inside the worker so the parent
+        process doesn't need to pickle the :class:`MaterialProperties`
+        dataclass across the boundary (it's keyed by name anyway).
+    applied_stress : float
+        Reserved for downstream solver hooks. Accepted for parity with the
+        ``compare_configurations`` signature even though the empirical
+        knockdown does not currently consume it.
+    seed : int, optional
+        Recorded into the porosity field for reproducibility provenance.
+
+    Returns
+    -------
+    (Vp, name, result_dict)
+        Tuple keyed on ``(Vp, name)`` so the caller can deterministically
+        re-assemble results even when the worker pool reorders completion.
+    """
+    material = MATERIALS[material_name]
+    porosity_field = PorosityField(material, Vp, seed=seed, **config)
+    mesh = CompositeMesh(porosity_field, material, nx=30, ny=10, nz=12)
+    empirical = EmpiricalSolver(mesh, material)
+    emp_results = empirical.get_all_failure_loads()
+
+    result = {
+        'config': config,
+        'mesh': mesh,
+        'porosity_field': porosity_field,
+        'empirical_solver': empirical,
+        'empirical': emp_results,
+    }
+    return (Vp, name, result)
+
+
+def _resolve_n_jobs(n_jobs: Optional[int]) -> int:
+    """Normalise ``n_jobs`` to a positive worker count.
+
+    ``None``/``0``/``-1`` map to ``os.cpu_count() or 1`` so callers can
+    request "all cores" without having to look up the count themselves.
+    ``1`` preserves the serial path for reproducibility / debugging.
+    """
+    if n_jobs is None or n_jobs <= 0:
+        return os.cpu_count() or 1
+    return int(n_jobs)
+
+
 def compare_configurations(void_volume_fraction: float,
                            material_name: str = 'T800_epoxy',
                            applied_stress: float = -1500.0,
                            configs: Optional[Dict] = None,
-                           seed: Optional[int] = None) -> Dict:
-    """Main analysis function — loops through porosity configurations."""
+                           seed: Optional[int] = None,
+                           n_jobs: int = 1) -> Dict:
+    """Main analysis function — loops through porosity configurations.
+
+    Parameters
+    ----------
+    void_volume_fraction : float
+        Specimen-average void volume fraction in [0, 1].
+    material_name : str
+        Material preset name; validated against :data:`MATERIALS`.
+    applied_stress : float
+        Reserved for downstream solver hooks (empirical knockdown does
+        not currently consume it).
+    configs : dict, optional
+        Mapping of configuration name -> :class:`PorosityField` kwargs.
+        Defaults to the bundled :data:`POROSITY_CONFIGS`.
+    seed : int, optional
+        Recorded into provenance and threaded into each
+        :class:`PorosityField` for reproducibility (#55). The pipeline is
+        deterministic, so this does not alter results today.
+    n_jobs : int, optional
+        Number of worker processes to use for the per-configuration sweep
+        (#52). ``1`` (default) runs serially — bit-for-bit identical to
+        the legacy behaviour, useful for tests / debugging. ``N > 1``
+        dispatches the (Vp, config) calls to a
+        :class:`concurrent.futures.ProcessPoolExecutor` of that size.
+        ``0`` / ``-1`` / ``None`` resolve to :func:`os.cpu_count`. Results
+        are deterministically re-assembled by ``(Vp, name)`` regardless
+        of completion order, so the returned dict is independent of ``N``.
+    """
     if material_name not in MATERIALS:
         raise ValueError(
             f"Unknown material {material_name!r}. "
             f"Available presets: {sorted(MATERIALS)}."
         )
-    material = MATERIALS[material_name]
     configs = configs or POROSITY_CONFIGS
-    results = {}
+    workers = _resolve_n_jobs(n_jobs)
 
     _bar = '=' * 70
     logger.info("\n%s", _bar)
@@ -3844,28 +3943,49 @@ def compare_configurations(void_volume_fraction: float,
     logger.info("Material: %s", material_name)
     logger.info("%s", _bar)
 
-    for name, config in configs.items():
-        logger.info("\n  Configuration: %s", name)
-        porosity_field = PorosityField(material, void_volume_fraction,
-                                       seed=seed, **config)
-        mesh = CompositeMesh(porosity_field, material, nx=30, ny=10, nz=12)
+    # Build the (Vp, name, config, ...) task list once. We always iterate
+    # the original ``configs`` dict so the assembled output preserves the
+    # caller's configuration ordering (Python dicts are insertion-ordered)
+    # regardless of which worker finishes first.
+    tasks = [
+        (void_volume_fraction, name, config, material_name, applied_stress, seed)
+        for name, config in configs.items()
+    ]
 
-        empirical = EmpiricalSolver(mesh, material)
+    raw_results: Dict[Tuple[float, str], Dict] = {}
+    if workers == 1 or len(tasks) <= 1:
+        # Serial path — preserves the legacy behaviour byte-for-byte and
+        # avoids the ProcessPoolExecutor fork cost for trivially small
+        # sweeps. The per-config "Configuration: ..." log lines fire here
+        # too, mirroring the original CLI UX.
+        for Vp, name, config, mat, stress, sd in tasks:
+            logger.info("\n  Configuration: %s", name)
+            Vp_out, name_out, result = _analyze_one(
+                Vp, name, config, mat, stress, sd)
+            raw_results[(Vp_out, name_out)] = result
+            comp_kd = result['empirical']['compression']['judd_wright']['knockdown']
+            ilss_kd = result['empirical']['ilss']['judd_wright']['knockdown']
+            logger.info("    Compression KD (J-W): %.3f", comp_kd)
+            logger.info("    ILSS KD (J-W):        %.3f", ilss_kd)
+    else:
+        logger.info("Parallel sweep: %d task(s) across %d worker process(es)",
+                    len(tasks), workers)
+        with concurrent.futures.ProcessPoolExecutor(max_workers=workers) as pool:
+            futures = [pool.submit(_analyze_one, *task) for task in tasks]
+            for fut in concurrent.futures.as_completed(futures):
+                Vp_out, name_out, result = fut.result()
+                raw_results[(Vp_out, name_out)] = result
+                comp_kd = result['empirical']['compression']['judd_wright']['knockdown']
+                ilss_kd = result['empirical']['ilss']['judd_wright']['knockdown']
+                logger.info("  Configuration %s done — "
+                            "compression KD (J-W) %.3f, ILSS KD (J-W) %.3f",
+                            name_out, comp_kd, ilss_kd)
 
-        emp_results = empirical.get_all_failure_loads()
-
-        results[name] = {
-            'config': config,
-            'mesh': mesh,
-            'porosity_field': porosity_field,
-            'empirical_solver': empirical,
-            'empirical': emp_results,
-        }
-
-        comp_kd = emp_results['compression']['judd_wright']['knockdown']
-        ilss_kd = emp_results['ilss']['judd_wright']['knockdown']
-        logger.info("    Compression KD (J-W): %.3f", comp_kd)
-        logger.info("    ILSS KD (J-W):        %.3f", ilss_kd)
+    # Re-assemble in the original config insertion order so callers see a
+    # deterministic dict regardless of which worker finished first.
+    results: Dict[str, Dict] = {}
+    for name in configs:
+        results[name] = raw_results[(void_volume_fraction, name)]
 
     logger.info("\n%s", _bar)
     logger.info("RANKINGS (by compression strength, Judd-Wright)")
@@ -4141,6 +4261,20 @@ def _build_arg_parser() -> 'argparse.ArgumentParser':
         action="store_true",
         help="List the available material presets and exit.",
     )
+    parser.add_argument(
+        "--jobs",
+        type=int,
+        default=1,
+        metavar="N",
+        help=(
+            "Number of worker processes for the per-configuration sweep "
+            "in compare_configurations (#52). 1 (default) runs serially "
+            "(deterministic, byte-identical to legacy behaviour); N>1 "
+            "parallelises the (Vp, config) calls across N processes; 0 or "
+            "-1 uses os.cpu_count(). Results are deterministically "
+            "re-assembled regardless of N."
+        ),
+    )
     return parser
 
 
@@ -4259,6 +4393,7 @@ def main(argv: Optional[List[str]] = None) -> int:
                 material_name=args.material,
                 applied_stress=args.applied_stress,
                 seed=args.seed,
+                n_jobs=args.jobs,
             )
         except ValueError as exc:
             print(f"ERROR: bad input for Vp={Vp}: {exc}", file=sys.stderr)

--- a/tests/test_porosity_fe.py
+++ b/tests/test_porosity_fe.py
@@ -2892,6 +2892,102 @@ _TINY_CONFIGS = {'uniform_spherical': {'distribution': 'uniform',
                                        'void_shape': 'spherical'}}
 
 
+def _extract_knockdowns(results: dict) -> dict:
+    """Flatten the per-config knockdown numbers for equality checks.
+
+    Picks the numerical scalars the parallel/serial paths must agree on,
+    skipping the embedded ``mesh`` / ``porosity_field`` / ``empirical_solver``
+    objects (those are different instances per call by construction).
+    """
+    flat = {}
+    for name, r in results.items():
+        emp = r['empirical']
+        for mode in ('compression', 'tension', 'shear', 'ilss'):
+            for model in ('judd_wright', 'power_law', 'linear'):
+                key = (name, mode, model)
+                flat[key] = emp[mode][model]['knockdown']
+    return flat
+
+
+class TestParallelSweep:
+    """Parallel ``compare_configurations`` path (#52)."""
+
+    def test_parallel_matches_serial(self):
+        """n_jobs>1 must produce numerically identical results to n_jobs=1.
+
+        The pipeline is deterministic linear algebra (no RNG), so the
+        parallel path is expected to be bit-identical, not merely close.
+        We assert ``assert_allclose`` with a tight tolerance to allow for
+        BLAS reorder noise on multi-threaded platforms.
+        """
+        configs = {
+            'uniform_spherical': POROSITY_CONFIGS['uniform_spherical'],
+            'clustered_midplane': POROSITY_CONFIGS['clustered_midplane'],
+        }
+        serial = compare_configurations(
+            0.03, configs=configs, n_jobs=1)
+        parallel = compare_configurations(
+            0.03, configs=configs, n_jobs=2)
+
+        # Same config-name set, in the same order (deterministic assembly).
+        assert list(serial.keys()) == list(parallel.keys())
+
+        s_flat = _extract_knockdowns(serial)
+        p_flat = _extract_knockdowns(parallel)
+        assert set(s_flat) == set(p_flat)
+        for k in s_flat:
+            np.testing.assert_allclose(
+                p_flat[k], s_flat[k], rtol=1e-10, atol=0.0,
+                err_msg=f"Knockdown drift between serial and parallel for {k}")
+
+    def test_resolve_n_jobs_normalises_zero_and_negative(self):
+        """0/-1/None all mean "use all cores"."""
+        from porosity_fe_analysis import _resolve_n_jobs
+        cores = os.cpu_count() or 1
+        assert _resolve_n_jobs(None) == cores
+        assert _resolve_n_jobs(0) == cores
+        assert _resolve_n_jobs(-1) == cores
+        assert _resolve_n_jobs(1) == 1
+        assert _resolve_n_jobs(4) == 4
+
+    def test_analyze_one_returns_picklable_dict(self):
+        """The (Vp, name) -> result tuple must round-trip through pickle.
+
+        Guards the ProcessPoolExecutor contract: if a future refactor
+        adds an un-picklable member (lambda, open file handle) the
+        parallel path silently degrades to a cryptic worker error. This
+        test catches it at the helper level.
+        """
+        import pickle
+        from porosity_fe_analysis import _analyze_one
+        Vp, name, result = _analyze_one(
+            0.02, 'uniform_spherical',
+            POROSITY_CONFIGS['uniform_spherical'],
+            'T800_epoxy', -1500.0, None)
+        assert Vp == 0.02
+        assert name == 'uniform_spherical'
+        # Round-trip the whole result dict (mesh + porosity_field +
+        # empirical_solver + emp_results all included).
+        round_tripped = pickle.loads(pickle.dumps(result))
+        assert (round_tripped['empirical']['compression']['judd_wright']
+                ['knockdown']
+                == result['empirical']['compression']['judd_wright']
+                ['knockdown'])
+
+    def test_single_config_does_not_spawn_pool(self):
+        """One task should run inline even when n_jobs>1 to avoid
+        ProcessPoolExecutor's fork overhead. We can't observe the pool
+        directly without monkeypatching, but we can assert the result
+        matches the serial path."""
+        configs = {'uniform_spherical': POROSITY_CONFIGS['uniform_spherical']}
+        serial = compare_configurations(0.03, configs=configs, n_jobs=1)
+        also_serial = compare_configurations(0.03, configs=configs, n_jobs=4)
+        s_flat = _extract_knockdowns(serial)
+        p_flat = _extract_knockdowns(also_serial)
+        for k in s_flat:
+            assert p_flat[k] == s_flat[k]
+
+
 class TestCLIMain:
     """Argparse-driven entry point (issue #58)."""
 
@@ -3013,6 +3109,54 @@ class TestCLIMain:
                 '--quiet', '--verbose',
             ])
         assert exc.value.code == 2
+
+    def test_jobs_cli_flag_passed_through(self, tmp_path, monkeypatch):
+        """``--jobs N`` from the CLI must thread into compare_configurations
+        as ``n_jobs=N`` (#52). We monkeypatch the function with a recording
+        shim instead of spinning up real workers — the actual parallel
+        sweep is exercised by ``TestParallelSweep`` above."""
+        seen = {}
+        original = porosity_fe_analysis.compare_configurations
+
+        def _spy(*args, **kwargs):
+            seen['n_jobs'] = kwargs.get('n_jobs')
+            return original(*args, **kwargs)
+
+        monkeypatch.setattr(porosity_fe_analysis, 'POROSITY_CONFIGS',
+                            _TINY_CONFIGS)
+        monkeypatch.setattr(porosity_fe_analysis,
+                            'compare_configurations', _spy)
+        rc = porosity_fe_analysis.main([
+            '--vp', '0.02',
+            '--output-dir', str(tmp_path),
+            '--quiet',
+            '--jobs', '2',
+        ])
+        assert rc == 0
+        assert seen.get('n_jobs') == 2
+
+    def test_jobs_default_is_serial(self, tmp_path, monkeypatch):
+        """Default ``--jobs`` (omitted) must resolve to ``n_jobs=1`` so
+        the legacy deterministic behaviour is preserved for unsuspecting
+        callers and CI."""
+        seen = {}
+        original = porosity_fe_analysis.compare_configurations
+
+        def _spy(*args, **kwargs):
+            seen['n_jobs'] = kwargs.get('n_jobs')
+            return original(*args, **kwargs)
+
+        monkeypatch.setattr(porosity_fe_analysis, 'POROSITY_CONFIGS',
+                            _TINY_CONFIGS)
+        monkeypatch.setattr(porosity_fe_analysis,
+                            'compare_configurations', _spy)
+        rc = porosity_fe_analysis.main([
+            '--vp', '0.02',
+            '--output-dir', str(tmp_path),
+            '--quiet',
+        ])
+        assert rc == 0
+        assert seen.get('n_jobs') == 1
 
 
 class TestMaterialPropertiesPerturb:


### PR DESCRIPTION
Fixes #52

## Summary
- Adds top-level `_analyze_one(Vp, name, config, material_name, applied_stress, seed) -> (Vp, name, result_dict)` so each `(Vp, config)` task is picklable.
- `compare_configurations` gains `n_jobs: int = 1`. `n_jobs == 1` runs serially (byte-identical to legacy). `n_jobs > 1` dispatches to `concurrent.futures.ProcessPoolExecutor` with `as_completed`. `n_jobs` of `0`/`-1`/`None` resolves to `os.cpu_count()` via `_resolve_n_jobs`. One-task sweeps short-circuit to serial to avoid fork overhead.
- Determinism: tasks built in `configs.items()` order; results re-assembled by `(Vp, name)` so the returned dict is independent of worker completion order.
- Adds `--jobs N` to the `porosity-analyze` CLI (default 1). `validate_porosity_cli.py` already had a `--jobs` flag (wired to a different per-dataset parallel path) — left as-is.

## Picklable contract
Confirmed empirically that `PorosityField` (~660 B), `CompositeMesh` (~39 KB), and `EmpiricalSolver` (~42 KB) pickle cleanly across the full `POROSITY_CONFIGS` set. No lambdas, no open file handles, no sparse matrices in the empirical path. Did **not** need to rebuild meshes on the main process; the worker returns the full dict and downstream plotting reads it unchanged. A pickle round-trip test guards this contract.

## Wall-time (4-core box, `--quiet`)
| Command | Wall time |
| --- | --- |
| `--vp 0.02 --jobs 1` (5 configs) | 1.75 s |
| `--vp 0.02 --jobs 4` (5 configs) | 1.21 s |
| `--vp 0.01 0.02 0.03 0.04 0.05 --jobs 1` (25 tasks) | 5.78 s |
| `--vp 0.01 0.02 0.03 0.04 0.05 --jobs 4` (25 tasks) | **2.87 s (~2x)** |

JSON outputs are bit-identical between serial and parallel runs (diffed `porosity_analysis_results_3pct.json` minus the provenance timestamp).

## Test plan
- [x] Full pytest suite — 406 passed, 1 skipped (+6 new tests, no regressions)
- [x] `test_parallel_matches_serial` — `n_jobs=1` vs `n_jobs=2`, `assert_allclose(rtol=1e-10)` on every (mode, model) knockdown
- [x] `test_resolve_n_jobs_normalises_zero_and_negative`
- [x] `test_analyze_one_returns_picklable_dict` (guards the worker contract)
- [x] `test_single_config_does_not_spawn_pool`
- [x] `test_jobs_cli_flag_passed_through` and `test_jobs_default_is_serial`

---
_Generated by [Claude Code](https://claude.ai/code/session_01X5dvvNWcbxZdjeHCZSXDzM)_