### PR TITLE
Validation FD bands (#144), Tsai-Wu F12 override (#145), strength-degradation docs (#141), layup-scale findings (#140)

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,6 +450,17 @@ Full 3D Tsai-Wu with degraded strengths:
 F1*s1 + F2*s2 + F11*s1^2 + F22*s2^2 + F66*s6^2 + 2*F12*s1*s2 = 1
 ```
 
+**Tsai-Wu `F_12` convention (caveat for external comparisons).** When
+benchmarking PorosityFE Tsai-Wu predictions against another code or
+reference dataset, confirm the in-plane interaction coefficient `F_12`
+convention matches. PorosityFE uses Tsai's recommendation
+`F_12 = -0.5 * sqrt(F_11 * F_22)` (Tsai & Wu, 1971) by default — an
+empirical choice, not a first-principles derivation. The exact value
+varies with the material system; if you have biaxial coupon
+calibration data, override it per-material via
+`MaterialProperties(tsai_wu_F12=...)` (must lie in `[-1, 0]` for a
+closed envelope).
+
 ## Validation
 
 PorosityFE is validated against **13 peer-reviewed experimental datasets**

--- a/README.md
+++ b/README.md
@@ -270,6 +270,27 @@ robust.)
 A runnable side-by-side comparison (table + two PNGs) lives in
 [`examples/distribution_comparison.py`](examples/distribution_comparison.py).
 
+### Solver selection: FE vs. empirical
+
+Both solver paths predict porosity knockdown, but they use different
+physics for the strength-degradation step. The empirical solver
+(`EmpiricalSolver`) applies calibrated closed-form correlations
+(Judd-Wright, power-law, linear) fit to coupon data. The FE solver
+(`FESolver`) instead applies a heuristic sqrt scaling on per-component
+ply strengths (`strength ~ sqrt(stiffness_retention)`; see
+`FESolver._degraded_strengths`). These are fundamentally different
+mathematical forms, so the two paths will give numerically different
+knockdowns for the same `(layup, Vp)` -- this divergence is by design,
+not a bug.
+
+Guidance on which to use:
+
+- **Empirical solver** -- fast screening, headline knockdown numbers,
+  and comparison against published coupon data.
+- **FE solver** -- stress-field analysis, per-element failure criteria
+  (Tsai-Wu / Hashin / max-stress), and any study that needs the full
+  mesh-level result.
+
 ## Output Files
 
 | File Pattern | Description |

--- a/porosity_fe/empirical.py
+++ b/porosity_fe/empirical.py
@@ -197,6 +197,17 @@ class EmpiricalSolver:
                 total += 0.5
         return total / len(ply_angles)
 
+    # TODO(#140): The linear f_md / _F_MD_REF scaling is preserved here for
+    # historical compatibility. Investigation in #140 measured a relative
+    # error of up to 33.5% against a CLT-derived stiffness-retention proxy
+    # (sqrt(Ex_layup(Vp)/Ex_layup(0)) / sqrt(Ex_QI(Vp)/Ex_QI(0)) over
+    # Vp in [0.005, 0.05]) for a UD [0,0,0]_s layup; >5% error also seen
+    # on UD-heavy [0_2,90]_s and off-axis [0,15,-15]_s layups. A
+    # polynomial or interpolated lookup should be evaluated against an
+    # independent reference dataset (FE simulation or experimental
+    # coupons spanning the intermediate f_md range) before the scaling
+    # is replaced. See TestLayupScaleRegressionPin in
+    # tests/test_porosity_fe.py.
     def _layup_scale(self, mode: str) -> float:
         """Scaling factor for empirical coefficients based on layup.
 

--- a/porosity_fe/fe/solver.py
+++ b/porosity_fe/fe/solver.py
@@ -346,7 +346,12 @@ class FESolver:
         Default failure criterion used by :meth:`solve` when no per-call
         override is supplied. ``'tsai_wu'`` (default) applies the
         quadratic Tsai-Wu interaction polynomial and preserves the
-        historical bit-identical behavior. ``'hashin'`` uses the Hashin
+        historical bit-identical behavior. The Tsai-Wu in-plane
+        interaction coefficient ``F_12`` is taken from
+        :attr:`MaterialProperties.tsai_wu_F12` when set; otherwise the
+        Tsai & Wu (1971) recommendation
+        ``F_12 = -0.5 * sqrt(F_11 * F_22)`` is used (see
+        :meth:`_evaluate_tsai_wu`). ``'hashin'`` uses the Hashin
         2D criterion with separate fiber/matrix tension/compression
         modes. ``'max_stress'`` uses an uncoupled maximum-stress check
         against each lamina strength. Validated against
@@ -1001,8 +1006,31 @@ class FESolver:
                           e: int, elem_Vp: float) -> np.ndarray:
         """Tsai-Wu polynomial evaluated for one element's Gauss points.
 
-        Bit-identical to the historical implementation. Returns the per-GP
-        failure index array (shape ``(n_gp,)``).
+        The diagonal coefficients ``F1, F2, F11, F22, F33, F44, F55, F66``
+        follow directly from the lamina strength allowables. The off-
+        diagonal interaction coefficient defaults to::
+
+            F_12 = -0.5 * sqrt(F_11 * F_22)
+
+        which is **Tsai's empirical recommendation** (Tsai & Wu 1971), not
+        a first-principles derivation: it produces a closed failure
+        envelope that reduces to the von Mises-like ellipse in the
+        isotropic limit, but the "true" value varies with the material
+        system and ideally comes from biaxial coupon calibration. The
+        default may be overridden per-material by setting
+        :attr:`MaterialProperties.tsai_wu_F12` to a value in ``[-1, 0]``;
+        when set, that user value is used in place of the recommendation.
+        ``F_13`` continues to mirror ``F_12``, and ``F_23`` retains the
+        analogous Tsai recommendation ``-0.5 * sqrt(F_22 * F_33)``.
+
+        Bit-identical to the historical implementation when
+        ``material.tsai_wu_F12 is None``. Returns the per-GP failure index
+        array (shape ``(n_gp,)``).
+
+        References
+        ----------
+        Tsai, S. W. & Wu, E. M. (1971). "A General Theory of Strength for
+        Anisotropic Materials." *J. Composite Materials* 5(1), 58-80.
         """
         Xt_s, Xc_s, Yt_s, Yc_s, S12_s, S23_s = strengths
         with np.errstate(over='ignore', invalid='ignore', divide='ignore'):
@@ -1019,7 +1047,14 @@ class FESolver:
             # products in case future refactors break the F11/F22/F33 sign.
             F11_F22 = max(F11 * F22, 0.0)
             F22_F33 = max(F22 * F33, 0.0)
-            F12 = -0.5 * np.sqrt(F11_F22)
+            # Issue #145: honour a user-supplied F_12 when provided.
+            # Validation (None or finite in [-1, 0]) is enforced by
+            # MaterialProperties.__post_init__, so trust the value here.
+            user_F12 = getattr(self.material, 'tsai_wu_F12', None)
+            if user_F12 is None:
+                F12 = -0.5 * np.sqrt(F11_F22)
+            else:
+                F12 = float(user_F12)
             F13 = F12
             F23 = -0.5 * np.sqrt(F22_F33)
 

--- a/porosity_fe/fe/solver.py
+++ b/porosity_fe/fe/solver.py
@@ -796,6 +796,39 @@ class FESolver:
         stiffness ratio. Strengths are clamped to a small numerical floor so
         the per-criterion polynomial cannot divide by zero.
 
+        Scaling rule
+        ------------
+        Per-component strengths are scaled by the square root of the
+        corresponding stiffness retention ratio. Concretely, for the
+        matrix-dominated components::
+
+            r_matrix = sqrt(C_eff[0, 0] / C_pristine[0, 0])
+            Yt  = sigma_2t  * r_matrix
+            Yc  = sigma_2c  * r_matrix
+            S12 = tau_12    * r_matrix
+            S23 = tau_ilss  * r_matrix
+
+        and analogously for the fiber-direction components via a rule-of-
+        mixtures effective-modulus ratio (also taken under a square root).
+
+        Heuristic correlation: per-component strength scales as the square
+        root of the stiffness retention ratio. Loosely motivated by Puck-
+        style strength-stiffness coupling (Puck & Schurmann 2002), but not
+        directly derived from a published model and not validated against
+        experimental degraded-strength data within PorosityFE. Alternative
+        scalings exist in the literature -- e.g. linear (``r``), quadratic
+        (``r**2``), and Davila-style critical-element forms -- and a future
+        kwarg may surface them; today only the sqrt rule is implemented.
+
+        FE vs. empirical divergence
+        ---------------------------
+        The empirical solver uses calibrated knockdown forms (Judd-Wright,
+        power-law, linear) for the same physical effect; the two paths use
+        fundamentally different mathematical forms, so FE and empirical
+        predictions may diverge for the same ``(layup, Vp)``. This is by
+        design -- see the README section on Solver Selection (FE vs.
+        empirical) for guidance on which path to trust for which question.
+
         Parameters
         ----------
         elem_Vp : float

--- a/porosity_fe/materials.py
+++ b/porosity_fe/materials.py
@@ -61,6 +61,13 @@ class MaterialProperties:
     fiber_volume_fraction : float
         Pristine fiber volume fraction ``V_f``, as a fraction in
         ``(0, 1)`` (e.g. ``0.60`` for a 60 % fiber laminate).
+    tsai_wu_F12 : float, optional
+        Tsai-Wu in-plane interaction coefficient (dimensionless).
+        ``None`` (default) defers to Tsai's recommendation
+        ``F_12 = -0.5 * sqrt(F_11 * F_22)`` (Tsai & Wu 1971) inside
+        :meth:`FESolver._evaluate_tsai_wu`. When provided, must lie in
+        ``[-1, 0]`` so the quadratic failure envelope stays closed; for
+        critical applications, calibrate against biaxial coupon data.
 
     Attributes
     ----------
@@ -150,6 +157,11 @@ class MaterialProperties:
     M_ref: float = 0.0                  # Reference moisture (wt %)
     T_g_dry: Optional[float] = None     # Dry glass-transition temperature (deg C)
 
+    # Tsai-Wu interaction coefficient. None (default) -> use Tsai's
+    # recommendation F_12 = -0.5 * sqrt(F_11 * F_22). For critical
+    # applications, calibrate against biaxial coupon data.
+    tsai_wu_F12: Optional[float] = None
+
     def __post_init__(self):
         # Stiffness moduli must be positive finite (non-zero for 1/E in compliance).
         for name in ('E11', 'E22', 'E33', 'G12', 'G13', 'G23',
@@ -227,6 +239,26 @@ class MaterialProperties:
                 f"MaterialProperties.M_ref (moisture wt%) must be >= 0, "
                 f"got {self.M_ref!r}."
             )
+
+        # Tsai-Wu interaction coefficient (issue #145). ``None`` defers to
+        # Tsai's recommendation F_12 = -0.5 * sqrt(F_11 * F_22) inside
+        # :meth:`FESolver._evaluate_tsai_wu`. When the user supplies a
+        # value, require a finite number in [-1, 0] so the quadratic
+        # failure envelope stays closed (physically meaningful). The exact
+        # value within that range is left to user judgement / biaxial
+        # calibration data.
+        if self.tsai_wu_F12 is not None:
+            if (not isinstance(self.tsai_wu_F12, (int, float, np.integer,
+                                                  np.floating))
+                    or isinstance(self.tsai_wu_F12, bool)
+                    or not np.isfinite(float(self.tsai_wu_F12))
+                    or not (-1.0 <= float(self.tsai_wu_F12) <= 0.0)):
+                raise ValueError(
+                    f"MaterialProperties.tsai_wu_F12 must be None or a "
+                    f"finite number in [-1, 0] (Tsai-Wu interaction "
+                    f"coefficient; values outside this range open the "
+                    f"failure envelope), got {self.tsai_wu_F12!r}."
+                )
 
     @property
     def total_thickness(self) -> float:

--- a/tests/test_porosity_fe.py
+++ b/tests/test_porosity_fe.py
@@ -3496,6 +3496,71 @@ class TestEmpiricalLayupScaling:
             assert abs(solver.JUDD_WRIGHT_ALPHA[mode] - alpha_qi * 2.0) < 1e-12
 
 
+class TestLayupScaleRegressionPin:
+    """Pin the current ``_layup_scale`` behavior across the intermediate
+    f_md range.
+
+    Snapshot of post-#140 investigation findings. The linear
+    ``f_md / _F_MD_REF`` scaling is preserved pending the validation
+    campaign documented in #140; these values are the current behavior,
+    not an endorsement of correctness. Any future refactor (linear or
+    nonlinear) must explicitly update these snapshots so the change is
+    visible in review.
+
+    Measurement methodology used in #140: relative CLT stiffness
+    retention ratio vs the QI baseline, i.e.
+    ``sqrt(Ex_layup(Vp)/Ex_layup(0)) / sqrt(Ex_QI(Vp)/Ex_QI(0))``,
+    compared against the empirical
+    ``exp(-alpha_QI*(scale_lin - 1)*Vp)`` over Vp in
+    ``[0.005, 0.05]``. Max abs relative error observed across the
+    layups below was 33.5% (UD at Vp=0.05); >5% on UD-heavy, off-axis,
+    and UD layups.
+    """
+
+    def _solver_with_layup(self, ply_angles):
+        material = MATERIALS['T800_epoxy']
+        pf = PorosityField(material, 0.03, distribution='uniform')
+        mesh = CompositeMesh(pf, material, nx=4, ny=3, nz=4)
+        return EmpiricalSolver(mesh, material, ply_angles=ply_angles)
+
+    def test_layup_scale_at_baseline_qi_returns_unity(self):
+        # QI [0,45,-45,90]_s -> f_md = 0.5 -> scale = 1.0 for all modes.
+        solver = self._solver_with_layup([0, 45, -45, 90, 90, -45, 45, 0])
+        for mode in ('compression', 'tension', 'shear', 'ilss',
+                     'transverse_tension'):
+            assert solver._layup_scale(mode) == pytest.approx(1.0, abs=1e-12)
+
+    def test_layup_scale_snapshot_at_intermediate_layups(self):
+        # 4-sig-fig snapshot of the current (linear) layup scale across the
+        # representative layups used in the #140 measurement set.
+        # Update only with an intentional algorithm change.
+        layups = {
+            'qi':       [0, 45, -45, 90, 90, -45, 45, 0],
+            'crossply': [0, 90, 90, 0],
+            'ud_heavy': [0, 0, 90, 90, 0, 0],
+            'off_axis': [0, 15, -15, -15, 15, 0],
+            'ud':       [0, 0, 0, 0, 0, 0],
+        }
+        expected = {
+            # name: (f_md, compression, tension, shear, ilss, transverse_tension)
+            'qi':       (0.5000, 1.000, 1.000, 1.000, 1.000, 1.000),
+            'crossply': (0.5000, 1.000, 1.000, 1.000, 1.000, 1.000),
+            'ud_heavy': (0.3333, 0.6667, 0.6667, 0.6667, 0.8000, 0.8000),
+            'off_axis': (0.3333, 0.6667, 0.6667, 0.6667, 0.8000, 0.8000),
+            'ud':       (0.0000, 0.1500, 0.1500, 0.1500, 0.8000, 0.8000),
+        }
+        for name, ply in layups.items():
+            solver = self._solver_with_layup(ply)
+            exp = expected[name]
+            assert solver.f_md == pytest.approx(exp[0], abs=5e-4), name
+            for i, mode in enumerate(('compression', 'tension', 'shear',
+                                      'ilss', 'transverse_tension'),
+                                     start=1):
+                got = solver._layup_scale(mode)
+                assert got == pytest.approx(exp[i], abs=5e-4), \
+                    f'{name}/{mode}: got {got!r}, expected {exp[i]!r}'
+
+
 class TestEmpiricalLinearSaturation:
     """The linear knockdown clips to 0 once Vp >= 1/beta."""
 

--- a/tests/test_porosity_fe.py
+++ b/tests/test_porosity_fe.py
@@ -5282,6 +5282,82 @@ class TestFailureCriteria:
         assert np.isnan(res.failure_mode_indices['fiber_t'])
         assert np.isnan(res.failure_mode_indices['matrix_c'])
 
+    # ------------------------------------------------------------------
+    # Issue #145: tsai_wu_F12 override on MaterialProperties.
+    # ------------------------------------------------------------------
+    def test_tsai_wu_default_F12_matches_recommendation(self):
+        """tsai_wu_F12=None must reproduce F_12 = -0.5 * sqrt(F_11 * F_22).
+
+        Verified by evaluating the per-GP polynomial on a pure σ_1 σ_2
+        biaxial state and recovering F_12 algebraically.
+        """
+        mat = self.material
+        assert mat.tsai_wu_F12 is None  # built-in preset uses Tsai default
+        # Pristine (Vp=0) strengths so degraded_strengths returns the raw
+        # allowables.
+        strengths = self.solver._degraded_strengths(0.0)
+        Xt_s, Xc_s, Yt_s, Yc_s, _, _ = strengths
+        F11 = 1.0 / (Xt_s * Xc_s)
+        F22 = 1.0 / (Yt_s * Yc_s)
+        F1 = 1.0 / Xt_s - 1.0 / Xc_s
+        F2 = 1.0 / Yt_s - 1.0 / Yc_s
+        F12_expected = -0.5 * np.sqrt(F11 * F22)
+
+        # Build a biaxial stress state and back out the F_12 the solver used.
+        s1, s2 = 100.0, 50.0
+        s = np.array([[s1, s2, 0.0, 0.0, 0.0, 0.0]])
+        fi = self.solver._evaluate_tsai_wu(s, strengths, e=0, elem_Vp=0.0)[0]
+        # fi = F1*s1 + F2*s2 + F11*s1^2 + F22*s2^2 + 2*F12*s1*s2
+        # (other terms vanish because σ_3, shears, and σ_2-σ_3 coupling
+        # all use a zero stress component).
+        diagonal = (F1 * s1 + F2 * s2 + F11 * s1 ** 2 + F22 * s2 ** 2)
+        F12_solver = (fi - diagonal) / (2.0 * s1 * s2)
+        assert F12_solver == pytest.approx(F12_expected, rel=1e-12, abs=1e-18)
+
+    def test_tsai_wu_user_F12_used_when_provided(self):
+        """A user-supplied tsai_wu_F12 must replace the Tsai recommendation."""
+        base = self.material
+        custom_F12 = -0.3
+        mat_custom = dataclasses.replace(base, tsai_wu_F12=custom_F12)
+
+        # Use the same mesh / porosity field as the default solver setup;
+        # only the material differs, so any FI change is attributable to F_12.
+        solver_custom = FESolver(self.mesh, mat_custom, self.pf,
+                                 failure_criterion='tsai_wu')
+
+        strengths = solver_custom._degraded_strengths(0.0)
+        # Biaxial stress state — F_12 only enters via 2*F_12*s1*s2.
+        s1, s2 = 100.0, 50.0
+        s = np.array([[s1, s2, 0.0, 0.0, 0.0, 0.0]])
+        Xt_s, Xc_s, Yt_s, Yc_s, _, _ = strengths
+        F11 = 1.0 / (Xt_s * Xc_s)
+        F22 = 1.0 / (Yt_s * Yc_s)
+        F1 = 1.0 / Xt_s - 1.0 / Xc_s
+        F2 = 1.0 / Yt_s - 1.0 / Yc_s
+        diagonal = (F1 * s1 + F2 * s2 + F11 * s1 ** 2 + F22 * s2 ** 2)
+
+        fi_custom = solver_custom._evaluate_tsai_wu(
+            s, strengths, e=0, elem_Vp=0.0)[0]
+        F12_recovered = (fi_custom - diagonal) / (2.0 * s1 * s2)
+        assert F12_recovered == pytest.approx(custom_F12, rel=1e-12, abs=1e-18)
+
+        # Cross-check: default solver gives a different FI on the same state.
+        fi_default = self.solver._evaluate_tsai_wu(
+            s, strengths, e=0, elem_Vp=0.0)[0]
+        assert fi_custom != pytest.approx(fi_default, rel=1e-12, abs=1e-18)
+
+    def test_tsai_wu_F12_out_of_range_raises(self):
+        """Positive tsai_wu_F12 opens the failure envelope -> ValueError."""
+        base = self.material
+        with pytest.raises(ValueError, match="tsai_wu_F12"):
+            dataclasses.replace(base, tsai_wu_F12=0.5)
+        # Below -1 is equally invalid.
+        with pytest.raises(ValueError, match="tsai_wu_F12"):
+            dataclasses.replace(base, tsai_wu_F12=-1.5)
+        # NaN / inf must also be rejected.
+        with pytest.raises(ValueError, match="tsai_wu_F12"):
+            dataclasses.replace(base, tsai_wu_F12=float('nan'))
+
 
 class TestEmpiricalSolverPlugin:
     """#62: EmpiricalSolver must accept a user-supplied knockdown callable."""

--- a/validation/validate_all.py
+++ b/validation/validate_all.py
@@ -183,11 +183,18 @@ def predict_strength(dataset: Dict[str, Any], prop_key: str,
 
     Issue #65: also propagates an assumed Vp measurement uncertainty
     (``sigma_Vp``, default 0.2 vol-% as a fraction — typical microscopy
-    resolution) into a one-sigma confidence band on each predicted point
-    using the closed-form local sensitivity
-    ``KD +/- |dKD/dVp| * sigma_Vp``.  The band is normalized by the same
-    baseline knockdown as the central prediction so it lives in the same
-    "normalized strength" coordinates as the experimental points.
+    resolution) into a one-sigma confidence band on each predicted point.
+
+    Issue #144: bands are now built by re-evaluating the knockdown model
+    at ``Vp - sigma_Vp`` and ``Vp + sigma_Vp`` (a two-point finite-
+    difference) instead of the linear delta-method
+    ``KD +/- |dKD/dVp| * sigma_Vp``.  For nonlinear knockdowns such as
+    Judd-Wright's power law, the linear approximation under-/over-shoots
+    by 10-20% at high Vp; the FD bands are exact at the model's own
+    ``Vp +/- sigma_Vp`` endpoints and naturally asymmetric.  The band is
+    normalized by the same baseline knockdown as the central prediction
+    so it lives in the same "normalized strength" coordinates as the
+    experimental points.
 
     Parameters
     ----------
@@ -231,33 +238,46 @@ def predict_strength(dataset: Dict[str, Any], prop_key: str,
     mode = _PROPERTY_TO_MODE[prop_key]
     baseline_vp = dataset.get('baseline_porosity_pct', 0.0) / 100.0
 
-    def _kd_and_dvp(vp_frac):
+    def _kd(vp_frac):
+        # Clamp into the PorosityField-supported domain [0, 1]. The lower
+        # edge of the 1-sigma band can otherwise dip below 0 for very low
+        # Vp, which is unphysical and would raise from PorosityField.
+        vp_frac = float(min(max(vp_frac, 0.0), 1.0))
         pf = PorosityField(mat, vp_frac, distribution='uniform',
                            void_shape='spherical')
         mesh = CompositeMesh(pf, mat, nx=10, ny=5,
                              nz=mat.n_plies, ply_angles=ply_angles)
         emp = EmpiricalSolver(mesh, mat, ply_angles=ply_angles)
         kd = emp.get_failure_load(mode=mode, model='judd_wright')['knockdown']
-        s = emp.local_sensitivities(mode=mode, model='judd_wright',
-                                    Vp=vp_frac)
-        return float(kd), float(s['dKD_dVp'])
+        return float(kd)
 
     if baseline_vp > 1e-9:
-        kd_base, _ = _kd_and_dvp(baseline_vp)
+        kd_base = _kd(baseline_vp)
     else:
         kd_base = 1.0
 
     predicted = []
     predicted_band = []
     for vp in vp_pcts:
-        kd, dkd_dvp = _kd_and_dvp(vp / 100.0)
+        vp_frac = vp / 100.0
+        kd = _kd(vp_frac)
         norm = kd / kd_base
-        # Linear (delta-method) 1-sigma propagation. Normalization is a
-        # constant w.r.t. Vp, so it falls straight through onto the band.
-        half_width = abs(dkd_dvp) * sigma_Vp / kd_base
+        # Two-point finite-difference 1-sigma propagation (#144). Evaluate
+        # the (nonlinear) knockdown at Vp +/- sigma_Vp instead of using the
+        # local derivative, so the resulting band is exact at the endpoints
+        # and naturally asymmetric for power-law knockdowns. Normalization
+        # is a constant w.r.t. Vp, so it falls straight through onto the
+        # band. Clamping of Vp - sigma_Vp into [0, 1] happens inside _kd.
+        kd_lower = _kd(vp_frac - sigma_Vp)
+        kd_upper = _kd(vp_frac + sigma_Vp)
+        norm_lower = kd_lower / kd_base
+        norm_upper = kd_upper / kd_base
+        # Knockdown is monotone-decreasing in Vp, so kd_upper <= kd_lower.
+        # Order the tuple as (low, high) regardless, so downstream code
+        # that assumes band[0] <= band[1] keeps working.
+        lo, hi = sorted((norm_lower, norm_upper))
         predicted.append(float(norm))
-        predicted_band.append((float(norm - half_width),
-                               float(norm + half_width)))
+        predicted_band.append((float(lo), float(hi)))
     return predicted, predicted_band
 
 


### PR DESCRIPTION
Two scientific/numerical fixes (#144, #145), one docstring/README clarification (#141), and an investigation-with-findings on the empirical layup-scaling assumption (#140).

## Closes

- Closes #144 — replace linear delta-method with two-point finite-difference for validation uncertainty bands
- Closes #141 — document the sqrt strength-degradation heuristic and FE-vs-empirical solver divergence
- Closes #145 — add `MaterialProperties.tsai_wu_F12` override (with `[-1, 0]` validation) and cite Tsai & Wu (1971)
- Closes #140 — regression-pin `_layup_scale` and document the measured linearity gap

## Changes

### #144 — validation/validate_all.py
`predict_strength`'s `predicted_band` now computes `(kd(Vp - sigma_Vp), kd(Vp + sigma_Vp))` directly instead of `kd_base ± |dKD/dVp|·sigma_Vp`. Bands become naturally asymmetric (more honest for nonlinear KD models). Vp is clamped to `[0, 1]` to handle endpoints near 0, and `(lo, hi)` is sorted so downstream `band[0] <= band[1]` assumptions still hold. Existing `test_band_present_in_run_all_datasets` only requires `lo <= point <= hi` which the asymmetric bands satisfy — no test changes needed.

### #145 — `MaterialProperties.tsai_wu_F12`
New optional field on `MaterialProperties` (default `None`). When `None`, `FESolver._evaluate_tsai_wu` keeps the historical Tsai recommendation `F_12 = -0.5·sqrt(F_11·F_22)`; when provided, the user's value is used. `__post_init__` rejects non-finite values and anything outside `[-1, 0]`. JSON I/O picks it up automatically via `asdict`; all 8 `MATERIALS` presets use keyword args so no preset edits needed. Three new tests pin the default-matches-recommendation invariant, the override path, and the range-validation. `_evaluate_tsai_wu` docstring now cites Tsai, S. W. & Wu, E. M. (1971).

### #141 — strength-degradation docs
`FESolver._degraded_strengths` docstring now states the scaling rule explicitly (`r_matrix = sqrt(C_eff[0,0] / C_pristine[0,0])`), hedges the citation (loosely Puck-style, not validated within PorosityFE), and points at the alternative-scalings discussion in the README. New README subsection **"Solver selection: FE vs. empirical"** documents the expected numerical divergence between the two paths and guides which solver to use for which task. **No API kwarg added** (out of scope without validation data).

### #140 — `_layup_scale` investigation
**This commit does NOT change `_layup_scale`'s scaling behavior.** It adds a regression-pin (`TestLayupScaleRegressionPin`, 2 tests) and a TODO comment with measured findings. Methodology: compared the current linear `f_md / _F_MD_REF` scaling against a CLT-derived stiffness-retention ratio for representative intermediate layups (T800/epoxy, compression mode, Vp grid `[0.5%, 1%, 2%, 3%, 5%]`):

| layup | f_md | linear_scale | max rel error vs CLT proxy |
|---|---|---|---|
| QI `[0,45,-45,90]_s` | 0.500 | 1.000 | 0.0% (baseline) |
| `[0,90]_s` | 0.500 | 1.000 | 0.2% |
| `[0_2,90]_s` | 0.333 | 0.667 | **11.9%** |
| `[0,15,-15]_s` | 0.333 | 0.667 | **11.8%** |
| `[0,0,0]_s` (UD) | 0.000 | 0.150 | **33.5%** |

The linear rule **over-predicts the reduction in porosity sensitivity** for fiber-dominated layups. The CLT proxy reflects stiffness retention rather than strength — so this is a directional indicator, not a quantitative replacement target. Replacing the scaling needs a real validation campaign (independent reference data, fit/lookup choice, regression testing across the full layup space). The TODO in `_layup_scale` captures the worst-case (33.5%) and the reference used.

No production code paths were changed in `_layup_scale`; the existing behavior is now pinned.

## Test plan

- [x] `pytest tests/ -q` — 555 passed, 1 skipped (was 550 on master; +5 from #140 and #145)
- [x] `validation.validate_all.predict_strength` imports cleanly with the new FD bands
- [x] `MaterialProperties(tsai_wu_F12=0.5)` raises `ValueError`; `MATERIALS['T800_epoxy'].tsai_wu_F12 is None` (default behavior preserved)
- [ ] CI green on this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_01L1ovdBYzTQRV4DKwSR4JmC)_