### PR TITLE
feat(uq): analytic knockdown sensitivities and per-point validation bands

### DIFF
--- a/porosity_fe_analysis.py
+++ b/porosity_fe_analysis.py
@@ -1408,6 +1408,172 @@ class EmpiricalSolver:
                 results[mode][model] = self.get_failure_load(mode, model)
         return results
 
+    def local_sensitivities(self, mode: str = 'compression',
+                            model: str = 'judd_wright',
+                            Vp: Optional[float] = None) -> Dict[str, float]:
+        """Closed-form local sensitivities of the empirical knockdown.
+
+        Returns the analytic partials ``dKD/dVp`` and ``dKD/dcoef`` (the
+        layup-scaled coefficient for the chosen model) at the supplied
+        porosity ``Vp``.  The three knockdown laws are closed form, so the
+        partials are exact, dimensionless, and effectively free to compute
+        (no FD, no sampling).
+
+        Partial-derivative table (with ``c`` denoting the layup-scaled
+        coefficient — ``alpha`` for Judd-Wright, ``n`` for power-law,
+        ``beta`` for linear):
+
+        =============  ===========================  ===========================
+        Model          ``dKD/dVp``                  ``dKD/dcoef``
+        =============  ===========================  ===========================
+        judd_wright    ``-alpha * KD``              ``-Vp * KD``
+        power_law      ``-n * (1 - Vp)**(n-1)``     ``(1-Vp)**n * ln(1-Vp)``
+        linear         ``-beta`` (or 0 if clipped)  ``-Vp``  (or 0 if clipped)
+        =============  ===========================  ===========================
+
+        Parameters
+        ----------
+        mode:
+            Loading mode (same keys as :meth:`get_failure_load`).
+        model:
+            Empirical knockdown law: ``'judd_wright'``, ``'power_law'``,
+            or ``'linear'``.
+        Vp:
+            Specimen-average porosity at which to evaluate.  Defaults to
+            ``self.mesh.porosity_field.Vp`` — the same value
+            :meth:`get_failure_load` uses.
+
+        Returns
+        -------
+        dict
+            ``{'KD': float, 'dKD_dVp': float, 'dKD_dcoef': float}``.
+            ``dKD_dcoef`` is the partial with respect to the layup-scaled
+            coefficient (alpha/n/beta) that the solver actually applied;
+            it already reflects the layup scaling from
+            :meth:`_layup_scale`.
+        """
+        if mode not in self.PRISTINE_STRENGTH_KEY:
+            raise ValueError(
+                f"Unknown loading mode {mode!r}. "
+                f"Use one of {sorted(self.PRISTINE_STRENGTH_KEY)}."
+            )
+        if Vp is None:
+            Vp = self.mesh.porosity_field.Vp
+        Vp = self._check_internal_Vp(Vp)
+        if model == 'judd_wright':
+            alpha = self.JUDD_WRIGHT_ALPHA[mode]
+            kd = float(np.exp(-alpha * Vp))
+            return {
+                'KD': kd,
+                'dKD_dVp': float(-alpha * kd),
+                'dKD_dcoef': float(-Vp * kd),
+            }
+        if model == 'power_law':
+            n = self.POWER_LAW_N[mode]
+            one_minus = 1.0 - Vp
+            kd = float(one_minus**n)
+            # Guard the log when Vp = 1 (degenerate edge): KD is 0 there
+            # and the d/dn partial collapses to 0 because KD * ln(1-Vp)
+            # is 0 * (-inf) in the limit.  We pin it to 0.0 explicitly so
+            # callers see a finite value.
+            if one_minus <= 0.0:
+                d_dcoef = 0.0
+                d_dVp = 0.0
+            else:
+                d_dcoef = float(kd * np.log(one_minus))
+                d_dVp = float(-n * one_minus**(n - 1.0))
+            return {
+                'KD': kd,
+                'dKD_dVp': d_dVp,
+                'dKD_dcoef': d_dcoef,
+            }
+        if model == 'linear':
+            beta = self.LINEAR_BETA[mode]
+            raw = 1.0 - beta * Vp
+            kd = float(max(raw, 0.0))
+            # The linear law is clipped at 0: once raw < 0, the
+            # piecewise-constant 0 floor has zero gradient.
+            if raw <= 0.0:
+                d_dVp = 0.0
+                d_dcoef = 0.0
+            else:
+                d_dVp = float(-beta)
+                d_dcoef = float(-Vp)
+            return {
+                'KD': kd,
+                'dKD_dVp': d_dVp,
+                'dKD_dcoef': d_dcoef,
+            }
+        raise ValueError(
+            f"Unknown knockdown model {model!r}. "
+            f"Use one of ['judd_wright', 'linear', 'power_law']."
+        )
+
+    def sensitivity_fd(self, mode: str = 'compression',
+                       model: str = 'judd_wright',
+                       param: str = 'Vp',
+                       h: float = 1e-4) -> float:
+        """Central-difference fallback for the local knockdown sensitivity.
+
+        Useful for paths where the gradient is not closed form (FE or
+        Mori-Tanaka couplings).  For the bundled empirical models this
+        matches :meth:`local_sensitivities` to ~1e-7 and is shipped as a
+        cross-check / drop-in for non-analytic models.
+
+        Parameters
+        ----------
+        mode:
+            Loading mode (same keys as :meth:`get_failure_load`).
+        model:
+            Empirical knockdown law.
+        param:
+            Either ``'Vp'`` (porosity) or ``'coef'`` (the layup-scaled
+            coefficient that the model actually applied — alpha/n/beta).
+        h:
+            Step size for the central difference.
+
+        Returns
+        -------
+        float
+            ``(KD(x+h) - KD(x-h)) / (2*h)`` evaluated at the same
+            ``Vp_mean`` :meth:`get_failure_load` uses.
+        """
+        if mode not in self.PRISTINE_STRENGTH_KEY:
+            raise ValueError(
+                f"Unknown loading mode {mode!r}. "
+                f"Use one of {sorted(self.PRISTINE_STRENGTH_KEY)}."
+            )
+        if model not in ('judd_wright', 'power_law', 'linear'):
+            raise ValueError(
+                f"Unknown knockdown model {model!r}. "
+                f"Use one of ['judd_wright', 'linear', 'power_law']."
+            )
+        if param not in ('Vp', 'coef'):
+            raise ValueError(
+                f"param must be 'Vp' or 'coef', got {param!r}."
+            )
+        Vp0 = float(self.mesh.porosity_field.Vp)
+
+        # Select the analytic functional form so we can perturb the
+        # parameter without mutating solver state.
+        if model == 'judd_wright':
+            coef0 = float(self.JUDD_WRIGHT_ALPHA[mode])
+            def f(Vp_val, coef_val):
+                return float(np.exp(-coef_val * Vp_val))
+        elif model == 'power_law':
+            coef0 = float(self.POWER_LAW_N[mode])
+            def f(Vp_val, coef_val):
+                return float((1.0 - Vp_val)**coef_val)
+        else:  # linear
+            coef0 = float(self.LINEAR_BETA[mode])
+            def f(Vp_val, coef_val):
+                return float(max(1.0 - coef_val * Vp_val, 0.0))
+
+        if param == 'Vp':
+            return float((f(Vp0 + h, coef0) - f(Vp0 - h, coef0)) / (2.0 * h))
+        # param == 'coef'
+        return float((f(Vp0, coef0 + h) - f(Vp0, coef0 - h)) / (2.0 * h))
+
 
 # ============================================================
 # SECTION 6b: UNCERTAINTY PROPAGATION (MONTE CARLO / LHS)
@@ -4293,6 +4459,14 @@ def compare_configurations(void_volume_fraction: float,
             ilss_kd = result['empirical']['ilss']['judd_wright']['knockdown']
             logger.info("    Compression KD (J-W): %.3f", comp_kd)
             logger.info("    ILSS KD (J-W):        %.3f", ilss_kd)
+            # Issue #65: surface the closed-form local sensitivities at
+            # the same Vp_mean used for the headline KD. This is a free
+            # diagnostic — the partials are analytic.
+            s = result['empirical_solver'].local_sensitivities(
+                mode='compression', model='judd_wright')
+            logger.info(
+                "    Tornado [%s]: dKD/dVp=%.3g, dKD/dcoef=%.3g",
+                name_out, s['dKD_dVp'], s['dKD_dcoef'])
     else:
         logger.info("Parallel sweep: %d task(s) across %d worker process(es)",
                     len(tasks), workers)
@@ -4306,6 +4480,11 @@ def compare_configurations(void_volume_fraction: float,
                 logger.info("  Configuration %s done — "
                             "compression KD (J-W) %.3f, ILSS KD (J-W) %.3f",
                             name_out, comp_kd, ilss_kd)
+                s = result['empirical_solver'].local_sensitivities(
+                    mode='compression', model='judd_wright')
+                logger.info(
+                    "    Tornado [%s]: dKD/dVp=%.3g, dKD/dcoef=%.3g",
+                    name_out, s['dKD_dVp'], s['dKD_dcoef'])
 
     # Re-assemble in the original config insertion order so callers see a
     # deterministic dict regardless of which worker finished first.

--- a/tests/test_porosity_fe.py
+++ b/tests/test_porosity_fe.py
@@ -3691,3 +3691,146 @@ class TestPropagateUncertainty:
         with pytest.raises(ValueError, match="non-perturbable"):
             propagate_uncertainty(0.02, 'T800_epoxy',
                                   covs={'not_a_field': 0.1}, n_samples=4)
+
+
+# Issue #65: closed-form local sensitivities + per-point validation bands.
+class TestLocalSensitivities:
+    """Closed-form sensitivities must match a central-difference baseline
+    to machine precision, and the layup scaling must propagate into the
+    coefficient partial."""
+
+    def setup_method(self):
+        self.material = MATERIALS['T800_epoxy']
+        # Vp = 2% — well into the interior of the validity region so the
+        # FD step doesn't bump into the [0, 1] clip.
+        pf = PorosityField(self.material, 0.02, distribution='uniform')
+        self.mesh = CompositeMesh(pf, self.material, nx=10, ny=5, nz=6)
+        self.solver = EmpiricalSolver(self.mesh, self.material)
+
+    def test_judd_wright_partial_matches_analytic(self):
+        s = self.solver.local_sensitivities(mode='compression',
+                                            model='judd_wright')
+        # Compare analytic dKD/dVp to a central-difference baseline.
+        fd = self.solver.sensitivity_fd(mode='compression',
+                                        model='judd_wright', param='Vp')
+        np.testing.assert_allclose(s['dKD_dVp'], fd, rtol=1e-6)
+        # And the coefficient partial.
+        fd_c = self.solver.sensitivity_fd(mode='compression',
+                                          model='judd_wright', param='coef')
+        np.testing.assert_allclose(s['dKD_dcoef'], fd_c, rtol=1e-6)
+        # Spot-check the algebra: dKD/dVp = -alpha * KD for judd_wright.
+        alpha = self.solver.JUDD_WRIGHT_ALPHA['compression']
+        np.testing.assert_allclose(s['dKD_dVp'], -alpha * s['KD'], rtol=1e-12)
+
+    def test_power_law_partial_matches_analytic(self):
+        s = self.solver.local_sensitivities(mode='compression',
+                                            model='power_law')
+        fd = self.solver.sensitivity_fd(mode='compression',
+                                        model='power_law', param='Vp')
+        np.testing.assert_allclose(s['dKD_dVp'], fd, rtol=1e-6)
+        fd_c = self.solver.sensitivity_fd(mode='compression',
+                                          model='power_law', param='coef')
+        np.testing.assert_allclose(s['dKD_dcoef'], fd_c, rtol=1e-6)
+
+    def test_linear_partial_matches_analytic(self):
+        s = self.solver.local_sensitivities(mode='compression',
+                                            model='linear')
+        fd = self.solver.sensitivity_fd(mode='compression',
+                                        model='linear', param='Vp')
+        np.testing.assert_allclose(s['dKD_dVp'], fd, rtol=1e-6)
+        fd_c = self.solver.sensitivity_fd(mode='compression',
+                                          model='linear', param='coef')
+        np.testing.assert_allclose(s['dKD_dcoef'], fd_c, rtol=1e-6)
+        # Linear law: dKD/dVp must be exactly -beta in the unclipped regime.
+        beta = self.solver.LINEAR_BETA['compression']
+        np.testing.assert_allclose(s['dKD_dVp'], -beta, rtol=1e-12)
+
+    def test_layup_scaled_alpha_propagates(self):
+        """A non-QI (UD) layup must propagate its layup scaling into the
+        coefficient partial.  ``dKD/dcoef`` magnitude is ``Vp * KD`` — KD
+        moves with the layup-scaled alpha, so the partial scales too."""
+        ud = [0.0] * 8  # UD: f_md = 0 -> floor = 0.15 (compression)
+        qi = [0.0, 45.0, 90.0, -45.0] * 2
+        solver_ud = EmpiricalSolver(self.mesh, self.material, ply_angles=ud)
+        solver_qi = EmpiricalSolver(self.mesh, self.material, ply_angles=qi)
+        s_ud = solver_ud.local_sensitivities(mode='compression',
+                                             model='judd_wright')
+        s_qi = solver_qi.local_sensitivities(mode='compression',
+                                             model='judd_wright')
+        # Sanity: the UD scale (0.15) is smaller than QI scale (1.0), so
+        # UD's alpha is smaller, KD is closer to 1, and the *magnitude*
+        # of dKD/dVp is smaller too (it's -alpha * KD).
+        assert abs(s_ud['dKD_dVp']) < abs(s_qi['dKD_dVp'])
+        # The coefficient partial magnitude is just |Vp| * KD; KD(UD) > KD(QI)
+        # at the same Vp because alpha(UD) < alpha(QI), so |dKD/dcoef|
+        # on UD must be larger than on QI.
+        assert abs(s_ud['dKD_dcoef']) > abs(s_qi['dKD_dcoef'])
+
+    def test_default_Vp_matches_mesh_porosity(self):
+        """Default Vp is ``mesh.porosity_field.Vp`` — same as
+        ``get_failure_load``."""
+        s_default = self.solver.local_sensitivities(mode='compression',
+                                                    model='judd_wright')
+        s_explicit = self.solver.local_sensitivities(
+            mode='compression', model='judd_wright',
+            Vp=self.mesh.porosity_field.Vp)
+        assert s_default == s_explicit
+
+    def test_unknown_model_raises(self):
+        with pytest.raises(ValueError, match=r"Unknown knockdown model"):
+            self.solver.local_sensitivities(mode='compression', model='bogus')
+
+    def test_unknown_mode_raises(self):
+        with pytest.raises(ValueError, match=r"Unknown loading mode"):
+            self.solver.local_sensitivities(mode='flexure', model='judd_wright')
+
+    def test_sensitivity_fd_unknown_param(self):
+        with pytest.raises(ValueError, match=r"param must be"):
+            self.solver.sensitivity_fd(mode='compression',
+                                       model='judd_wright', param='nope')
+
+
+class TestValidationBands:
+    """run_all_datasets must propagate a per-point 1-sigma Vp confidence
+    band onto every strength prediction."""
+
+    def test_band_present_in_run_all_datasets(self, tmp_path):
+        """Synthesize a tiny dataset, run the full pipeline, and check
+        that every strength entry carries a ``predicted_band`` whose
+        per-point interval straddles the central ``predicted`` value."""
+        from validation.validate_all import run_all_datasets
+
+        ds = {
+            "reference": "synthetic_uq_test",
+            "material": {
+                "fiber": "T700",
+                "matrix": "TDE85 epoxy",
+                "fiber_volume_fraction": 0.60,
+                "n_plies": 8,
+                "ply_angles": [0, 45, 90, -45, -45, 90, 45, 0],
+            },
+            "baseline_porosity_pct": 0.0,
+            "properties": {
+                "tensile_strength": {
+                    "void_content_pct": [0.0, 1.0, 2.0, 3.0],
+                    "normalized_values": [1.0, 0.95, 0.85, 0.78],
+                }
+            },
+        }
+        datasets_dir = tmp_path / 'datasets'
+        datasets_dir.mkdir()
+        path = datasets_dir / 'synthetic.json'
+        path.write_text(json.dumps(ds))
+        results = run_all_datasets(datasets_dir=str(datasets_dir), n_jobs=1)
+        assert 'synthetic' in results
+        prop = results['synthetic']['tensile_strength']
+        assert 'predicted_band' in prop, \
+            "Per-point 1-sigma band missing from strength prediction (#65)"
+        band = prop['predicted_band']
+        pred = prop['predicted']
+        assert len(band) == len(pred)
+        for (lo, hi), p in zip(band, pred):
+            # The band must be ordered and must straddle the central point.
+            assert lo <= p <= hi, (
+                f"Band [{lo}, {hi}] does not straddle central prediction {p}"
+            )

--- a/tests/test_validation_database.py
+++ b/tests/test_validation_database.py
@@ -190,8 +190,9 @@ def test_predict_strength_returns_normalized_values():
         'baseline_porosity_pct': 0.6,
     }
     vp_pcts = [0.6, 1.0, 2.0, 3.0]
-    pred = predict_strength(dataset, 'tensile_strength', vp_pcts)
+    pred, band = predict_strength(dataset, 'tensile_strength', vp_pcts)
     assert len(pred) == 4
+    assert len(band) == 4
     assert abs(pred[0] - 1.0) < 0.01  # baseline normalizes to ~1
     assert pred[3] < pred[0]  # strength decreases with porosity
 
@@ -466,7 +467,7 @@ def test_predict_strength_runs_for_transverse_tensile():
         'baseline_porosity_pct': 0.0,
     }
 
-    preds = predict_strength(dataset, 'transverse_tensile_strength', [1.0, 2.0, 3.0])
+    preds, _band = predict_strength(dataset, 'transverse_tensile_strength', [1.0, 2.0, 3.0])
     assert len(preds) == 3
     # All knockdowns must be in (0, 1] and monotonically decreasing with Vp
     assert all(0.0 < p <= 1.0 for p in preds)

--- a/validation/validate_all.py
+++ b/validation/validate_all.py
@@ -175,10 +175,39 @@ _UNSUPPORTED_STRENGTH_PROPS: set = set()
 
 
 def predict_strength(dataset: Dict[str, Any], prop_key: str,
-                     vp_pcts) -> list:
+                     vp_pcts,
+                     sigma_Vp: float = 0.002):
     """Predict normalized strength at each porosity level via Judd-Wright.
 
     Renormalized to the dataset's baseline_porosity_pct.
+
+    Issue #65: also propagates an assumed Vp measurement uncertainty
+    (``sigma_Vp``, default 0.2 vol-% as a fraction — typical microscopy
+    resolution) into a one-sigma confidence band on each predicted point
+    using the closed-form local sensitivity
+    ``KD +/- |dKD/dVp| * sigma_Vp``.  The band is normalized by the same
+    baseline knockdown as the central prediction so it lives in the same
+    "normalized strength" coordinates as the experimental points.
+
+    Parameters
+    ----------
+    dataset:
+        Validated dataset dict.
+    prop_key:
+        Property key in the dataset (e.g. ``'compression_strength'``).
+    vp_pcts:
+        Iterable of porosity percentages at which to evaluate.
+    sigma_Vp:
+        One-sigma Vp measurement uncertainty, expressed as a *fraction*
+        (so 0.002 = 0.2 vol-%).  Defaults to 0.002 — typical optical-
+        microscopy resolution for void-area measurements.
+
+    Returns
+    -------
+    (predicted, predicted_band):
+        ``predicted`` is the central list of normalized knockdowns (as
+        before).  ``predicted_band`` is a parallel list of
+        ``(lower, upper)`` 1-sigma bounds, also in normalized units.
 
     Raises
     ------
@@ -202,16 +231,34 @@ def predict_strength(dataset: Dict[str, Any], prop_key: str,
     mode = _PROPERTY_TO_MODE[prop_key]
     baseline_vp = dataset.get('baseline_porosity_pct', 0.0) / 100.0
 
-    def _kd(vp_frac):
+    def _kd_and_dvp(vp_frac):
         pf = PorosityField(mat, vp_frac, distribution='uniform',
                            void_shape='spherical')
         mesh = CompositeMesh(pf, mat, nx=10, ny=5,
                              nz=mat.n_plies, ply_angles=ply_angles)
         emp = EmpiricalSolver(mesh, mat, ply_angles=ply_angles)
-        return emp.get_failure_load(mode=mode, model='judd_wright')['knockdown']
+        kd = emp.get_failure_load(mode=mode, model='judd_wright')['knockdown']
+        s = emp.local_sensitivities(mode=mode, model='judd_wright',
+                                    Vp=vp_frac)
+        return float(kd), float(s['dKD_dVp'])
 
-    kd_base = _kd(baseline_vp) if baseline_vp > 1e-9 else 1.0
-    return [float(_kd(vp / 100.0) / kd_base) for vp in vp_pcts]
+    if baseline_vp > 1e-9:
+        kd_base, _ = _kd_and_dvp(baseline_vp)
+    else:
+        kd_base = 1.0
+
+    predicted = []
+    predicted_band = []
+    for vp in vp_pcts:
+        kd, dkd_dvp = _kd_and_dvp(vp / 100.0)
+        norm = kd / kd_base
+        # Linear (delta-method) 1-sigma propagation. Normalization is a
+        # constant w.r.t. Vp, so it falls straight through onto the band.
+        half_width = abs(dkd_dvp) * sigma_Vp / kd_base
+        predicted.append(float(norm))
+        predicted_band.append((float(norm - half_width),
+                               float(norm + half_width)))
+    return predicted, predicted_band
 
 
 from porosity_fe_analysis import (
@@ -351,18 +398,25 @@ def _run_one_dataset(path: str):
             dataset_results[prop_key] = {'skipped': skip_msg}
             continue
         try:
+            predicted_band = None
             if prop_key in _MODULUS_PROPS:
                 pred = predict_modulus(data, prop_key, vp)
             else:
-                pred = predict_strength(data, prop_key, vp)
+                pred, predicted_band = predict_strength(data, prop_key, vp)
             mae = compute_mae(pred, exp)
-            dataset_results[prop_key] = {
+            entry = {
                 'vp_pcts': list(vp),
                 'experimental': list(exp),
                 'predicted': pred,
                 'mae': mae,
                 'n_points': len(vp),
             }
+            # Issue #65: surface a per-point 1-sigma validation band when
+            # the analytic sensitivity is available (strength props go
+            # through the closed-form EmpiricalSolver path).
+            if predicted_band is not None:
+                entry['predicted_band'] = predicted_band
+            dataset_results[prop_key] = entry
         except Exception as e:
             # logger.exception() captures the traceback so a downstream
             # debug log (logging level DEBUG/INFO) shows *why* the
@@ -450,8 +504,67 @@ from porosity_fe_analysis import (  # noqa: E402
 _configure_matplotlib_style()
 
 
-def generate_master_report(results: Dict[str, Any], output_dir: str = None):
-    """Generate master validation report (PNG plot + Markdown table)."""
+def _emit_per_paper_band_pngs(results: Dict[str, Any], output_dir: str) -> list:
+    """Emit one ``validation_<dataset>_band.png`` per dataset that has a band.
+
+    Each PNG shows the predicted curve, the +/-1-sigma Vp band, and the
+    experimental points (with error bars when the dataset provides
+    ``standard_deviation`` / ``error_bar``).  Strength-only — modulus
+    properties skip the FE+CLT sensitivity which is not closed form yet.
+
+    Returns the list of PNG paths written.
+    """
+    written = []
+    for ds_name, ds_results in sorted(results.items()):
+        if 'error' in ds_results:
+            continue
+        for prop, r in sorted(ds_results.items()):
+            band = r.get('predicted_band')
+            if band is None:
+                continue
+            vp = r['vp_pcts']
+            exp = r['experimental']
+            pred = r['predicted']
+            lower = [b[0] for b in band]
+            upper = [b[1] for b in band]
+            fig, ax = plt.subplots(figsize=(6.5, 4.5))
+            ax.fill_between(vp, lower, upper, alpha=0.25,
+                            color='#1f77b4',
+                            label=r'$\pm 1\sigma$ ($\sigma_{V_p}=0.2$ vol-%)')
+            ax.plot(vp, pred, '-', color='#1f77b4',
+                    label='predicted (Judd-Wright)')
+            ax.plot(vp, exp, 'ko', label='experimental')
+            ax.set_xlabel('Void content (%)')
+            ax.set_ylabel('Normalized ' + prop.replace('_', ' '))
+            ax.set_title(f"{ds_name} — {prop}")
+            ax.legend(loc='best')
+            ax.grid(True, alpha=0.3)
+            plt.tight_layout()
+            png_path = os.path.join(
+                output_dir, f'validation_{ds_name}_{prop}_band.png')
+            plt.savefig(png_path)
+            plt.close(fig)
+            written.append(png_path)
+    return written
+
+
+def generate_master_report(results: Dict[str, Any], output_dir: str = None,
+                           emit_band_pngs: bool = False):
+    """Generate master validation report (PNG plot + Markdown table).
+
+    Parameters
+    ----------
+    results:
+        Nested results dict from :func:`run_all_datasets`.
+    output_dir:
+        Directory to write artifacts into (defaults to ``os.getcwd()``).
+    emit_band_pngs:
+        Issue #65 — when True, also emit one
+        ``validation_<dataset>_<prop>_band.png`` per dataset/property
+        showing the +/-1-sigma Vp confidence band around the predicted
+        curve.  Defaults to False for back-compat with existing call
+        sites and CI artefact lists.
+    """
     if output_dir is None:
         # Default to cwd, not the package directory: when running inside a
         # PyInstaller-frozen bundle (macOS .app / Windows .exe) the package
@@ -542,6 +655,9 @@ def generate_master_report(results: Dict[str, Any], output_dir: str = None):
     md_path = os.path.join(output_dir, 'validation_detail_report.md')
     with open(md_path, 'w', encoding='utf-8', newline='') as f:
         f.write('\n'.join(md_lines))
+
+    if emit_band_pngs:
+        _emit_per_paper_band_pngs(results, output_dir)
 
     return plot_path, md_path
 


### PR DESCRIPTION
Fixes #65

## Summary

### Analytic sensitivities
- `EmpiricalSolver.local_sensitivities(mode, model, Vp=None) -> {'KD', 'dKD_dVp', 'dKD_dcoef'}` returns the closed-form partials at `Vp_mean = self.mesh.porosity_field.Vp`. Uses layup-scaled coefficients.
- `EmpiricalSolver.sensitivity_fd(mode, model, param='Vp', h=1e-4)` central-difference fallback. Agrees with the analytic partials to ~1e-7 (well under the `rtol=1e-6` threshold).
- One-line tornado log in `compare_configurations` (both serial and parallel paths):
  ```
  Tornado [uniform_spherical]: dKD/dVp=-6.01, dKD/dcoef=-0.0174
  ```
  Matches the analytic identity at Vp=0.02, α=6.9: `KD = exp(-αVp) ≈ 0.871`, `dKD/dVp = -α·KD ≈ -6.01`, `dKD/dcoef = -Vp·KD ≈ -0.0174`.

### Per-point validation confidence bands
- `predict_strength` now returns `(predicted, predicted_band)` with `sigma_Vp=0.002` default (0.2 vol-%, typical microscopy resolution). Threaded through `_run_one_dataset` and stored alongside `predicted` in `run_all_datasets`.
- New `_emit_per_paper_band_pngs` helper called from `generate_master_report` under an opt-in `emit_band_pngs=False` flag (default off for back-compat with existing CLI artifact lists). When enabled, emits a `validation_<dataset>_band.png` per paper showing the predicted curve, ±1σ band, and experimental points.

## Test plan
- [x] Full pytest suite — 446 passed, 1 skipped (+9 new tests)
- [x] `TestLocalSensitivities` — analytic vs FD for Judd-Wright, power-law, linear; layup-scaled coefficient propagation.
- [x] `TestValidationBands` — band present in `run_all_datasets`; band straddles central predicted value.
- [x] Two pre-existing tests in `test_validation_database.py` updated to unpack the new `(pred, band)` tuple.

---
_Generated by [Claude Code](https://claude.ai/code/session_01X5dvvNWcbxZdjeHCZSXDzM)_