### PR TITLE
chore: gitignore validate_porosity output artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,10 @@ porosity_fe_results_*.npz
 *.vtk
 examples/output/
 
+# Validation pipeline output (from `validate_porosity` runs)
+validation_detail_report.md
+validation_master_report.png
+
 # Sphinx build artefacts
 docs/_build/
 docs/api/


### PR DESCRIPTION
## Why
The doc-drift scan agent ran `validate_porosity` and left `validation_detail_report.md` and `validation_master_report.png` at the repo root. These are runtime outputs of the validation pipeline; they shouldn't be committed.

Pairs with the prior `.coverage` gitignore tweak (#138).

## Patterns added
- `validation_detail_report.md`
- `validation_master_report.png`

---
_Generated by [Claude Code](https://claude.ai/code/session_01X5dvvNWcbxZdjeHCZSXDzM)_