### PR TITLE
feat(fe): penalty_factor kwarg, Jacobi pre-scaling, conditioning diagnostic

### DIFF
--- a/porosity_fe_analysis.py
+++ b/porosity_fe_analysis.py
@@ -4019,7 +4019,7 @@ class BoundaryHandler:
     @staticmethod
     def apply_penalty(K: scipy.sparse.csc_matrix, F: np.ndarray,
                       constrained_dofs: Dict[int, float],
-                      penalty_factor: float = 1e8
+                      penalty_factor: float = 1e6
                       ) -> Tuple[scipy.sparse.csc_matrix, np.ndarray]:
         """Apply penalty method for prescribed displacements.
 
@@ -4036,7 +4036,11 @@ class BoundaryHandler:
         constrained_dofs : dict
             {dof_index: prescribed_value}.
         penalty_factor : float
-            Multiplier for max diagonal entry.
+            Multiplier for max diagonal entry. Defaults to ``1e6`` (six
+            decades of BC enforcement), lowered from the historical
+            ``1e8`` because the latter pushed ``cond(K_mod)`` to ~2.4e9
+            and capped LU-vs-CG agreement at ~3e-6 even when the
+            iterative residual was at machine precision (issue #60).
 
         Returns
         -------
@@ -4351,7 +4355,9 @@ class FESolver:
               failure_criterion: Optional[Literal[
                   'tsai_wu', 'hashin', 'max_stress']] = None,
               solver: Literal['direct', 'cg', 'minres'] = 'direct',
-              rtol: float = 1e-9) -> FieldResults:
+              rtol: float = 1e-9,
+              diag_scale: bool = False,
+              penalty_factor: float = 1e6) -> FieldResults:
         """Solve the static FE problem.
 
         Parameters
@@ -4387,6 +4393,23 @@ class FESolver:
         rtol : float
             Relative-residual tolerance for the iterative solvers. Ignored
             when ``solver='direct'``.
+        diag_scale : bool, optional
+            If ``True``, symmetrically Jacobi-pre-scale the penalty-
+            modified system before solving:
+            ``(D^{-1/2} K_mod D^{-1/2}) y = D^{-1/2} F_mod``,
+            ``u = D^{-1/2} y``, where ``D = diag(K_mod)``. The math is
+            unchanged but the diagonal-conditioning ratio is reduced by
+            2-3 decades on graded/voided meshes, which improves both LU
+            backward error and CG/MINRES convergence. Defaults to
+            ``False`` to preserve bit-identical legacy behavior; opt in
+            when conditioning is a concern (issue #60).
+        penalty_factor : float, optional
+            Multiplier on ``max(diag(K))`` used by
+            :meth:`BoundaryHandler.apply_penalty` to enforce Dirichlet
+            BCs. Lowered from ``1e8`` to ``1e6`` (default) in issue #60
+            to keep ``cond(K_mod)`` well below the float64 ceiling while
+            still enforcing BCs to six decades. Tune higher only if BC
+            slack is a problem; tune lower if conditioning is.
 
         Returns
         -------
@@ -4443,7 +4466,33 @@ class FESolver:
             logger.info("  Applied %d displacement BCs", len(constrained))
 
         # 3. Apply penalty
-        K_mod, F_mod = BoundaryHandler.apply_penalty(K, F, constrained)
+        K_mod, F_mod = BoundaryHandler.apply_penalty(
+            K, F, constrained, penalty_factor=penalty_factor,
+        )
+
+        # 3a. Conditioning diagnostic (issue #60). The diagonal ratio is
+        # an inexpensive proxy for cond(K_mod) — full condest is O(n^2)
+        # for sparse matrices and we want this on every solve. Warn the
+        # user well before float64's ~1e16 headroom is exhausted.
+        _diag = K_mod.diagonal()
+        _diag_abs = np.abs(_diag)
+        _diag_min = float(_diag_abs[_diag_abs > 0.0].min()) \
+            if np.any(_diag_abs > 0.0) else 0.0
+        _diag_max = float(_diag_abs.max()) if _diag_abs.size else 0.0
+        cond_diag_ratio = (_diag_max / _diag_min) if _diag_min > 0.0 \
+            else float('inf')
+        logger.info(
+            "Matrix conditioning: cond_diag_ratio=%.4e "
+            "(penalty_factor=%.2e, diag_scale=%s)",
+            cond_diag_ratio, penalty_factor, diag_scale,
+        )
+        if cond_diag_ratio > 1e12:
+            logger.warning(
+                "Matrix conditioning near float64 limit "
+                "(cond_diag_ratio=%.2e); consider lowering "
+                "penalty_factor or enabling diag_scale.",
+                cond_diag_ratio,
+            )
 
         # 4. Solve
         if solver not in ('direct', 'cg', 'minres'):
@@ -4457,17 +4506,51 @@ class FESolver:
                 self.mesh.n_dof, solver,
             )
 
+        # 4a. Optional symmetric Jacobi pre-scaling (issue #60).
+        # Replace (K_mod, F_mod) with (K_scaled, F_scaled) for the solve;
+        # after solving, unscale y -> u via u = d_inv_sqrt * y.
+        if diag_scale:
+            _d = K_mod.diagonal()
+            if not np.all(_d > 0):
+                raise RuntimeError(
+                    "Cannot apply diag_scale: K_mod has a non-positive "
+                    "diagonal entry. Check assembly / penalty."
+                )
+            d_inv_sqrt = 1.0 / np.sqrt(_d)
+            _D_is = scipy.sparse.diags(d_inv_sqrt)
+            K_solve = (_D_is @ K_mod) @ _D_is
+            F_solve = d_inv_sqrt * F_mod
+            # Log the post-scaling diagonal ratio so the user can see
+            # what the rescaling bought them.
+            _d_scaled = K_solve.diagonal()
+            _d_scaled_abs = np.abs(_d_scaled)
+            _ds_min = float(_d_scaled_abs[_d_scaled_abs > 0.0].min()) \
+                if np.any(_d_scaled_abs > 0.0) else 0.0
+            _ds_max = float(_d_scaled_abs.max()) \
+                if _d_scaled_abs.size else 0.0
+            cond_diag_ratio_scaled = (_ds_max / _ds_min) \
+                if _ds_min > 0.0 else float('inf')
+            logger.info(
+                "Matrix conditioning after diag_scale: "
+                "cond_diag_ratio=%.4e (was %.4e)",
+                cond_diag_ratio_scaled, cond_diag_ratio,
+            )
+        else:
+            K_solve = K_mod
+            F_solve = F_mod
+            d_inv_sqrt = None
+
         if solver == 'direct':
-            u = scipy.sparse.linalg.spsolve(K_mod, F_mod)
+            y = scipy.sparse.linalg.spsolve(K_solve, F_solve)
 
             # Hygiene checks on the solution vector
-            if not np.isfinite(u).all():
+            if not np.isfinite(y).all():
                 raise RuntimeError(
                     "spsolve produced non-finite values (NaN or Inf) in the solution "
                     "vector. Check matrix conditioning and boundary conditions."
                 )
-            _r = K_mod @ u - F_mod
-            _rel_res = np.linalg.norm(_r) / max(np.linalg.norm(F_mod), 1.0)  # type: ignore[call-overload,operator]
+            _r = K_solve @ y - F_solve
+            _rel_res = np.linalg.norm(_r) / max(np.linalg.norm(F_solve), 1.0)  # type: ignore[call-overload,operator]
             if _rel_res >= 1e-6:
                 raise RuntimeError(
                     f"spsolve residual {_rel_res:.4e} exceeds tolerance 1e-6. "
@@ -4476,7 +4559,7 @@ class FESolver:
         else:
             # Jacobi (diagonal) preconditioner: K is SPD after penalty,
             # diag(K) is strictly positive.
-            diag = K_mod.diagonal()
+            diag = K_solve.diagonal()
             if not np.all(diag > 0):
                 raise RuntimeError(
                     "Cannot build Jacobi preconditioner: K_mod has a "
@@ -4485,16 +4568,16 @@ class FESolver:
             M = scipy.sparse.diags(1.0 / diag)
 
             if solver == 'cg':
-                u, info = scipy.sparse.linalg.cg(
-                    K_mod, F_mod, M=M, rtol=rtol,
+                y, info = scipy.sparse.linalg.cg(
+                    K_solve, F_solve, M=M, rtol=rtol,
                 )
             else:  # solver == 'minres'
-                u, info = scipy.sparse.linalg.minres(
-                    K_mod, F_mod, M=M, rtol=rtol,
+                y, info = scipy.sparse.linalg.minres(
+                    K_solve, F_solve, M=M, rtol=rtol,
                 )
 
-            _r = K_mod @ u - F_mod
-            _norm_b = float(np.linalg.norm(F_mod))  # type: ignore[call-overload]
+            _r = K_solve @ y - F_solve
+            _norm_b = float(np.linalg.norm(F_solve))  # type: ignore[call-overload]
             _rel_res = float(
                 np.linalg.norm(_r) / _norm_b if _norm_b > 0.0 else 0.0  # type: ignore[call-overload,operator]
             )
@@ -4514,6 +4597,13 @@ class FESolver:
                 "%s converged: relative residual %.4e (rtol=%.4e)",
                 solver, _rel_res, rtol,
             )
+
+        # 4b. Unscale if we Jacobi-pre-scaled. ``y`` solves the scaled
+        # system; the physical displacement is ``u = D^{-1/2} y``.
+        if diag_scale:
+            u = d_inv_sqrt * y
+        else:
+            u = y
 
         if verbose:
             t2 = time.perf_counter()

--- a/tests/test_porosity_fe.py
+++ b/tests/test_porosity_fe.py
@@ -2122,6 +2122,166 @@ class TestFESolverIterative:
             )
 
 
+class TestPenaltyFactorAndConditioning:
+    """Regression tests for the matrix-conditioning diagnostic, the
+    user-exposed ``penalty_factor`` kwarg, and the optional Jacobi
+    pre-scaling path (issue #60).
+
+    Background: the penalty-method BC enforcement uses
+    ``alpha = penalty_factor * max(diag(K))``. Pre-#60 this was hardwired
+    at ``penalty_factor=1e8`` which pushed cond(K_mod) to ~2.4e9 and
+    capped LU-vs-CG agreement at ~3e-6 even when the CG residual was at
+    machine precision. PR #60 lowers the default to ``1e6``, exposes the
+    knob, logs ``cond_diag_ratio`` on every solve, and adds a
+    symmetric-Jacobi pre-scaling path.
+    """
+
+    def setup_method(self):
+        import inspect
+        self._inspect = inspect
+        self.material = MATERIALS['T800_epoxy']
+        self.pf = PorosityField(self.material, 0.03, distribution='uniform')
+        # Small but non-trivial mesh — keeps the suite fast while still
+        # exercising the iterative solvers and giving a measurable
+        # cond_diag_ratio.
+        self.mesh = CompositeMesh(self.pf, self.material, nx=3, ny=2, nz=2)
+
+    def test_default_penalty_lowered(self):
+        """``BoundaryHandler.apply_penalty`` default must be 1e6, not 1e8."""
+        sig = self._inspect.signature(BoundaryHandler.apply_penalty)
+        default = sig.parameters['penalty_factor'].default
+        assert default == 1e6, (
+            f"Expected apply_penalty default penalty_factor=1e6, got {default!r}"
+        )
+
+    def test_penalty_factor_kwarg_threaded_through_solve(self):
+        """Passing penalty_factor through solve must reach apply_penalty.
+
+        We use a deliberately-loose penalty (1e2) which makes BC
+        enforcement slack enough to perturb the solution detectably
+        relative to the default (1e6).
+        """
+        solver = FESolver(self.mesh, self.material, self.pf)
+        r_default = solver.solve(
+            loading='compression', applied_strain=-0.001, solver='direct',
+        )
+        r_loose = solver.solve(
+            loading='compression', applied_strain=-0.001, solver='direct',
+            penalty_factor=1e2,
+        )
+        scale = float(np.max(np.abs(r_default.displacement)))
+        delta = float(np.max(np.abs(
+            r_loose.displacement - r_default.displacement
+        )))
+        # Loose penalty must produce a *detectable* perturbation
+        # (otherwise the kwarg is being ignored).
+        assert delta / max(scale, 1e-30) > 1e-4, (
+            f"penalty_factor kwarg appears not to be threaded through "
+            f"to apply_penalty: relative delta {delta/max(scale,1e-30):.3e}"
+        )
+
+    def test_conditioning_warning_logged(self, caplog):
+        """penalty_factor=1e15 must trip the float64-headroom warning."""
+        import logging
+        solver = FESolver(self.mesh, self.material, self.pf)
+        with caplog.at_level(logging.WARNING, logger='porosity_fe_analysis'):
+            solver.solve(
+                loading='compression', applied_strain=-0.001, solver='direct',
+                penalty_factor=1e15,
+            )
+        msgs = [rec.message for rec in caplog.records
+                if rec.levelno >= logging.WARNING]
+        assert any('Matrix conditioning near float64 limit' in m
+                   for m in msgs), (
+            f"Expected conditioning warning, got records: {msgs!r}"
+        )
+
+    def test_diag_scale_off_matches_legacy(self):
+        """diag_scale=False (default) must reproduce the un-rescaled path
+        bit-identically — diag_scale should be opt-in only.
+        """
+        solver = FESolver(self.mesh, self.material, self.pf)
+        r_default = solver.solve(
+            loading='compression', applied_strain=-0.001, solver='direct',
+        )
+        r_explicit_off = solver.solve(
+            loading='compression', applied_strain=-0.001, solver='direct',
+            diag_scale=False,
+        )
+        np.testing.assert_allclose(
+            r_explicit_off.displacement, r_default.displacement,
+            rtol=0.0, atol=0.0,
+            err_msg="diag_scale=False should be bit-identical to default",
+        )
+
+    def test_diag_scale_on_matches_off_for_well_conditioned(self):
+        """The Jacobi rescaling is a similarity transform on the linear
+        system — math unchanged, only conditioning. For a well-
+        conditioned problem the two paths must agree to ~1e-7.
+        """
+        solver = FESolver(self.mesh, self.material, self.pf)
+        r_off = solver.solve(
+            loading='compression', applied_strain=-0.001, solver='direct',
+            diag_scale=False,
+        )
+        r_on = solver.solve(
+            loading='compression', applied_strain=-0.001, solver='direct',
+            diag_scale=True,
+        )
+        scale = float(np.max(np.abs(r_off.displacement)))
+        delta = float(np.max(np.abs(r_on.displacement - r_off.displacement)))
+        assert delta / max(scale, 1e-30) < 1e-7, (
+            f"diag_scale on/off mismatch on well-conditioned mesh: "
+            f"max|du|/max|u| = {delta/max(scale, 1e-30):.3e}"
+        )
+
+    def test_diag_scale_reduces_conditioning_ratio(self, caplog):
+        """On a voided/graded mesh diag_scale must measurably reduce
+        the diagonal-conditioning ratio. We capture the INFO line both
+        ways and assert the rescaled ratio is strictly smaller.
+        """
+        import logging
+        import re
+
+        # Voided/graded mesh — clustered distribution drives spatial
+        # variation in stiffness, which widens the diagonal spread.
+        pf_voided = PorosityField(self.material, 0.10,
+                                  distribution='clustered', seed=42)
+        mesh_voided = CompositeMesh(pf_voided, self.material, nx=4, ny=3, nz=3)
+        solver = FESolver(mesh_voided, self.material, pf_voided)
+
+        def _capture_ratio(diag_scale_value):
+            caplog.clear()
+            with caplog.at_level(logging.INFO, logger='porosity_fe_analysis'):
+                solver.solve(
+                    loading='compression', applied_strain=-0.001,
+                    solver='direct', diag_scale=diag_scale_value,
+                )
+            # The post-scaling line (when diag_scale=True) takes priority;
+            # otherwise grab the initial diagnostic.
+            target_prefix = ('Matrix conditioning after diag_scale'
+                             if diag_scale_value
+                             else 'Matrix conditioning:')
+            for rec in caplog.records:
+                if rec.message.startswith(target_prefix):
+                    m = re.search(r'cond_diag_ratio=([0-9.eE+\-]+)',
+                                  rec.message)
+                    if m:
+                        return float(m.group(1))
+            raise AssertionError(
+                f"Did not find cond_diag_ratio log line for "
+                f"diag_scale={diag_scale_value}; got: "
+                f"{[r.message for r in caplog.records]!r}"
+            )
+
+        ratio_off = _capture_ratio(False)
+        ratio_on = _capture_ratio(True)
+        assert ratio_on < ratio_off, (
+            f"diag_scale=True did not reduce cond_diag_ratio: "
+            f"off={ratio_off:.3e}, on={ratio_on:.3e}"
+        )
+
+
 class TestILSSBeamTheoryValidation:
     """Beam-theory validation for the ILSS short-beam-shear FE BCs.
 


### PR DESCRIPTION
Fixes #60

## Summary
Follow-up to the just-merged #97/#57 (iterative solver), which noted that the penalty conditioning (κ ≈ 2.4e9) was capping LU-vs-CG agreement at ~3e-6 even when CG residual was at machine precision.

### Item 1: penalty_factor + conditioning report
- `BoundaryHandler.apply_penalty` default lowered from `1e8` → `1e6` (still 6-decade BC enforcement, safely below float64's 16-decade headroom).
- `FESolver.solve` exposes `penalty_factor: float = 1e6` so users can tune without monkey-patching.
- After applying the penalty, `cond_diag_ratio = max(diag(K_mod)) / min(diag(K_mod))` is computed and logged at INFO. If `> 1e12`, a `logger.warning` fires ("matrix conditioning near float64 limit; consider lowering penalty_factor or enabling diag_scale").

### Item 2: Jacobi pre-scaling
- New `diag_scale: bool = False` kwarg on `FESolver.solve` (default off to preserve bit-identical legacy behavior).
- When enabled: `D = diag(K_mod)`, solve `(D^{-1/2} K_mod D^{-1/2}) y = D^{-1/2} F_mod`, unscale `u = D^{-1/2} y`. Applies uniformly to `direct`, `cg`, and `minres` paths.
- The `cond_diag_ratio` is re-logged post-scaling so users can see the reduction.

## Measurements (clustered-porosity voided mesh, nx=4 ny=3 nz=3)

| Configuration | `cond_diag_ratio` |
|---|---|
| Old `penalty_factor=1e8`, `diag_scale=False` | 2.22e+09 |
| New `penalty_factor=1e6`, `diag_scale=False` | 2.22e+07 |
| New `penalty_factor=1e6`, `diag_scale=True` | 1.00e+00 |
| `penalty_factor=1e15` (forced) | 2.37e+16 → `WARNING` fires |

### CG-vs-LU agreement (rtol=1e-14)

| Configuration | `max\|du\| / max\|u\|` |
|---|---|
| Old `penalty_factor=1e8`, `diag_scale=False` | 7.97e-08 |
| New `penalty_factor=1e6`, `diag_scale=False` | 7.81e-09 |
| New `penalty_factor=1e6`, `diag_scale=True` | **1.25e-12** |

One decade from the penalty drop, four more from Jacobi rescaling.

## Test plan
- [x] Full pytest suite — 473 passed, 1 skipped (+6 new tests)
- [x] Zero pre-existing tests required adjustment — displacement- and force-controlled modes unaffected by the penalty change, as expected
- [x] `TestPenaltyFactorAndConditioning`: default lowered, kwarg threaded, conditioning warning fires, `diag_scale=False` matches legacy, `diag_scale=True` matches False to `rtol=1e-7` on well-conditioned, scaling reduces ratio

---
_Generated by [Claude Code](https://claude.ai/code/session_01X5dvvNWcbxZdjeHCZSXDzM)_