### PR TITLE
feat(cli): add --version flag to porosity-analyze

### DIFF
--- a/porosity_fe_analysis.py
+++ b/porosity_fe_analysis.py
@@ -4077,6 +4077,11 @@ def _build_arg_parser() -> 'argparse.ArgumentParser':
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     parser.add_argument(
+        "--version",
+        action="version",
+        version=f"%(prog)s {__version__}",
+    )
+    parser.add_argument(
         "--material",
         default="T800_epoxy",
         help="Material preset name (validated against the built-in presets).",

--- a/tests/test_porosity_fe.py
+++ b/tests/test_porosity_fe.py
@@ -2901,6 +2901,15 @@ class TestCLIMain:
         assert exc.value.code == 0
         assert 'porosity-analyze' in capsys.readouterr().out
 
+    def test_version_flag(self, capsys):
+        """--version prints '<prog> <__version__>' and exits 0 (issue #80)."""
+        with pytest.raises(SystemExit) as exc:
+            porosity_fe_analysis.main(['--version'])
+        assert exc.value.code == 0
+        out = capsys.readouterr().out
+        assert 'porosity-analyze' in out
+        assert porosity_fe_analysis.__version__ in out
+
     def test_list_materials(self, capsys):
         assert porosity_fe_analysis.main(['--list-materials']) == 0
         out = capsys.readouterr().out


### PR DESCRIPTION
Fixes #80

## Summary
- Adds `--version` to `porosity-analyze` (`porosity_fe_analysis.py`), backed by the existing `__version__` (resolved via `importlib.metadata.version("porosity-fe")` with a `"1.2.0"` source-checkout fallback).
- `validate_porosity_cli.py` already had `--version` wired via a local `_resolve_version()` helper performing the same `importlib.metadata` lookup; left as-is to avoid pulling `matplotlib`/`scipy` into the validate CLI just for `__version__`.
- The second item from #80 (route progress through `logger`) was completed in PR #86 (closes #78).

## Smoke test
```
$ python -m porosity_fe_analysis --version
porosity-analyze 1.2.0

$ python validate_porosity_cli.py --version
validate_porosity 1.2.0
```

## Test plan
- [x] Full pytest suite — 401 passed, 1 skipped (+1 new test)
- [x] `TestCLIMain::test_version_flag` — exits 0, prints `porosity-analyze` and `__version__`

---
_Generated by [Claude Code](https://claude.ai/code/session_01X5dvvNWcbxZdjeHCZSXDzM)_