### PR TITLE
chore: gitignore coverage.py runtime artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,12 @@ Thumbs.db
 # Pytest
 .pytest_cache/
 
+# Coverage.py artefacts
+.coverage
+.coverage.*
+htmlcov/
+coverage.xml
+
 # Runtime analysis output (from `porosity-analyze` runs, examples, smoke tests)
 porosity_analysis_results_*.json
 porosity_fe_results_*.json


### PR DESCRIPTION
## Why
The coverage-gap scan agent (currently running in a worktree) writes a `.coverage` file at the repo root when it runs `coverage.py`. The stop hook flagged it as untracked. These are runtime artifacts — they shouldn't be committed.

## Patterns added
- `.coverage` — main coverage data file
- `.coverage.*` — per-test-process suffixed files when coverage runs under xdist or fork-based parallel runs
- `htmlcov/` — `coverage html` output directory
- `coverage.xml` — `coverage xml` output (e.g. for Codecov upload)

## Test plan
- [x] `.coverage` no longer appears as untracked after a `coverage run` invocation

---
_Generated by [Claude Code](https://claude.ai/code/session_01X5dvvNWcbxZdjeHCZSXDzM)_