### PR TITLE
feat(json): dataclass default, NCR format in schema, round-trip integration tests

### DIFF
--- a/porosity_fe_analysis.py
+++ b/porosity_fe_analysis.py
@@ -22,6 +22,7 @@ Dependencies:
 
 import argparse
 import concurrent.futures
+import dataclasses
 import datetime
 import json
 import logging
@@ -154,7 +155,8 @@ def _json_default(o):
     """json.dump ``default=`` hook: make numpy scalars/arrays serializable.
 
     The science payload is already float()-wrapped, but user-supplied
-    fields (e.g. ndarray ply_angles) would otherwise raise TypeError (#20).
+    fields (e.g. ndarray ply_angles, dataclass configs, datetime stamps)
+    would otherwise raise TypeError (#20).
     """
     if isinstance(o, np.generic):
         return o.item()
@@ -162,6 +164,11 @@ def _json_default(o):
         return o.tolist()
     if isinstance(o, (datetime.datetime, datetime.date)):
         return o.isoformat()
+    # Plain dataclass instances (e.g. MaterialProperties) — accept on a
+    # best-effort basis so callers can stash a dataclass field in the
+    # config dict without an explicit asdict() at the call site.
+    if dataclasses.is_dataclass(o) and not isinstance(o, type):
+        return dataclasses.asdict(o)
     raise TypeError(
         f"Object of type {type(o).__name__} is not JSON serializable"
     )

--- a/tests/test_results_schema_roundtrip.py
+++ b/tests/test_results_schema_roundtrip.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""End-to-end JSON output contract tests (#20).
+
+Exercises the full save -> jsonschema.validate -> load_results_from_json
+loop on a minimal one-Vp / one-config sweep so any drift in the envelope,
+schema, or loader is caught in a single test file.
+"""
+
+import dataclasses
+import json
+import os
+
+import numpy as np
+import pytest
+
+from porosity_fe_analysis import (
+    FORMAT_EMPIRICAL_SWEEP,
+    FORMAT_NCR,
+    JSON_SCHEMA_VERSION,
+    POROSITY_CONFIGS,
+    _json_default,
+    compare_configurations,
+    load_results_from_json,
+    save_results_to_json,
+)
+
+
+_SCHEMA_PATH = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    "validation",
+    "schemas",
+    "porosity_results_schema.json",
+)
+
+
+def _load_schema():
+    with open(_SCHEMA_PATH, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _tiny_results():
+    """Smallest sweep that still produces a real payload."""
+    return compare_configurations(
+        0.03,
+        configs={"uniform_spherical": POROSITY_CONFIGS["uniform_spherical"]},
+    )
+
+
+def test_save_validate_load_round_trip(tmp_path):
+    import jsonschema
+
+    path = str(tmp_path / "round_trip.json")
+    save_results_to_json(_tiny_results(), path)
+
+    with open(path, encoding="utf-8") as f:
+        on_disk = json.load(f)
+
+    # Schema validation: catches envelope drift.
+    jsonschema.validate(instance=on_disk, schema=_load_schema())
+
+    # Loader returns the same dict (apart from object identity).
+    loaded = load_results_from_json(path)
+    assert loaded == on_disk
+
+    # Envelope sanity.
+    assert loaded["schema_version"] == JSON_SCHEMA_VERSION
+    assert loaded["format"] == FORMAT_EMPIRICAL_SWEEP
+    assert "provenance" in loaded
+    assert "uniform_spherical" in loaded
+
+
+def test_ncr_format_validates_against_schema(tmp_path):
+    """The NCR exporter is one of the three known top-level formats and
+    must validate against the same shared schema (#20)."""
+    import jsonschema
+
+    from app import build_ncr_record, write_ncr_json
+
+    result = {
+        "config": {
+            "material_name": "T800_epoxy",
+            "n_plies": 24,
+            "t_ply": 0.183,
+            "Vp": 3.0,
+            "distribution": "uniform",
+            "void_shape": "spherical",
+            "nx": 30, "ny": 10, "nz": 12,
+        },
+        "empirical": {
+            "compression": {
+                "judd_wright": {"failure_stress": 1234.5, "knockdown": 0.823},
+            },
+            "ilss": {
+                "judd_wright": {"failure_stress": 67.0, "knockdown": 0.744},
+            },
+        },
+    }
+    meta = {
+        "prepared_by": "test",
+        "ncr_reference": "NCR-2026-0001",
+        "structural_class": "primary",
+        "date": "2026-05-19",
+        "layup": "[0/90]_s",
+    }
+    path = str(tmp_path / "ncr.json")
+    write_ncr_json(path, build_ncr_record(result, meta))
+
+    with open(path, encoding="utf-8") as f:
+        doc = json.load(f)
+
+    jsonschema.validate(instance=doc, schema=_load_schema())
+    assert doc["format"] == FORMAT_NCR
+
+    loaded = load_results_from_json(path)
+    assert loaded["format"] == FORMAT_NCR
+
+
+def test_numpy_default_handler_round_trips_ndarray(tmp_path):
+    """An ndarray smuggled into a config dict must serialise via
+    _json_default rather than raise TypeError (#20 item 4)."""
+    results = _tiny_results()
+    entry = dict(results["uniform_spherical"])
+    entry["config"] = {
+        **entry["config"],
+        "ply_angles_deg": np.array([0.0, 45.0, -45.0, 90.0]),
+        "n_plies_np": np.int64(12),
+    }
+    results = {"uniform_spherical": entry}
+
+    path = str(tmp_path / "with_ndarray.json")
+    save_results_to_json(results, path)
+
+    loaded = load_results_from_json(path)
+    assert loaded["uniform_spherical"]["config"]["ply_angles_deg"] == [
+        0.0,
+        45.0,
+        -45.0,
+        90.0,
+    ]
+    assert loaded["uniform_spherical"]["config"]["n_plies_np"] == 12
+
+
+def test_json_default_handles_dataclass():
+    """Plain dataclass instances must be serialisable by _json_default
+    (#20 item 4: numpy-type fragility)."""
+
+    @dataclasses.dataclass
+    class _Foo:
+        a: int
+        b: str
+
+    out = _json_default(_Foo(a=1, b="x"))
+    assert out == {"a": 1, "b": "x"}
+
+
+def test_json_default_rejects_unknown_type():
+    class _Opaque:
+        pass
+
+    with pytest.raises(TypeError, match="not JSON serializable"):
+        _json_default(_Opaque())

--- a/validation/schemas/porosity_results_schema.json
+++ b/validation/schemas/porosity_results_schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Porosity Analysis Results",
-  "description": "Output contract for save_results_to_json / FESolver.export_results / the Streamlit exporters. The envelope (schema_version, format, provenance) is validated strictly so consumers can detect version/contract drift; the science payload is intentionally permissive so adding result fields is not a breaking schema change.",
+  "description": "Output contract for save_results_to_json / FESolver.export_results / the Streamlit empirical exporter / the NCR exporter. The envelope (schema_version, format, provenance) is validated strictly so consumers can detect version/contract drift; the science payload is intentionally permissive so adding result fields is not a breaking schema change. The known top-level format identifiers are listed in the `format` enum (#20).",
   "type": "object",
   "required": ["schema_version", "format", "provenance"],
   "properties": {
@@ -11,7 +11,12 @@
     },
     "format": {
       "type": "string",
-      "enum": ["porosity-fe.empirical-sweep", "porosity-fe.fe-fields"]
+      "description": "Output payload identifier. Mirrors the FORMAT_* module constants in porosity_fe_analysis.py.",
+      "enum": [
+        "porosity-fe.empirical-sweep",
+        "porosity-fe.fe-fields",
+        "porosity-fe.ncr"
+      ]
     },
     "provenance": {
       "type": "object",
@@ -51,6 +56,10 @@
         "git_sha": {"type": ["string", "null"]},
         "hostname": {"type": ["string", "null"]}
       }
+    },
+    "raw_sidecar": {
+      "type": "string",
+      "description": "Basename of the optional .npz sidecar containing the raw displacement/stress/strain arrays (FESolver.export_results include_raw=True)."
     }
   },
   "additionalProperties": true


### PR DESCRIPTION
Fixes #20

## Summary
Closes the remaining items of #20 not already covered by PR #88 (provenance block) and PR #92 (loader / schema):

- Extends `_json_default` (`porosity_fe_analysis.py:154`) with a `dataclasses.is_dataclass(o)` branch returning `dataclasses.asdict(o)`. Also adds the `dataclasses` import.
- Updates `validation/schemas/porosity_results_schema.json` to (a) include `porosity-fe.ncr` in the `format` enum so NCR exports validate cleanly against the schema, and (b) document the optional `raw_sidecar` field (FE export with `include_raw=True`).
- Adds 5 integration tests in `tests/test_results_schema_roundtrip.py`:
  - `test_save_validate_load_round_trip` — tiny `compare_configurations` → save → `jsonschema.validate` → `load_results_from_json` → equality check.
  - `test_ncr_format_validates_against_schema` — NCR write → validate → load → assert `FORMAT_NCR`.
  - `test_numpy_default_handler_round_trips_ndarray` — ndarray + `np.int64` smuggled into `config`, round-trips cleanly.
  - `test_json_default_handles_dataclass` — direct coverage of the new dataclass branch.
  - `test_json_default_rejects_unknown_type` — `TypeError` fallthrough.

Most of the issue's scope (schema_version, provenance, top-level wrapper, `_json_default` for `np.generic`/`np.ndarray`/datetime, `load_results_from_json` loader, version-mismatch handling) was already shipped in prior merged PRs.

## Test plan
- [x] Full pytest suite — 421 passed, 1 skipped (+5 new tests)

---
_Generated by [Claude Code](https://claude.ai/code/session_01X5dvvNWcbxZdjeHCZSXDzM)_