### PR TITLE
feat(cli): reconcile Vp percent vs fraction units

### DIFF
--- a/porosity_fe/cli.py
+++ b/porosity_fe/cli.py
@@ -53,15 +53,35 @@ def _build_arg_parser() -> 'argparse.ArgumentParser':
         default="T800_epoxy",
         help="Material preset name (validated against the built-in presets).",
     )
-    parser.add_argument(
+    # #127: the Streamlit app collects Vp as a percentage (0-100) while the
+    # CLI historically required a fraction in [0, 1]. Users who used the GUI
+    # first naturally type `--vp 3` and get a confusing error. We keep `--vp`
+    # as fractions (the documented contract) and add a `--vp-pct` alias for
+    # callers who want to think in percent. The two are mutually exclusive.
+    vp_group = parser.add_mutually_exclusive_group()
+    vp_group.add_argument(
         "--vp",
         type=float,
         nargs="+",
-        default=list(DEFAULT_POROSITY_LEVELS),
+        default=None,
         metavar="VP",
         help=(
-            "One or more void volume fractions in [0, 1]. Defaults to the "
-            "historical sweep."
+            "One or more void volume fractions as a decimal in [0, 1]. "
+            "Example: --vp 0.03 for 3%%, --vp 0.01 0.03 0.05 for a sweep. "
+            "Use --vp-pct if you'd rather pass percentages (the Streamlit "
+            "app accepts percentages; this CLI defaults to fractions)."
+        ),
+    )
+    vp_group.add_argument(
+        "--vp-pct",
+        type=float,
+        nargs="+",
+        default=None,
+        metavar="VP_PCT",
+        help=(
+            "One or more void volume fractions as a percentage in [0, 100]. "
+            "Internally converted to fractions (--vp-pct 3 is equivalent to "
+            "--vp 0.03)."
         ),
     )
     parser.add_argument(
@@ -236,11 +256,26 @@ def main(argv: Optional[List[str]] = None) -> int:
             f"Available presets: {sorted(materials)}."
         )
 
+    # #127: resolve --vp / --vp-pct into a single list of fractions for the
+    # rest of the pipeline. argparse already enforces mutual exclusion, so
+    # at most one is non-None.
+    if args.vp_pct is not None:
+        args.vp = [pct / 100.0 for pct in args.vp_pct]
+    elif args.vp is None:
+        args.vp = list(DEFAULT_POROSITY_LEVELS)
+
     for Vp in args.vp:
         if not (0.0 <= Vp <= 1.0) or Vp != Vp:  # NaN-safe range check
+            hint = ""
+            if 1.0 < Vp <= 100.0:
+                hint = (
+                    f" (looks like a percentage; "
+                    f"did you mean `--vp {Vp / 100.0:.4f}` or `--vp-pct {Vp}`?)"
+                )
             parser.error(
                 f"--vp value {Vp!r} is out of range; expected a finite "
                 f"float in [0, 1] (a void *fraction*, not a percentage)."
+                f"{hint}"
             )
 
     output_dir = args.output_dir

--- a/tests/test_porosity_fe.py
+++ b/tests/test_porosity_fe.py
@@ -4311,6 +4311,56 @@ class TestCLIMain:
         assert rc == 0
         assert seen.get('n_jobs') == 1
 
+    # #127: --vp / --vp-pct unit reconciliation -------------------------
+
+    def test_vp_pct_alias_converts_to_fraction(self, tmp_path, monkeypatch):
+        """`--vp-pct 2` must run as if `--vp 0.02` were passed."""
+        seen = []
+        original = porosity_fe_analysis.compare_configurations
+
+        def _spy(*args, **kwargs):
+            # First positional arg of compare_configurations is the Vp.
+            Vp = args[0] if args else kwargs.get('void_volume_fraction')
+            seen.append(float(Vp))
+            return original(*args, **kwargs)
+
+        monkeypatch.setattr(porosity_fe_analysis, 'POROSITY_CONFIGS',
+                            _TINY_CONFIGS)
+        monkeypatch.setattr(porosity_fe_analysis,
+                            'compare_configurations', _spy)
+        rc = porosity_fe_analysis.main([
+            '--vp-pct', '2',
+            '--output-dir', str(tmp_path),
+            '--quiet',
+        ])
+        assert rc == 0
+        assert seen == [pytest.approx(0.02, rel=1e-12)]
+
+    def test_vp_pct_and_vp_mutually_exclusive(self, tmp_path, capsys):
+        """Passing both --vp and --vp-pct must error out cleanly."""
+        with pytest.raises(SystemExit) as exc:
+            porosity_fe_analysis.main([
+                '--vp', '0.02', '--vp-pct', '2',
+                '--output-dir', str(tmp_path),
+            ])
+        # argparse exits 2 for invalid usage.
+        assert exc.value.code == 2
+        err = capsys.readouterr().err
+        assert 'not allowed with' in err
+
+    def test_vp_percentage_typo_gets_helpful_hint(self, tmp_path, capsys):
+        """`--vp 3` (looks like a percentage) must suggest both fixes."""
+        with pytest.raises(SystemExit) as exc:
+            porosity_fe_analysis.main([
+                '--vp', '3',
+                '--output-dir', str(tmp_path),
+            ])
+        assert exc.value.code == 2
+        err = capsys.readouterr().err
+        # Both alternatives surfaced — user gets to pick.
+        assert '--vp 0.0300' in err
+        assert '--vp-pct 3' in err
+
 
 class TestMaterialPropertiesPerturb:
     """Unit tests for the MaterialProperties.perturb sampling primitive."""


### PR DESCRIPTION
Fixes #127

## Summary
The Streamlit app collects Vp as a **percentage** (slider 0.1–15, label "Void volume fraction (%)") and divides by 100 internally. The `porosity-analyze` CLI's `--vp` flag historically required a **fraction** in [0, 1]. A user who's used the GUI and tries the CLI naturally types `--vp 3` expecting "3%" and gets a confusing error.

This PR keeps the documented `--vp` contract (fractions, no breaking change for scripted users), adds a new `--vp-pct` alias for callers who'd rather pass percentages, makes the two mutually exclusive, and improves the validation error to suggest both fixes when the value looks like a percentage was passed.

## Changes
- `porosity_fe/cli.py` — `--vp` and `--vp-pct` declared in an argparse mutually-exclusive group; `--vp-pct N` is converted internally to `N / 100.0`. Help text on `--vp` now explicitly calls out the GUI/CLI unit difference.
- `porosity_fe/cli.py` — the validation error for out-of-range `--vp` now appends a hint when the value is in `(1, 100]` (i.e. looks like the user thought in percentages):
  ```
  --vp value 3.0 is out of range; expected a finite float in [0, 1]
  (a void *fraction*, not a percentage). (looks like a percentage;
  did you mean `--vp 0.0300` or `--vp-pct 3.0`?)
  ```

## Smoke tests
```
$ porosity-analyze --vp 0.02          # happy path, unchanged behavior
$ porosity-analyze --vp-pct 2         # new alias, runs as if --vp 0.02
$ porosity-analyze --vp 3             # error with both fix suggestions
$ porosity-analyze --vp 0.03 --vp-pct 3   # argparse rejects: "not allowed with"
```

## Test plan
- [x] Full pytest suite — 514 passed, 1 skipped (+3 new tests in `TestCLIMain`)
- [x] `test_vp_pct_alias_converts_to_fraction` — `--vp-pct 2` reaches `compare_configurations` with `Vp = 0.02`
- [x] `test_vp_pct_and_vp_mutually_exclusive` — passing both exits 2 with "not allowed with" in stderr
- [x] `test_vp_percentage_typo_gets_helpful_hint` — `--vp 3` exits 2 with **both** `--vp 0.0300` and `--vp-pct 3` suggestions in the error
- [x] `ruff check .` — clean
- [x] `mypy porosity_fe porosity_fe_analysis.py` — clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01X5dvvNWcbxZdjeHCZSXDzM)_