### PR TITLE
Pin parallel-sweep / UQ / oblate-Eshelby coverage (#143, #153, #154) + Hashin docstring (#142)

### DIFF
--- a/porosity_fe/fe/solver.py
+++ b/porosity_fe/fe/solver.py
@@ -1015,7 +1015,12 @@ class FESolver:
                          ) -> Dict[str, np.ndarray]:
         """2D Hashin failure indices for unidirectional plies.
 
-        Implements the standard four-mode Hashin criterion (Hashin, 1980).
+        Implements the Hashin (1980) 2D criterion with separate fiber/matrix
+        tension/compression modes. Reference:
+
+            Hashin, Z. (1980). "Failure Criteria for Unidirectional Fiber
+            Composites." J. Appl. Mech. 47(2), 329-334.
+
         Indices are computed per Gauss point on the in-plane local stresses
         ``(σ_11, σ_22, τ_12)``; ``σ_33`` and out-of-plane shears are ignored
         because the standard formulation is 2D. The ``shear`` slot returns
@@ -1023,6 +1028,32 @@ class FESolver:
 
         Returns a dict of per-GP arrays:
         ``{'max_fi', 'fiber_t', 'fiber_c', 'matrix_t', 'matrix_c', 'shear'}``.
+
+        Notes
+        -----
+        "Hashin" is a family of criteria rather than a single canonical form.
+        Commercial codes (ANSYS, Abaqus's user-material variants, LS-DYNA's
+        ``MAT_LAMINATED_COMPOSITE_FABRIC``, etc.) ship slightly different
+        variants of the matrix-compression mode in particular. The two most
+        common deviations from the 1980 paper are:
+
+        1. **Matrix-compression denominator.** The 1980 paper uses
+           ``(2·S_23)^2`` together with the ``((Y_c / (2·S_23))^2 - 1) ·
+           (σ_22 / Y_c)`` cross term; some codes substitute plain ``S_23``,
+           others reformulate the denominator entirely (e.g. ``(2·S_23)^2 -
+           (S_23 - Y_c)^2`` style expressions).
+        2. **Shear strength in the matrix-compression term.** The 1980 paper
+           uses ``S_12`` (in-plane shear) in the ``(τ_12 / S_12)^2``
+           contribution to matrix compression; some commercial implementations
+           swap this for ``S_23`` (through-thickness shear), which changes
+           predictions for transversely-loaded plies.
+
+        The PorosityFE implementation matches the 1980 paper exactly:
+        matrix-compression uses ``(2·S_23)^2`` as the normal-stress denominator
+        and ``S_12`` in the shear term. Users comparing PorosityFE indices
+        against an external Hashin reference (commercial solver, textbook,
+        or another open-source code) should verify the variant convention
+        on the other side before treating any divergence as a bug.
         """
         Xt_s, Xc_s, Yt_s, Yc_s, S12_s, S23_s = strengths
         sigma_11 = s_all[:, 0]

--- a/tests/test_porosity_fe.py
+++ b/tests/test_porosity_fe.py
@@ -4755,6 +4755,56 @@ class TestPropagateUncertainty:
             propagate_uncertainty(0.02, 'T800_epoxy',
                                   covs={'not_a_field': 0.1}, n_samples=4)
 
+    # Issue #153: pin the input-validation branches in propagate_uncertainty,
+    # _normalize_uq_spec, and _draw_unit_samples. These are advanced-user
+    # guard rails -- the messages are exactly what someone debugging an
+    # unusual UQ input needs, so a silent regression would hurt.
+
+    def test_invalid_field_raises(self):
+        with pytest.raises(ValueError, match="non-perturbable"):
+            propagate_uncertainty(0.02, 'T800_epoxy',
+                                  covs={'not_a_field': 0.1},
+                                  n_samples=self._N)
+
+    def test_invalid_sampling_method_raises(self):
+        with pytest.raises(ValueError, match="Unknown sampling method"):
+            propagate_uncertainty(0.02, 'T800_epoxy',
+                                  covs={'sigma_1c': 0.08},
+                                  n_samples=self._N,
+                                  method='importance_sampling')
+
+    def test_invalid_percentile_raises(self):
+        with pytest.raises(ValueError, match=r"percentiles must lie in \[0, 100\]"):
+            propagate_uncertainty(0.02, 'T800_epoxy',
+                                  covs={'sigma_1c': 0.08},
+                                  n_samples=self._N,
+                                  percentiles=(5, 150))
+
+    def test_non_positive_n_samples_raises(self):
+        with pytest.raises(ValueError, match="n_samples must be a positive integer"):
+            propagate_uncertainty(0.02, 'T800_epoxy',
+                                  covs={'sigma_1c': 0.08},
+                                  n_samples=0)
+        with pytest.raises(ValueError, match="n_samples must be a positive integer"):
+            propagate_uncertainty(0.02, 'T800_epoxy',
+                                  covs={'sigma_1c': 0.08},
+                                  n_samples=-1)
+
+    def test_unknown_material_raises(self):
+        with pytest.raises(ValueError, match="Unknown material"):
+            propagate_uncertainty(0.02, 'nonsense',
+                                  covs={'sigma_1c': 0.08},
+                                  n_samples=self._N)
+
+    def test_malformed_spec_tuple_raises(self):
+        # The (distribution, params) shape check lives on the `spec=` path;
+        # passing a 1-tuple there should fail with the documented message.
+        with pytest.raises(ValueError,
+                           match=r"must be a \(distribution, params\) pair"):
+            propagate_uncertainty(0.02, 'T800_epoxy',
+                                  spec={'E11': (0.1,)},
+                                  n_samples=self._N)
+
 
 # Issue #65: closed-form local sensitivities + per-point validation bands.
 class TestLocalSensitivities:

--- a/tests/test_porosity_fe.py
+++ b/tests/test_porosity_fe.py
@@ -4190,6 +4190,16 @@ def _extract_knockdowns(results: dict) -> dict:
     return flat
 
 
+def _crashing_worker(*args, **kwargs):
+    """Module-level stand-in for ``_analyze_one`` used by the parallel
+    exception-propagation test (#154).
+
+    Has to live at module scope so ``ProcessPoolExecutor`` can pickle it
+    by qualified name when ``compare_configurations`` submits tasks.
+    """
+    raise RuntimeError("Worker crash")
+
+
 class TestParallelSweep:
     """Parallel ``compare_configurations`` path (#52)."""
 
@@ -4267,6 +4277,52 @@ class TestParallelSweep:
         p_flat = _extract_knockdowns(also_serial)
         for k in s_flat:
             assert p_flat[k] == s_flat[k]
+
+    def test_parallel_worker_exception_propagates(self, monkeypatch):
+        """A worker exception must re-raise in the parent, not be
+        silently swallowed (#154).
+
+        ``compare_configurations`` collects parallel results via
+        ``future.result()`` inside an ``as_completed`` loop; that call
+        re-raises whatever the worker raised. We pin that contract by
+        monkeypatching ``_analyze_one`` on the pipeline module to raise
+        ``RuntimeError`` unconditionally. On Linux the
+        ``ProcessPoolExecutor`` default start method is fork, so the
+        child inherits the patched module attribute and the exception
+        crosses the process boundary as expected.
+        """
+        from porosity_fe import pipeline as _pipeline
+
+        monkeypatch.setattr(_pipeline, "_analyze_one", _crashing_worker)
+
+        # Two configs so we actually take the parallel branch
+        # (``len(tasks) > 1`` and ``workers > 1``).
+        configs = {
+            'uniform_spherical': POROSITY_CONFIGS['uniform_spherical'],
+            'clustered_midplane': POROSITY_CONFIGS['clustered_midplane'],
+        }
+        with pytest.raises(RuntimeError, match="Worker crash"):
+            compare_configurations(0.03, configs=configs, n_jobs=2)
+
+    def test_parallel_results_assembled_by_config_name(self):
+        """Result-dict key order must match caller-supplied config insertion
+        order, never worker completion order (#154).
+
+        ``as_completed`` yields futures in completion order, which is
+        non-deterministic, so the assembly loop has to re-iterate the
+        original ``configs`` mapping. We run the sweep 10 times with
+        distinctive names to make any worker-completion-order leak
+        obvious; even a single iteration with reversed keys would fail.
+        """
+        configs = {
+            'cfg_alpha': POROSITY_CONFIGS['uniform_spherical'],
+            'cfg_beta': POROSITY_CONFIGS['clustered_midplane'],
+        }
+        expected_order = list(configs.keys())
+        for _ in range(10):
+            results = compare_configurations(
+                0.03, configs=configs, n_jobs=2)
+            assert list(results.keys()) == expected_order
 
 
 class TestCLIMain:

--- a/tests/test_porosity_fe.py
+++ b/tests/test_porosity_fe.py
@@ -1152,6 +1152,160 @@ class TestMTEffectiveStiffness:
         assert b[0, 0] > a[0, 0]
 
 
+class TestOblateMTValidation:
+    """Regression pin for the oblate (penny-void) Eshelby branch (#143).
+
+    Issue #32 fixed an earlier bug where oblate (alpha < 1) voids were
+    silently routed to the prolate Eshelby g-function. The current
+    implementation in ``_mt_effective_stiffness`` selects the correct
+    g-function on ``alpha > 1.0`` vs the ``else`` (alpha <= 1) branch.
+    The math is correct; these tests pin numerical snapshots of the
+    post-#32 behavior so that future refactors are forced to confirm
+    they reproduce the same Mori-Tanaka output.
+
+    Reference: Mura, T. (1987) *Micromechanics of Defects in Solids* §11
+    and Nemat-Nasser & Hori (1999) §7.4 describe the prolate/oblate
+    Eshelby tensor split. No closed-form analytical value is hand-
+    derived here; the snapshots in ``test_oblate_transverse_stiffness_
+    regression_pin`` are pinned from the current correct implementation
+    (a regression pin, per the issue's note that the math is already
+    right).
+    """
+
+    def setup_method(self):
+        self.mat = MATERIALS['T800_epoxy']
+        self.C_m = self.mat.get_isotropic_matrix_stiffness()
+        self.nu_m = self.mat.matrix_poisson
+
+    def test_sphere_limit_oblate_matches_prolate(self):
+        """As alpha -> 1, the prolate and oblate branches must converge to the
+        same sphere result (analytic continuation across alpha = 1).
+
+        Note on tolerance: the issue text proposed ``atol=1e-12``, but at
+        ``alpha = 1`` exactly both branches divide by (alpha^2 - 1) and are
+        singular. The smallest aspect-ratio offset that still bypasses the
+        function's internal sphere shortcut (which fires when all three
+        radii are within 1% of each other) is eps ~ 0.011. At that offset
+        the prolate(1+eps) and oblate(1-eps) results are two physically
+        different configurations and necessarily differ at O(eps), so a
+        bit-exact match is mathematically impossible. We pin the looser
+        but still tight tolerance that actually holds. Measured gap at
+        eps=0.011: |Cp - Co|_inf / |Csph|_inf ~ 3.5e-3.
+        """
+        eps = 0.011  # just outside the 1% sphere shortcut
+        # Compute the sphere baseline via the function's sphere shortcut
+        # (radii all equal => short-circuit branch).
+        from porosity_fe_analysis import _mt_cache_clear
+        _mt_cache_clear()
+        C_sphere = _mt_effective_stiffness(
+            self.C_m, 0.05, (1.0, 1.0, 1.0), self.nu_m)
+        _mt_cache_clear()
+        C_prolate = _mt_effective_stiffness(
+            self.C_m, 0.05, (1.0, 1.0, 1.0 + eps), self.nu_m)
+        _mt_cache_clear()
+        C_oblate = _mt_effective_stiffness(
+            self.C_m, 0.05, (1.0, 1.0, 1.0 - eps), self.nu_m)
+
+        scale = np.max(np.abs(C_sphere))
+        # Each branch is within ~0.2% of the sphere result at eps=0.011.
+        np.testing.assert_allclose(C_prolate, C_sphere, atol=0.005 * scale)
+        np.testing.assert_allclose(C_oblate, C_sphere, atol=0.005 * scale)
+        # Cross-difference (both branches agree near the sphere limit)
+        # to ~0.5% — pins that the formulas are analytic continuations.
+        np.testing.assert_allclose(C_prolate, C_oblate, atol=0.01 * scale)
+
+    def test_oblate_transverse_stiffness_regression_pin(self):
+        """Snapshot pin for a penny-shaped void (alpha = 0.01) at 5% porosity.
+
+        Regression pin per #143; snapshot of post-#32 behavior. Penny axis
+        is along x_3 (radii = (1, 1, 0.01)), so x_1 / x_2 are the in-plane
+        (transverse to the disk axis) directions. ``C_eff[1, 1]`` is the
+        in-plane stiffness perpendicular to the penny axis.
+
+        These values were generated from the current implementation and
+        will catch any silent regression in the oblate g-function or the
+        Voigt permutation that maps the canonical-frame Eshelby tensor
+        onto the actual axis.
+        """
+        from porosity_fe_analysis import _mt_cache_clear
+        _mt_cache_clear()
+        C_eff = _mt_effective_stiffness(
+            self.C_m, 0.05, (1.0, 1.0, 0.01), self.nu_m)
+        # Snapshot to ~5 significant figures; rtol=1e-4 catches numerically
+        # meaningful regressions while tolerating cross-platform FP noise.
+        assert C_eff[1, 1] == pytest.approx(5345.6799, rel=1e-4)
+        assert C_eff[0, 0] == pytest.approx(5345.6799, rel=1e-4)
+        # Off-diagonal in-plane coupling (also pinned)
+        assert C_eff[0, 1] == pytest.approx(2884.2736, rel=1e-4)
+        # Penny in-plane transverse isotropy: C[0,0] == C[1,1] exactly.
+        assert C_eff[0, 0] == pytest.approx(C_eff[1, 1], rel=1e-12)
+
+    def test_oblate_monotonic_in_vp(self):
+        """Increasing porosity must monotonically reduce transverse stiffness
+        for an oblate (penny) void at fixed aspect ratio.
+        """
+        from porosity_fe_analysis import _mt_cache_clear
+        Vps = [0.001, 0.01, 0.03, 0.05]
+        C22_values = []
+        for Vp in Vps:
+            _mt_cache_clear()
+            C = _mt_effective_stiffness(
+                self.C_m, Vp, (1.0, 1.0, 0.01), self.nu_m)
+            C22_values.append(C[1, 1])
+        C22_values = np.array(C22_values)
+        assert np.all(np.diff(C22_values) < 0), (
+            f"transverse stiffness not strictly decreasing in Vp: {C22_values}"
+        )
+
+    def test_oblate_more_severe_than_prolate_at_matched_vp(self):
+        """At matched Vp, compare oblate (penny) vs prolate (needle) transverse
+        stiffness reduction.
+
+        Note on the issue's expected inequality (#143): the issue text
+        predicted that penny (oblate) voids would degrade C[1, 1] *more*
+        than prolate (needle) voids at matched Vp. That intuition is
+        wrong for the canonical orientation:
+
+        - Penny axis along x_3 (radii = (1, 1, 0.01)) means the disk lies
+          IN the x_1-x_2 plane. Loads along x_1 (i.e. C[1, 1]) travel
+          along the long in-plane dimension of the disk and barely see
+          the void — degradation is mild (ratio ~ 0.952 at Vp = 0.05).
+          The brutal direction is C[2, 2] (through-thickness, where the
+          load is forced across the penny's short axis); this matches
+          the existing ``test_penny_void_anisotropy_along_short_axis``
+          regression for #32.
+        - Prolate along x_3 (radii = (1, 1, 100)) is a long needle.
+          Transverse loads (C[1, 1]) have to flow around the entire
+          length of the needle — degradation is severe (ratio ~ 0.833
+          at Vp = 0.05).
+
+        So at matched Vp, prolate degrades C[1, 1] MORE than oblate, not
+        less. We pin the actual (correct) physics here rather than the
+        issue's predicted inequality.
+        """
+        from porosity_fe_analysis import _mt_cache_clear
+        Vp = 0.05
+        _mt_cache_clear()
+        C_oblate = _mt_effective_stiffness(
+            self.C_m, Vp, (1.0, 1.0, 0.01), self.nu_m)
+        _mt_cache_clear()
+        C_prolate = _mt_effective_stiffness(
+            self.C_m, Vp, (1.0, 1.0, 100.0), self.nu_m)
+
+        ratio_oblate = C_oblate[1, 1] / self.C_m[1, 1]
+        ratio_prolate = C_prolate[1, 1] / self.C_m[1, 1]
+        # Actual measured ratios (snapshotted): oblate ~0.952, prolate ~0.833.
+        # Prolate is MORE severe on the transverse C[1, 1] component.
+        assert ratio_prolate < ratio_oblate, (
+            f"expected prolate C[1,1] reduction stronger than oblate; "
+            f"got oblate={ratio_oblate:.4f}, prolate={ratio_prolate:.4f}"
+        )
+        # Pin the numerical values too so the inequality direction can't
+        # silently flip without flagging the snapshot.
+        assert ratio_oblate == pytest.approx(0.9516, rel=1e-3)
+        assert ratio_prolate == pytest.approx(0.8328, rel=1e-3)
+
+
 class TestDegradedCompositeStiffness:
     """Direct unit tests for _degraded_composite_stiffness (#48).
 


### PR DESCRIPTION
Three coverage-pin issues + one docstring fix. All independent changes.

## Closes

- Closes #142 — cite Hashin (1980), document variant differences in `_evaluate_hashin`
- Closes #143 — regression-pin the oblate (penny-void) Eshelby branch in `_mt_effective_stiffness`
- Closes #153 — pin `propagate_uncertainty` input-validation branches
- Closes #154 — pin parallel-sweep worker exception propagation and result ordering

## Changes

**Test coverage (+12 tests)**
- `TestParallelSweep` (+2): worker exception propagation (verified via `monkeypatch` on `_analyze_one` — works because fork lets the child process see the patched module attribute), and result-dict ordering invariant (10x loop, asserts insertion-order keying regardless of completion order). Adds a module-level `_crashing_worker` helper so `ProcessPoolExecutor` can pickle it.
- `TestPropagateUncertainty` (+6): invalid field, invalid sampling method, out-of-range percentile, non-positive `n_samples`, unknown material, malformed spec tuple. Two minor deviations from the issue text: the kwarg is `material=`, not `material_name=`; and the malformed-tuple check lives on the `spec=` path (`covs=` only takes scalars), so the test uses `spec=` to hit the actual validator.
- New `TestOblateMTValidation` (+4): sphere-limit equivalence between oblate and prolate branches, regression-pin of `C_eff[1,1] = 5345.6799` at `alpha=0.01, Vp=5%` for T800/epoxy, monotonic decrease in `Vp`, and oblate vs. prolate severity.

**⚠️ Finding on #143**: The issue's stated inequality direction (`C_oblate[1,1] / C_pristine < C_prolate[1,1] / C_pristine`) is **reversed in the actual physics** — penny voids along `x3` barely touch in-plane stiffness (`C[1,1]/C_m = 0.952`) while long needles along `x3` force transverse loads to flow around the full needle length (`C[1,1]/C_m = 0.833`). The existing `test_penny_void_anisotropy_along_short_axis` (#32) already confirms penny voids degrade their short-axis direction most strongly, consistent with this finding. The new test pins the *correct* direction and the test docstring explains why. Sphere-limit tolerance was loosened from the issue's suggested `atol=1e-12` to `~5e-3` because the prolate/oblate g-functions divide by `(alpha²-1) = 0` exactly at `alpha=1` and the code short-circuits to a separate sphere formula near it — the closest alpha that bypasses the shortcut is `~1.011`, which is physically distinct from a sphere at O(eps). Rationale documented in the test.

**Docstring (#142)**
- `FESolver._evaluate_hashin` now cites Hashin (1980) explicitly and adds a Notes block describing the two common deviations in commercial codes (matrix-compression denominator; `S_12` vs `S_23` in the shear term). README has no Hashin section to update; only Tsai-Wu is referenced there.

No production code paths were touched.

## Test plan

- [x] `pytest tests/ -q` — 550 passed, 1 skipped (was 538 on master)
- [x] No flaky behavior in `TestParallelSweep` (the 10-iteration ordering loop ran clean)
- [ ] CI green on this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_01L1ovdBYzTQRV4DKwSR4JmC)_