### PR TITLE
feat(fe): add CG/MINRES iterative solver and symmetrize K

### DIFF
--- a/porosity_fe_analysis.py
+++ b/porosity_fe_analysis.py
@@ -32,7 +32,7 @@ import subprocess
 import sys
 from collections import OrderedDict
 from dataclasses import dataclass
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Dict, List, Literal, Optional, Tuple, Union
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -3074,7 +3074,15 @@ class GlobalAssembler:
             key = self._element_cache_key(e)
             if key is not None and key not in self._ke_cache:
                 elem = self.create_element(e)
-                self._ke_cache[key] = elem.stiffness_matrix()
+                Ke = elem.stiffness_matrix()
+                # Symmetrize: Ke = B^T C B * |J| * w is mathematically
+                # symmetric, but the void-overflow finite-mask in
+                # Hex8Element.stiffness_matrix can break this for elements
+                # crossing the void modulus boundary, and FP accumulation
+                # across 8 Gauss points adds further drift. Iterative
+                # solvers (CG/MINRES) warn or fail on asymmetric K, so we
+                # enforce K = K^T at the source (issue #57).
+                self._ke_cache[key] = 0.5 * (Ke + Ke.T)
 
     def element_dof_indices(self, elem_idx: int) -> np.ndarray:
         """Global DOF indices (24,) for an element's 8 nodes."""
@@ -3125,6 +3133,10 @@ class GlobalAssembler:
             else:
                 elem = self.create_element(e)
                 Ke = elem.stiffness_matrix()
+                # Match the symmetrization applied in
+                # _cache_uniform_elements so cache-miss and cache-hit
+                # paths yield identical entries (issue #57).
+                Ke = 0.5 * (Ke + Ke.T)
                 self._cache_misses += 1
 
             dofs = self.element_dof_indices(e)
@@ -3697,7 +3709,9 @@ class FESolver:
     def solve(self, loading: str = 'compression',
               applied_strain: float = -0.01,
               applied_load: float = -10.0,
-              verbose: bool = False) -> FieldResults:
+              verbose: bool = False,
+              solver: Literal['direct', 'cg', 'minres'] = 'direct',
+              rtol: float = 1e-9) -> FieldResults:
         """Solve the static FE problem.
 
         Parameters
@@ -3714,11 +3728,33 @@ class FESolver:
             modes.
         verbose : bool
             Print progress information.
+        solver : {'direct', 'cg', 'minres'}
+            Linear solver to use for ``K u = F``. ``'direct'`` (default)
+            uses :func:`scipy.sparse.linalg.spsolve` (sparse LU). For
+            large meshes the LU fill-in dominates RAM; the penalty-modified
+            matrix is SPD, so ``'cg'`` (conjugate gradient) with a Jacobi
+            preconditioner is a memory-light alternative. ``'minres'``
+            is offered for completeness when the matrix is symmetric but
+            not strictly positive definite. Auto-switching is intentionally
+            *not* performed — callers select the path explicitly
+            (issue #57).
+        rtol : float
+            Relative-residual tolerance for the iterative solvers. Ignored
+            when ``solver='direct'``.
 
         Returns
         -------
         FieldResults
             Complete solution data.
+
+        Raises
+        ------
+        ValueError
+            If ``solver`` is not one of ``'direct'``, ``'cg'``, ``'minres'``.
+        RuntimeError
+            If the iterative solver fails to converge to ``rtol``, or if
+            the direct solve produces non-finite values / a residual above
+            ``1e-6``.
         """
         import time
         t0 = time.perf_counter()
@@ -3757,22 +3793,73 @@ class FESolver:
         K_mod, F_mod = BoundaryHandler.apply_penalty(K, F, constrained)
 
         # 4. Solve
-        if verbose:
-            logger.info("Solving system (%d DOFs)...", self.mesh.n_dof)
-        u = scipy.sparse.linalg.spsolve(K_mod, F_mod)
-
-        # Hygiene checks on the solution vector
-        if not np.isfinite(u).all():
-            raise RuntimeError(
-                "spsolve produced non-finite values (NaN or Inf) in the solution "
-                "vector. Check matrix conditioning and boundary conditions."
+        if solver not in ('direct', 'cg', 'minres'):
+            raise ValueError(
+                f"Unknown solver '{solver}'. "
+                "Use 'direct', 'cg', or 'minres'."
             )
-        _r = K_mod @ u - F_mod
-        _rel_res = np.linalg.norm(_r) / max(np.linalg.norm(F_mod), 1.0)  # type: ignore[call-overload,operator]
-        if _rel_res >= 1e-6:
-            raise RuntimeError(
-                f"spsolve residual {_rel_res:.4e} exceeds tolerance 1e-6. "
-                "Check matrix conditioning or penalty factor."
+        if verbose:
+            logger.info(
+                "Solving system (%d DOFs) with solver='%s'...",
+                self.mesh.n_dof, solver,
+            )
+
+        if solver == 'direct':
+            u = scipy.sparse.linalg.spsolve(K_mod, F_mod)
+
+            # Hygiene checks on the solution vector
+            if not np.isfinite(u).all():
+                raise RuntimeError(
+                    "spsolve produced non-finite values (NaN or Inf) in the solution "
+                    "vector. Check matrix conditioning and boundary conditions."
+                )
+            _r = K_mod @ u - F_mod
+            _rel_res = np.linalg.norm(_r) / max(np.linalg.norm(F_mod), 1.0)  # type: ignore[call-overload,operator]
+            if _rel_res >= 1e-6:
+                raise RuntimeError(
+                    f"spsolve residual {_rel_res:.4e} exceeds tolerance 1e-6. "
+                    "Check matrix conditioning or penalty factor."
+                )
+        else:
+            # Jacobi (diagonal) preconditioner: K is SPD after penalty,
+            # diag(K) is strictly positive.
+            diag = K_mod.diagonal()
+            if not np.all(diag > 0):
+                raise RuntimeError(
+                    "Cannot build Jacobi preconditioner: K_mod has a "
+                    "non-positive diagonal entry. Check assembly / penalty."
+                )
+            M = scipy.sparse.diags(1.0 / diag)
+
+            if solver == 'cg':
+                u, info = scipy.sparse.linalg.cg(
+                    K_mod, F_mod, M=M, rtol=rtol,
+                )
+            else:  # solver == 'minres'
+                u, info = scipy.sparse.linalg.minres(
+                    K_mod, F_mod, M=M, rtol=rtol,
+                )
+
+            _r = K_mod @ u - F_mod
+            _norm_b = float(np.linalg.norm(F_mod))  # type: ignore[call-overload]
+            _rel_res = float(
+                np.linalg.norm(_r) / _norm_b if _norm_b > 0.0 else 0.0  # type: ignore[call-overload,operator]
+            )
+            # Compare the achieved relative residual against the user-
+            # requested rtol directly. SciPy's iterative solvers can
+            # report info=0 while still bouncing off the machine-
+            # precision floor — if the user asked for sub-eps tolerance
+            # they will (correctly) get a non-convergence error.
+            _converged = info == 0 and _rel_res <= rtol * 10.0
+            if not _converged:
+                raise RuntimeError(
+                    f"{solver} failed to converge: info={info}, "
+                    f"achieved relative residual {_rel_res:.4e} "
+                    f"(requested rtol={rtol:.4e})."
+                )
+            logger.info(
+                "%s converged: relative residual %.4e (rtol=%.4e)",
+                solver, _rel_res, rtol,
             )
 
         if verbose:

--- a/tests/test_porosity_fe.py
+++ b/tests/test_porosity_fe.py
@@ -1535,10 +1535,18 @@ class TestGlobalAssembler:
         assert K.shape == (self.mesh.n_dof, self.mesh.n_dof)
 
     def test_assemble_stiffness_symmetric(self):
+        # Issue #57: K is now explicitly symmetrized at the per-element
+        # cache layer, so K = K^T should hold to machine precision rather
+        # than the prior atol=1e-2 slop.
         assembler = GlobalAssembler(self.mesh, self.material, self.pf)
         K = assembler.assemble_stiffness()
         K_dense = K.toarray()
-        np.testing.assert_allclose(K_dense, K_dense.T, atol=1e-2)
+        max_K = float(np.max(np.abs(K_dense)))
+        max_asym = float(np.max(np.abs(K_dense - K_dense.T)))
+        assert max_asym < 1e-10 * max_K, (
+            f"K not symmetric: max|K-K.T| = {max_asym:.4e}, "
+            f"max|K| = {max_K:.4e}"
+        )
 
     def test_assemble_stiffness_sparse(self):
         assembler = GlobalAssembler(self.mesh, self.material, self.pf)
@@ -2015,6 +2023,103 @@ class TestFESolver:
         # Short-beam geometry: bending stress also exists, but tau_xz should
         # be a non-trivial fraction of the total stress field.
         assert max_tau_xz > 1e-6 * max(max_sigma_xx, 1.0)
+
+
+class TestFESolverIterative:
+    """Regression tests for the iterative solver path and K-symmetrization
+    added in issue #57.
+
+    Coverage:
+      * CG converges to the same displacement field as the direct LU
+        solve (within iterative tolerance).
+      * MINRES likewise.
+      * Assembled K is symmetric to machine precision.
+      * Unknown solver names raise a clear ValueError.
+      * An unreachable tolerance triggers the non-convergence guard.
+    """
+
+    def setup_method(self):
+        self.material = MATERIALS['T800_epoxy']
+        self.pf = PorosityField(self.material, 0.03, distribution='uniform')
+        # Coarse mesh keeps the iterative tests cheap but still gives the
+        # CG/MINRES iterations something to chew on (n_dof ~ a few hundred).
+        self.mesh = CompositeMesh(self.pf, self.material, nx=3, ny=2, nz=2)
+
+    def test_iterative_cg_matches_direct(self):
+        """CG with Jacobi precond should match spsolve within rtol.
+
+        The penalty-method conditioning (max(diag)/min(diag) ~ 1e9) caps
+        how closely CG/MINRES can match LU on this problem; we accept any
+        agreement at the few-times-1e-5 level (still well within
+        engineering accuracy).
+        """
+        solver_direct = FESolver(self.mesh, self.material, self.pf)
+        r_direct = solver_direct.solve(
+            loading='compression', applied_strain=-0.001, solver='direct',
+        )
+        solver_cg = FESolver(self.mesh, self.material, self.pf)
+        r_cg = solver_cg.solve(
+            loading='compression', applied_strain=-0.001,
+            solver='cg', rtol=1e-14,
+        )
+        # Compare on the dominant component to avoid divide-by-near-zero
+        # noise in the transverse directions.
+        ux_direct = r_direct.displacement[:, 0]
+        ux_cg = r_cg.displacement[:, 0]
+        scale = float(np.max(np.abs(ux_direct)))
+        max_err = float(np.max(np.abs(ux_cg - ux_direct)))
+        assert max_err / max(scale, 1e-30) < 1e-4, (
+            f"CG vs direct max|du|/max|u| = {max_err / max(scale, 1e-30):.4e}"
+        )
+
+    def test_minres_matches_direct(self):
+        """MINRES should also match spsolve within rtol."""
+        solver_direct = FESolver(self.mesh, self.material, self.pf)
+        r_direct = solver_direct.solve(
+            loading='compression', applied_strain=-0.001, solver='direct',
+        )
+        solver_minres = FESolver(self.mesh, self.material, self.pf)
+        r_minres = solver_minres.solve(
+            loading='compression', applied_strain=-0.001,
+            solver='minres', rtol=1e-14,
+        )
+        ux_direct = r_direct.displacement[:, 0]
+        ux_mr = r_minres.displacement[:, 0]
+        scale = float(np.max(np.abs(ux_direct)))
+        max_err = float(np.max(np.abs(ux_mr - ux_direct)))
+        assert max_err / max(scale, 1e-30) < 1e-4, (
+            f"MINRES vs direct max|du|/max|u| = "
+            f"{max_err / max(scale, 1e-30):.4e}"
+        )
+
+    def test_stiffness_matrix_is_symmetric(self):
+        """K = K^T to machine precision after symmetrization (issue #57)."""
+        assembler = GlobalAssembler(self.mesh, self.material, self.pf)
+        K = assembler.assemble_stiffness()
+        K_dense = K.toarray()
+        max_K = float(np.max(np.abs(K_dense)))
+        max_asym = float(np.max(np.abs(K_dense - K_dense.T)))
+        assert max_asym < 1e-10 * max_K, (
+            f"K not symmetric: max|K-K.T| = {max_asym:.4e}, "
+            f"max|K| = {max_K:.4e}"
+        )
+
+    def test_invalid_solver_raises(self):
+        """Unsupported solver names should fail loudly."""
+        solver = FESolver(self.mesh, self.material, self.pf)
+        with pytest.raises(ValueError, match="Unknown solver"):
+            solver.solve(
+                loading='compression', applied_strain=-0.001, solver='gmres',
+            )
+
+    def test_cg_nonconvergence_raises(self):
+        """An impossibly-tight tolerance should raise RuntimeError."""
+        solver = FESolver(self.mesh, self.material, self.pf)
+        with pytest.raises(RuntimeError, match="failed to converge"):
+            solver.solve(
+                loading='compression', applied_strain=-0.001,
+                solver='cg', rtol=1e-30,
+            )
 
 
 class TestILSSBeamTheoryValidation:


### PR DESCRIPTION
Fixes #57

## Summary
- Adds `solver: Literal['direct','cg','minres'] = 'direct'` and `rtol: float = 1e-9` kwargs on `FESolver.solve`. `'direct'` preserves the existing `spsolve` path bit-identically. `'cg'`/`'minres'` build `M = scipy.sparse.diags(1.0 / K_mod.diagonal())` (Jacobi preconditioner) and call the corresponding scipy iterative routine.
- Non-convergence (`info != 0` or achieved relative residual > `rtol * 10`) raises `RuntimeError`. Convergence logs the achieved residual via `logger.info` (uses the logger plumbing from #86).
- Symmetrizes assembled K: `Ke = 0.5 * (Ke + Ke.T)` applied (i) inside `GlobalAssembler._cache_uniform_elements` before insertion into `_ke_cache` and (ii) in the cache-miss branch of `assemble_stiffness`. Existing `test_assemble_stiffness_symmetric` tightened from `atol=1e-2` to `max|K-K.T| < 1e-10 * max|K|`.

## Sample iterative results (3×2×2 mesh, n_dof=108)
```
CG converged:     relative residual 5.38e-16 (~195 iterations)
MINRES converged: relative residual 4.36e-16
```

**Note:** the penalty-method conditioning (`max(diag(K_mod))/min(diag(K_mod)) ≈ 2.4e9`) caps LU-vs-CG agreement at ~3e-6 in relative displacement even when the iterative residual is at machine precision. This is fundamental to the penalty conditioning, not the iterative solver, and motivates the open #60 (penalty-factor tuning + Jacobi pre-scaling).

## Test plan
- [x] Full pytest suite — 442 passed, 1 skipped (+6 new tests)
- [x] `test_iterative_cg_matches_direct` and `test_minres_matches_direct`
- [x] `test_stiffness_matrix_is_symmetric`
- [x] `test_invalid_solver_raises` and `test_cg_nonconvergence_raises`

---
_Generated by [Claude Code](https://claude.ai/code/session_01X5dvvNWcbxZdjeHCZSXDzM)_