### PR TITLE
Pin validation-branch coverage (#147, #149, #152) + packaging polish (#158)

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,3 +6,10 @@
 include examples/*.py
 include examples/README.md
 include examples/.gitignore
+
+# Top-level metadata files. `license = {text = "MIT"}` in pyproject.toml
+# embeds the license string but does not ship the LICENSE file itself in
+# the sdist; including it here ensures redistributors get the canonical
+# text. CHANGELOG.md is similarly outside any package directory.
+include LICENSE
+include CHANGELOG.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,9 +61,13 @@ all = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/elhajjar1/PorosityFE"
-Repository = "https://github.com/elhajjar1/PorosityFE"
-Issues = "https://github.com/elhajjar1/PorosityFE/issues"
+# This fork (ranipdx-glitch) is the active development home: it owns the
+# GitHub Pages deployment, the active issue tracker, and ongoing PRs.
+# Unify all URLs on this org so PyPI metadata points users at the live
+# project rather than the upstream snapshot.
+Homepage = "https://github.com/ranipdx-glitch/PorosityFE"
+Repository = "https://github.com/ranipdx-glitch/PorosityFE"
+Issues = "https://github.com/ranipdx-glitch/PorosityFE/issues"
 Documentation = "https://ranipdx-glitch.github.io/PorosityFE/"
 
 [project.scripts]

--- a/tests/test_porosity_fe.py
+++ b/tests/test_porosity_fe.py
@@ -2560,6 +2560,46 @@ class TestEnvironmentalKnockdown:
             kd_fat, rel=1e-12)
 
 
+class TestFatigueModelValidation:
+    """#149: pin input-validation branches of FatigueModel.knockdown_factor.
+
+    Covers the three guard clauses that were previously unexercised:
+    - unknown ``mode`` rejected by :meth:`FatigueModel._slope`
+    - non-finite ``R`` rejected up front
+    - ``cycles`` either below 1 or non-finite rejected before slope lookup
+    """
+
+    def setup_method(self):
+        from porosity_fe_analysis import FatigueModel
+        self.FatigueModel = FatigueModel
+
+    def test_unknown_mode_raises(self):
+        """Unknown mode keys must raise ValueError with a descriptive message."""
+        fm = self.FatigueModel()
+        with pytest.raises(ValueError, match=r"Unknown fatigue mode"):
+            fm.knockdown_factor('unknown_mode', cycles=1e6)
+
+    def test_non_finite_R_raises(self):
+        """Non-finite ``R`` (nan / inf / -inf) must be rejected."""
+        fm = self.FatigueModel()
+        for bad_R in (float('nan'), float('inf'), float('-inf')):
+            with pytest.raises(ValueError, match=r"R must be finite"):
+                fm.knockdown_factor('tension', cycles=1e6, R=bad_R)
+
+    def test_cycles_below_one_raises(self):
+        """``cycles < 1`` (below the static one-cycle anchor) is invalid."""
+        fm = self.FatigueModel()
+        with pytest.raises(ValueError, match=r"cycles must be a finite"):
+            fm.knockdown_factor('tension', cycles=0.5)
+
+    def test_cycles_non_finite_raises(self):
+        """Non-finite ``cycles`` (inf / nan) must also be rejected."""
+        fm = self.FatigueModel()
+        for bad_cycles in (float('inf'), float('nan')):
+            with pytest.raises(ValueError, match=r"cycles must be a finite"):
+                fm.knockdown_factor('tension', cycles=bad_cycles)
+
+
 class TestDistributionComparison:
     """#83: uniform vs clustered/interface knockdowns at matched Vp_mean.
 

--- a/tests/test_porosity_fe.py
+++ b/tests/test_porosity_fe.py
@@ -4401,6 +4401,55 @@ class TestCLIMain:
         assert '--vp 0.0300' in err
         assert '--vp-pct 3' in err
 
+    # #147: pin the two uncovered error-handling branches in cli.main so
+    # future refactors can't silently drop the user-facing hints.
+
+    def test_cli_main_vp_out_of_range_with_percentage_hint(
+            self, tmp_path, capsys):
+        """`--vp 5` is in the 1-100 "looks like a percentage" band, so the
+        error must include BOTH the fraction-form suggestion (`--vp 0.0500`)
+        and the percent-alias suggestion (`--vp-pct 5`). Regression for the
+        hint added in #127/#137 — covers cli.py lines ~270-275."""
+        with pytest.raises(SystemExit) as exc:
+            porosity_fe_analysis.main([
+                '--vp', '5',
+                '--output-dir', str(tmp_path),
+            ])
+        # argparse.error() exits with code 2 for invalid usage.
+        assert exc.value.code == 2
+        err = capsys.readouterr().err
+        # Both alternatives must be surfaced so the user can pick.
+        assert '--vp 0.0500' in err
+        assert '--vp-pct 5' in err
+
+    def test_cli_main_output_dir_permission_error(
+            self, tmp_path, monkeypatch, capsys):
+        """If ``os.makedirs`` raises OSError (e.g. permission denied or an
+        invalid path), the CLI must surface the failure on stderr and
+        return exit code 2 rather than crashing with a traceback. Covers
+        cli.py lines ~284-287."""
+        def _raise_permission_error(*args, **kwargs):
+            raise PermissionError("denied")
+
+        # Patch ``os.makedirs`` on the cli module so the call inside
+        # main() picks up the raising stub. The shim doesn't re-export
+        # the cli submodule, so import it via the package directly.
+        from porosity_fe import cli as _cli_mod
+        monkeypatch.setattr(
+            _cli_mod.os, 'makedirs',
+            _raise_permission_error,
+        )
+        rc = porosity_fe_analysis.main([
+            '--vp', '0.02',
+            '--output-dir', str(tmp_path / 'nope'),
+            '--quiet',
+        ])
+        assert rc == 2
+        err = capsys.readouterr().err
+        # Error message should mention the underlying failure so the user
+        # knows what went wrong.
+        assert 'denied' in err.lower() or 'permission' in err.lower()
+
 
 class TestMaterialPropertiesPerturb:
     """Unit tests for the MaterialProperties.perturb sampling primitive."""

--- a/tests/test_results_schema_roundtrip.py
+++ b/tests/test_results_schema_roundtrip.py
@@ -165,3 +165,83 @@ def test_json_default_rejects_unknown_type():
 
     with pytest.raises(TypeError, match="not JSON serializable"):
         _json_default(_Opaque())
+
+
+def test_save_results_hostname_opt_in_via_env(tmp_path, monkeypatch):
+    """#152: ``provenance.hostname`` is opt-in via
+    ``POROSITY_FE_INCLUDE_HOSTNAME``. When the env var is set the field
+    is populated with a non-empty string; when unset the key is omitted
+    from the provenance block entirely (no workstation-name leakage).
+    """
+    results = _tiny_results()
+
+    # Opt-in: env var set to a truthy value -> hostname populated.
+    monkeypatch.setenv("POROSITY_FE_INCLUDE_HOSTNAME", "1")
+    on_path = str(tmp_path / "with_host.json")
+    save_results_to_json(results, on_path)
+    with open(on_path, encoding="utf-8") as f:
+        prov_on = json.load(f)["provenance"]
+    assert "hostname" in prov_on
+    assert isinstance(prov_on["hostname"], str)
+    assert prov_on["hostname"]  # non-empty
+
+    # Default: env var unset -> hostname key absent from the provenance.
+    monkeypatch.delenv("POROSITY_FE_INCLUDE_HOSTNAME", raising=False)
+    off_path = str(tmp_path / "no_host.json")
+    save_results_to_json(results, off_path)
+    with open(off_path, encoding="utf-8") as f:
+        prov_off = json.load(f)["provenance"]
+    assert "hostname" not in prov_off
+
+
+def test_save_results_config_name_collision_raises(tmp_path):
+    """#152: a user-supplied ConfigResult keyed with one of the reserved
+    envelope keys (``'schema_version'`` / ``'format'``) must raise
+    ValueError rather than silently overwrite the envelope on disk.
+    """
+    results = _tiny_results()
+    original = next(iter(results.values()))
+    colliding = {"schema_version": original}
+
+    path = str(tmp_path / "collision.json")
+    with pytest.raises(ValueError, match="collides"):
+        save_results_to_json(colliding, path)
+
+
+def test_save_results_legacy_dict_shape_still_works(tmp_path):
+    """#152: the pre-#103 ``Dict[str, dict]`` shape (raw worker-dict with
+    ``porosity_field`` / ``config`` / ``empirical`` keys) must still
+    round-trip through save_results_to_json so callers that haven't
+    migrated to ConfigResult keep working.
+    """
+    # Borrow real numbers from a tiny sweep, then re-shape them into the
+    # legacy worker-dict that predates ConfigResult.
+    cr = _tiny_results()["uniform_spherical"]
+
+    class _PFStub:
+        # Legacy path reads only ``.Vp`` off the porosity_field object.
+        Vp = cr.Vp
+        seed = cr.seed
+
+    legacy_results = {
+        "uniform_spherical": {
+            "porosity_field": _PFStub(),
+            "config": cr.config,
+            "empirical": cr.empirical,
+        },
+    }
+
+    path = str(tmp_path / "legacy.json")
+    save_results_to_json(legacy_results, path)
+
+    loaded = load_results_from_json(path)
+    assert loaded["schema_version"] == JSON_SCHEMA_VERSION
+    assert loaded["format"] == FORMAT_EMPIRICAL_SWEEP
+    assert "uniform_spherical" in loaded
+    assert loaded["uniform_spherical"]["void_volume_fraction"] == float(cr.Vp)
+    # Empirical knockdown table survives the round-trip.
+    assert (
+        loaded["uniform_spherical"]["empirical"]["compression"]["judd_wright"]
+        ["knockdown"]
+        == cr.empirical["compression"]["judd_wright"]["knockdown"]
+    )


### PR DESCRIPTION
Four small, independent improvements from the codebase-enhancement scan, bundled together.

## Closes

- Closes #149 — pin `FatigueModel.knockdown_factor` mode / R / cycles validation branches
- Closes #152 — pin JSON I/O hostname-opt-in, config-name collision, and legacy dict-shape branches
- Closes #147 — pin CLI `--vp` percentage-hint and output-dir `OSError` branches
- Closes #158 — packaging polish: explicit `LICENSE` / `CHANGELOG.md` in `MANIFEST.in`; unify `[project.urls]` on `ranipdx-glitch`

## Changes

**Test coverage (9 new tests)**
- `tests/test_porosity_fe.py` — `TestFatigueModelValidation` (4 tests: unknown mode, non-finite R, cycles < 1, non-finite cycles) and 2 new `TestCLIMain` cases (`test_cli_main_vp_out_of_range_with_percentage_hint`, `test_cli_main_output_dir_permission_error`).
- `tests/test_results_schema_roundtrip.py` — 3 new tests: `test_save_results_hostname_opt_in_via_env`, `test_save_results_config_name_collision_raises`, `test_save_results_legacy_dict_shape_still_works`.

**Packaging**
- `MANIFEST.in`: explicit `include LICENSE` and `include CHANGELOG.md` so the sdist doesn't depend on setuptools' default-include behavior.
- `pyproject.toml`: `[project.urls]` now consistently points at `ranipdx-glitch/PorosityFE` (this fork owns the active Pages deployment, the issues, and PR #161); the upstream `elhajjar1` URLs were the inconsistent half.

No production code paths were touched. The new tests pin behavior; the packaging change is metadata only.

## Test plan

- [x] `pytest tests/ -q` — 523 passed, 1 skipped (was 514 before this branch)
- [x] sdist build verified to contain `LICENSE` and `CHANGELOG.md` (`tar tzf dist/*.tar.gz | grep -iE 'license|changelog'`)
- [ ] CI green across the 12-entry matrix on this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_01L1ovdBYzTQRV4DKwSR4JmC)_