### PR TITLE
chore: fix accumulated ruff and mypy lint failures on master

### DIFF
--- a/examples/clustered_midplane.py
+++ b/examples/clustered_midplane.py
@@ -21,11 +21,16 @@ _REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if _REPO_ROOT not in sys.path:
     sys.path.insert(0, _REPO_ROOT)
 
-import matplotlib
+import matplotlib  # noqa: E402
+
 matplotlib.use("Agg")
 
 from porosity_fe_analysis import (  # noqa: E402
-    MATERIALS, CompositeMesh, EmpiricalSolver, FEVisualizer, PorosityField,
+    MATERIALS,
+    CompositeMesh,
+    EmpiricalSolver,
+    FEVisualizer,
+    PorosityField,
 )
 
 OUT_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "output")
@@ -43,7 +48,7 @@ def main() -> None:
     result = solver.get_failure_load(mode="ilss", model="judd_wright")
 
     z, Vp_z = pf.effective_porosity_profile(nz=100)
-    print(f"Material:        T800_epoxy")
+    print("Material:        T800_epoxy")
     print(f"Vp (mean):       {pf.Vp * 100:.2f}%   (clustered@midplane, spherical)")
     print(f"Vp (peak):       {Vp_z.max() * 100:.2f}%  at z = "
           f"{z[Vp_z.argmax()]:.2f} mm")

--- a/examples/compute_degraded_clt_moduli.py
+++ b/examples/compute_degraded_clt_moduli.py
@@ -21,7 +21,8 @@ _REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if _REPO_ROOT not in sys.path:
     sys.path.insert(0, _REPO_ROOT)
 
-import matplotlib
+import matplotlib  # noqa: E402
+
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt  # noqa: E402
 import numpy as np  # noqa: E402
@@ -40,10 +41,14 @@ def main() -> None:
     Ex, Ey, Gxy = [], [], []
     for Vp in Vps:
         m = compute_degraded_clt_moduli(material, ply_angles, float(Vp))
-        Ex.append(m["Ex"]); Ey.append(m["Ey"]); Gxy.append(m["Gxy"])
-    Ex = np.array(Ex); Ey = np.array(Ey); Gxy = np.array(Gxy)
+        Ex.append(m["Ex"])
+        Ey.append(m["Ey"])
+        Gxy.append(m["Gxy"])
+    Ex = np.array(Ex)
+    Ey = np.array(Ey)
+    Gxy = np.array(Gxy)
 
-    print(f"Layup: [0/45/-45/90]_s   (8 plies, T800_epoxy)")
+    print("Layup: [0/45/-45/90]_s   (8 plies, T800_epoxy)")
     print(f"{'Vp(%)':>7s} {'Ex/Ex0':>9s} {'Ey/Ey0':>9s} {'Gxy/Gxy0':>11s}")
     for v, ex, ey, g in zip(Vps, Ex / Ex[0], Ey / Ey[0], Gxy / Gxy[0]):
         print(f"{v*100:7.2f} {ex:9.4f} {ey:9.4f} {g:11.4f}")
@@ -55,9 +60,13 @@ def main() -> None:
     ax.set_xlabel("Void volume fraction Vp (%)")
     ax.set_ylabel("Normalized modulus")
     ax.set_title("CLT-degraded laminate moduli vs. porosity")
-    ax.grid(alpha=0.3); ax.legend(); ax.set_ylim(0, 1.05)
+    ax.grid(alpha=0.3)
+    ax.legend()
+    ax.set_ylim(0, 1.05)
     out_png = os.path.join(OUT_DIR, "clt_degraded_moduli.png")
-    fig.tight_layout(); fig.savefig(out_png); plt.close(fig)
+    fig.tight_layout()
+    fig.savefig(out_png)
+    plt.close(fig)
     print(f"PNG saved: {out_png}")
 
 

--- a/examples/discrete_voids.py
+++ b/examples/discrete_voids.py
@@ -19,11 +19,16 @@ _REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if _REPO_ROOT not in sys.path:
     sys.path.insert(0, _REPO_ROOT)
 
-import matplotlib
+import matplotlib  # noqa: E402
+
 matplotlib.use("Agg")
 
 from porosity_fe_analysis import (  # noqa: E402
-    MATERIALS, CompositeMesh, EmpiricalSolver, FEVisualizer, PorosityField,
+    MATERIALS,
+    CompositeMesh,
+    EmpiricalSolver,
+    FEVisualizer,
+    PorosityField,
     VoidGeometry,
 )
 
@@ -48,10 +53,10 @@ def main() -> None:
     solver = EmpiricalSolver(mesh, material)
     result = solver.get_failure_load(mode="compression", model="judd_wright")
 
-    print(f"Material:        T800_epoxy")
+    print("Material:        T800_epoxy")
     print(f"Vp (background): {pf.Vp * 100:.2f}%   "
           f"({len(voids)} discrete voids on top)")
-    print(f"Discrete voids:")
+    print("Discrete voids:")
     for i, v in enumerate(voids):
         scf = v.stress_concentration_factor()["compression"]
         print(f"  void {i}: center={v.center.tolist()}, "

--- a/examples/interface_penny.py
+++ b/examples/interface_penny.py
@@ -20,11 +20,16 @@ _REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if _REPO_ROOT not in sys.path:
     sys.path.insert(0, _REPO_ROOT)
 
-import matplotlib
+import matplotlib  # noqa: E402
+
 matplotlib.use("Agg")
 
 from porosity_fe_analysis import (  # noqa: E402
-    MATERIALS, CompositeMesh, EmpiricalSolver, FEVisualizer, PorosityField,
+    MATERIALS,
+    CompositeMesh,
+    EmpiricalSolver,
+    FEVisualizer,
+    PorosityField,
 )
 
 OUT_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "output")
@@ -42,7 +47,7 @@ def main() -> None:
     res_comp = solver.get_failure_load(mode="compression", model="judd_wright")
 
     z, Vp_z = pf.effective_porosity_profile(nz=400)
-    print(f"Material:           T800_epoxy")
+    print("Material:           T800_epoxy")
     print(f"Vp (mean):          {pf.Vp * 100:.2f}%   (interface, penny)")
     print(f"Vp (peak):          {Vp_z.max() * 100:.2f}%  at z = "
           f"{z[Vp_z.argmax()]:.3f} mm")

--- a/examples/uniform_spherical.py
+++ b/examples/uniform_spherical.py
@@ -21,11 +21,16 @@ _REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if _REPO_ROOT not in sys.path:
     sys.path.insert(0, _REPO_ROOT)
 
-import matplotlib
+import matplotlib  # noqa: E402
+
 matplotlib.use("Agg")
 
 from porosity_fe_analysis import (  # noqa: E402
-    MATERIALS, CompositeMesh, EmpiricalSolver, FEVisualizer, PorosityField,
+    MATERIALS,
+    CompositeMesh,
+    EmpiricalSolver,
+    FEVisualizer,
+    PorosityField,
 )
 
 OUT_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "output")

--- a/porosity_fe_analysis.py
+++ b/porosity_fe_analysis.py
@@ -33,7 +33,7 @@ import sys
 import warnings
 from collections import OrderedDict
 from dataclasses import dataclass, field
-from typing import Callable, Dict, List, Literal, Optional, Tuple, Union
+from typing import Any, Callable, Dict, List, Literal, Optional, Tuple, Union
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -2575,7 +2575,7 @@ class EmpiricalSolver:
         model_label = model if isinstance(model, str) else getattr(
             model, '__name__', 'user_callable')
 
-        details = {
+        details: Dict[str, Any] = {
             'critical_location': [0.0, 0.0, 0.0],
             'mode': mode,
         }
@@ -2622,7 +2622,7 @@ class EmpiricalSolver:
         R : float, optional
             Stress ratio for the fatigue knockdown (informational).
         """
-        results: Dict[str, Dict[str, dict]] = {}
+        results: Dict[str, Dict[str, FailureResult]] = {}
         all_models: List[Tuple[str, Union[str, Callable[[float, str], float]]]] = [
             ('judd_wright', 'judd_wright'),
             ('power_law', 'power_law'),
@@ -6005,8 +6005,8 @@ class FESolver:
                                           'failure_criterion', 'tsai_wu')),
                 'mode_indices': (
                     {k: float(v) for k, v in field_results.failure_mode_indices.items()}
-                    if getattr(field_results, 'failure_mode_indices', None)
-                    is not None else None
+                    if field_results.failure_mode_indices is not None
+                    else None
                 ),
                 'knockdown_factor': float(field_results.knockdown),
             },

--- a/tests/test_porosity_fe.py
+++ b/tests/test_porosity_fe.py
@@ -857,7 +857,7 @@ class TestResultsSchemaAndReproducibility:
         assert d1 == d2
 
     def test_json_default_handles_numpy_and_ndarray(self, tmp_path):
-        from porosity_fe_analysis import _json_default, ConfigResult
+        from porosity_fe_analysis import _json_default
         assert _json_default(np.float64(1.5)) == 1.5
         assert _json_default(np.int64(7)) == 7
         assert _json_default(np.array([1.0, 2.0])) == [1.0, 2.0]


### PR DESCRIPTION
## Why PR #101's lint was red

The `lint` job in `.github/workflows/tests.yml` runs `ruff check .` and `mypy porosity_fe_analysis.py`. PR #101 was red because the test matrix's 12 jobs all pass but the lint job fails — and not because of anything specific to #101. Master itself has accumulated **28 ruff errors + 4 mypy errors** across the last several merged PRs. The squash merges all went through anyway (branch protection isn't enforcing lint as a required status), but the failures pile up on every new PR opened against master until someone clears them.

This PR clears them.

## What this fixes

### Ruff (28 → 0)

| File group | Original error | Fix |
|---|---|---|
| `examples/*.py` (15 errors) | `I001` un-sorted imports, `F541` empty f-strings | Auto-fixed via `ruff --fix` |
| `examples/compute_degraded_clt_moduli.py` (8 errors) | `E702` multiple statements on one line | Split the `; `-chained statements |
| `examples/*.py` (5 errors) | `E402` module-level import not at top | The `import matplotlib` line was missing the `# noqa: E402` that the `porosity_fe_analysis` import block already had (matplotlib's backend selector legitimately must come before the package import). Added `# noqa: E402` |
| `tests/test_porosity_fe.py:860` (1 error) | `F401 ConfigResult imported but unused` | Removed (the import was a leftover from the #44 salvage) |

### Mypy (4 → 0)

| Line | Error | Fix |
|---|---|---|
| 2585, 2587 | `details['environment_knockdown'] = float(...)` failed because mypy inferred `details: Dict[str, Sequence[object]]` from the literal | Annotated `details: Dict[str, Any]` explicitly |
| 2625 | `results: Dict[str, Dict[str, dict]]` no longer matches — `get_failure_load` now returns `FailureResult` (post-#44) | Annotated `results: Dict[str, Dict[str, FailureResult]]` |
| 6007 | `field_results.failure_mode_indices.items()` was guarded via `getattr(..., None) is not None`, which mypy can't narrow | Replaced with a direct `field_results.failure_mode_indices is not None` check |

## Test plan
- [x] `ruff check .` — All checks passed
- [x] `mypy porosity_fe_analysis.py` — Success: no issues found
- [x] Full pytest suite — 493 passed, 1 skipped

## Going forward
The squash merges keep landing through a failing lint job because the workflow isn't a *required* status check. If you want to prevent this drift from re-accumulating, enable required status checks on `master` for the `lint` job in repo settings → branches → branch protection rules.

---
_Generated by [Claude Code](https://claude.ai/code/session_01X5dvvNWcbxZdjeHCZSXDzM)_