### PR TITLE
CSV precision (#128), JSON units block (#131), CLI honesty (#132), F_MD_FLOOR docs (#139)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to PorosityFE will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- **Self-documenting `units` block in JSON envelopes** (`save_results_to_json`,
+  `write_results_json` / `_serialise_payload_json`, `serialise_ncr_json`) plus
+  per-field `description` entries on numeric leaves in
+  `validation/schemas/porosity_results_schema.json` so downstream consumers
+  reading only the JSON can tell whether `knockdown` is a fraction, a
+  percentage, or a multiplier. `JSON_SCHEMA_VERSION` bumped to `1.1`
+  (additive, backwards-compatible — 1.0 files still load and validate). (#131)
 - **`--jobs N` flag on the `porosity-fe` CLI** parallelises the per-
   configuration sweep in `compare_configurations` over a
   `concurrent.futures.ProcessPoolExecutor`. `N=1` (default) preserves

--- a/README.md
+++ b/README.md
@@ -397,7 +397,7 @@ alpha_eff(mode) = alpha_QI(mode) * (f_md / 0.5)
 n_eff(mode)     = max(n_QI(mode) * (f_md / 0.5), 0.1)
 ```
 
-A floor of `0.15` is applied to the scale (`0.80` for ILSS, which is always matrix-dominated):
+A floor of `0.15` is applied to the scale (`0.80` for ILSS, which is always matrix-dominated). The `_F_MD_FLOOR` / `_F_MD_FLOOR_ILSS` constants in `EmpiricalSolver` are empirical floors documented inline in the source (see issue #139 for the calibration gap):
 
 | Layup | `f_md` | scale | `alpha_eff` (compression) |
 |---|---|---|---|

--- a/porosity_fe/cli.py
+++ b/porosity_fe/cli.py
@@ -93,7 +93,13 @@ def _build_arg_parser() -> 'argparse.ArgumentParser':
         "--applied-stress",
         type=float,
         default=-1500.0,
-        help="Applied stress (MPa) passed to compare_configurations.",
+        help=(
+            "Applied stress (MPa), reserved for downstream solver hooks. "
+            "Accepted for parity with compare_configurations but currently "
+            "unused: the empirical knockdown sweep does not consume it, so "
+            "changing this value will not affect results. Retained as a "
+            "stable CLI surface for future use (#132)."
+        ),
     )
     parser.add_argument(
         "--seed",

--- a/porosity_fe/empirical.py
+++ b/porosity_fe/empirical.py
@@ -64,8 +64,35 @@ class EmpiricalSolver:
     _MATRIX_DOMINATED_MODES = frozenset({'ilss', 'transverse_tension'})
     # QI reference fraction and minimum floor
     _F_MD_REF = 0.5    # f_md for the QI layup used in calibration
-    _F_MD_FLOOR = 0.15  # even UD has some matrix sensitivity
-    _F_MD_FLOOR_ILSS = 0.80  # ILSS / transverse-tension are always matrix-dominated
+    # ``_F_MD_FLOOR`` / ``_F_MD_FLOOR_ILSS`` are hard floors on the layup-scale
+    # multiplier ``scale = f_md / _F_MD_REF`` returned by ``_layup_scale``.
+    # Without them ``scale -> 0`` for pure UD ([0]_n, f_md = 0.0), which would
+    # imply zero porosity sensitivity for fiber-dominated layups — physically
+    # wrong, since even UD coupons show measurable porosity knockdown at high
+    # Vp (Judd & Wright 1978 and successors all report a non-zero UD response).
+    # The floor preserves the *shape* of that physically-required behaviour
+    # while keeping the scaling rule simple and monotonic.
+    #
+    # The specific values (0.15 / 0.80) are EMPIRICAL TUNING CONSTANTS with
+    # no published derivation or cross-validation note. They were introduced
+    # together with the layup-scaling rule in commit 55affc0 (#10, a Vp-
+    # validation fix) and carried forward unchanged through the package
+    # refactor (#136). No coupon-dataset regression, optimization, or
+    # physical-argument origin has been located for either value — see
+    # issue #139 for the calibration gap. A future calibration campaign
+    # should validate ``_F_MD_FLOOR`` against UD coupon data across
+    # Vp in [0, 5%] (per-mode, since compression vs tension UD sensitivities
+    # differ) and ``_F_MD_FLOOR_ILSS`` against matrix-dominated coupons in
+    # the same range. Issue #140 (which already pinned a ~33% linearity gap
+    # in ``_layup_scale`` itself) and #139 should be addressed together so
+    # the replacement rule and its floors are calibrated against the same
+    # reference dataset.
+    _F_MD_FLOOR = 0.15  # even UD retains some matrix sensitivity; empirical, see #139
+    # ILSS and transverse-tension are matrix-/interface-dominated regardless
+    # of fiber-direction layup (the void-dominated stress component is in the
+    # matrix), so the floor preserves most of the QI calibration. 0.80 is an
+    # empirical tuning constant — not derived from published validation data.
+    _F_MD_FLOOR_ILSS = 0.80  # ILSS / transverse-tension floor; empirical, see #139
 
     def __init__(self, mesh: CompositeMesh, material: MaterialProperties,
                  ply_angles: Optional[Union[List[float], str]] = 'QI',

--- a/porosity_fe/io.py
+++ b/porosity_fe/io.py
@@ -44,11 +44,39 @@ def _json_default(o):
 
 # JSON output schema (#20). Bump the major when an incompatible change
 # to the payload structure ships; bump the minor for additive changes.
-JSON_SCHEMA_VERSION = "1.0"
+# 1.1 (#131): added optional top-level ``units`` block documenting the
+# physical units of numeric leaves. Purely additive; consumers on 1.0
+# loaders can safely ignore the new key.
+JSON_SCHEMA_VERSION = "1.1"
 FORMAT_EMPIRICAL_SWEEP = "porosity-fe.empirical-sweep"
 FORMAT_FE_FIELDS = "porosity-fe.fe-fields"
 FORMAT_NCR = "porosity-fe.ncr"
 _KNOWN_FORMATS = {FORMAT_EMPIRICAL_SWEEP, FORMAT_FE_FIELDS, FORMAT_NCR}
+
+
+# Per-format units descriptors for the self-documenting ``units`` envelope
+# block (#131). Keys correspond to the numeric leaves each writer emits,
+# so downstream consumers reading only the JSON can interpret ambiguous
+# fields like ``knockdown`` without consulting external docs.
+_UNITS_EMPIRICAL_SWEEP = {
+    "failure_stress": "MPa",
+    "knockdown": "dimensionless fraction in (0, 1]",
+    "void_volume_fraction": "dimensionless fraction in [0, 1]",
+}
+_UNITS_NCR = {
+    "failure_stress": "MPa",
+    "knockdown": "dimensionless fraction in (0, 1]",
+    "governing_residual_strength": "MPa",
+    "governing_knockdown": "dimensionless fraction in (0, 1]",
+    "measured_Vp_percent": "%",
+    "t_ply_mm": "mm",
+}
+_UNITS_STREAMLIT_EMPIRICAL = {
+    "failure_stress": "MPa",
+    "knockdown": "dimensionless fraction in (0, 1]",
+    "Vp_percent": "%",
+    "t_ply": "mm",
+}
 
 
 def _build_provenance(seed: Optional[int] = None) -> dict:
@@ -183,14 +211,19 @@ def save_results_to_json(results: Dict, filename: str,
         'schema_version': JSON_SCHEMA_VERSION,
         'format': FORMAT_EMPIRICAL_SWEEP,
         'provenance': _build_provenance(seed=seed),
+        # Self-documenting units block (#131): documents the physical units
+        # of the numeric leaves in the payload below so downstream consumers
+        # reading only the JSON can interpret values without external docs.
+        'units': dict(_UNITS_EMPIRICAL_SWEEP),
     }
     for name, data in results.items():
-        if name in ('schema_version', 'format'):
+        if name in ('schema_version', 'format', 'units'):
             # Defensive: a user-named config that collides with envelope
             # keys would silently overwrite them. Skip with a clear error.
+            # (#131 added 'units' to the reserved set.)
             raise ValueError(
                 f"Configuration name {name!r} collides with the JSON "
-                f"envelope keys ('schema_version', 'format')."
+                f"envelope keys ('schema_version', 'format', 'units')."
             )
         # Resolve the void_volume_fraction and config dict for both the
         # legacy dict shape and the new ConfigResult shape. The legacy

--- a/porosity_fe/pipeline.py
+++ b/porosity_fe/pipeline.py
@@ -51,9 +51,10 @@ def _analyze_one(Vp: float,
         process doesn't need to pickle the :class:`MaterialProperties`
         dataclass across the boundary (it's keyed by name anyway).
     applied_stress : float
-        Reserved for downstream solver hooks. Accepted for parity with the
-        ``compare_configurations`` signature even though the empirical
-        knockdown does not currently consume it.
+        Reserved for downstream solver hooks; **currently unused**.
+        Accepted for parity with the ``compare_configurations`` signature
+        even though the empirical knockdown does not consume it, so
+        changing this value will not affect the worker's output (#132).
     seed : int, optional
         Recorded into the porosity field for reproducibility provenance.
 
@@ -147,8 +148,10 @@ def compare_configurations(void_volume_fraction: float,
     material_name : str
         Material preset name; validated against :data:`MATERIALS`.
     applied_stress : float
-        Reserved for downstream solver hooks (empirical knockdown does
-        not currently consume it).
+        Reserved for downstream solver hooks; **currently unused**. The
+        empirical knockdown sweep does not consume this value, so passing
+        a different number will not change the returned results. Retained
+        in the signature for forward compatibility (#132).
     configs : dict, optional
         Mapping of configuration name -> :class:`PorosityField` kwargs.
         Defaults to the bundled :data:`POROSITY_CONFIGS`.

--- a/porosity_fe/reporting.py
+++ b/porosity_fe/reporting.py
@@ -122,10 +122,14 @@ def write_results_json(filepath: str, payload: dict) -> None:
         _build_provenance,
         _json_default,
     )
+    from porosity_fe.io import _UNITS_STREAMLIT_EMPIRICAL
     envelope = {
         "schema_version": JSON_SCHEMA_VERSION,
         "format": FORMAT_EMPIRICAL_SWEEP,
         "provenance": _build_provenance(),
+        # Self-documenting units block (#131): documents the physical units
+        # of the numeric leaves in the payload below.
+        "units": dict(_UNITS_STREAMLIT_EMPIRICAL),
         **payload,
     }
     with open(filepath, "w", encoding="utf-8") as f:
@@ -174,10 +178,14 @@ def _serialise_payload_json(payload: dict) -> str:
         _build_provenance,
         _json_default,
     )
+    from porosity_fe.io import _UNITS_STREAMLIT_EMPIRICAL
     envelope = {
         "schema_version": JSON_SCHEMA_VERSION,
         "format": FORMAT_EMPIRICAL_SWEEP,
         "provenance": _build_provenance(),
+        # Self-documenting units block (#131): documents the physical units
+        # of the numeric leaves in the payload below.
+        "units": dict(_UNITS_STREAMLIT_EMPIRICAL),
         **payload,
     }
     return json.dumps(envelope, indent=2, default=_json_default)
@@ -410,10 +418,14 @@ def serialise_ncr_json(ncr: dict) -> str:
         _build_provenance,
         _json_default,
     )
+    from porosity_fe.io import _UNITS_NCR
     envelope = {
         "schema_version": JSON_SCHEMA_VERSION,
         "format": FORMAT_NCR,
         "provenance": _build_provenance(),
+        # Self-documenting units block (#131): documents the physical units
+        # of the numeric leaves in the NCR payload below.
+        "units": dict(_UNITS_NCR),
         **ncr,
     }
     return json.dumps(envelope, indent=2, default=_json_default)

--- a/porosity_fe/reporting.py
+++ b/porosity_fe/reporting.py
@@ -132,6 +132,23 @@ def write_results_json(filepath: str, payload: dict) -> None:
         json.dump(envelope, f, indent=2, default=_json_default)
 
 
+def _format_csv_row(mode: str, model: str, r: dict) -> list:
+    """Format a single empirical row for CSV export with engineering precision.
+
+    Raw Python floats round-trip with full 15-digit precision through
+    ``csv.writer``, which produces noisy spreadsheet/script-consumer
+    output (#128). Apply explicit per-field precision instead:
+
+    * ``failure_stress_MPa`` -> 1 decimal place (engineering MPa)
+    * ``knockdown`` -> 4 decimal places (dimensionless ratio)
+    """
+    return [
+        mode, model,
+        f"{r['failure_stress_MPa']:.1f}",
+        f"{r['knockdown']:.4f}",
+    ]
+
+
 def write_results_csv(filepath: str, payload: dict) -> None:
     """Write the export payload as a flat CSV.
 
@@ -147,11 +164,7 @@ def write_results_csv(filepath: str, payload: dict) -> None:
         for mode in payload["empirical"]:
             for model in payload["empirical"][mode]:
                 r = payload["empirical"][mode][model]
-                writer.writerow([
-                    mode, model,
-                    r["failure_stress_MPa"],
-                    r["knockdown"],
-                ])
+                writer.writerow(_format_csv_row(mode, model, r))
 
 
 def _serialise_payload_json(payload: dict) -> str:
@@ -179,11 +192,7 @@ def _serialise_payload_csv(payload: dict) -> str:
     for mode in payload["empirical"]:
         for model in payload["empirical"][mode]:
             r = payload["empirical"][mode][model]
-            writer.writerow([
-                mode, model,
-                r["failure_stress_MPa"],
-                r["knockdown"],
-            ])
+            writer.writerow(_format_csv_row(mode, model, r))
     return buf.getvalue()
 
 

--- a/tests/test_porosity_fe.py
+++ b/tests/test_porosity_fe.py
@@ -4234,7 +4234,9 @@ class TestProvenanceInSaveResultsJson:
         save_results_to_json(results, path)
         with open(path, encoding="utf-8") as f:
             data = json.load(f)
-        assert data['schema_version'] == '1.0'
+        # Track the current envelope version rather than hard-coding it,
+        # so a future additive minor bump doesn't break this assertion (#131).
+        assert data['schema_version'] == JSON_SCHEMA_VERSION
 
 
 class TestJsonEncodingRoundTrip:
@@ -4277,7 +4279,7 @@ class TestProvenanceInFEExportResults:
         assert isinstance(prov['numpy_version'], str) and prov['numpy_version']
         assert isinstance(prov['timestamp_utc'], str) and prov['timestamp_utc']
         assert 'porosity_fe_version' in prov
-        assert data['schema_version'] == '1.0'
+        assert data['schema_version'] == JSON_SCHEMA_VERSION
 
 
 class TestIssue55ProvenanceContract:

--- a/tests/test_porosity_fe.py
+++ b/tests/test_porosity_fe.py
@@ -3730,7 +3730,8 @@ class TestExportHelpers:
         assert data_lines[0] == "mode,model,failure_stress_MPa,knockdown"
         # Three (mode, model) rows in the sample → header + 3 = 4 lines.
         assert len(data_lines) == 4
-        assert "compression,judd_wright,1234.5,0.823" in data_lines
+        # failure_stress -> 1 dp, knockdown -> 4 dp (#128).
+        assert "compression,judd_wright,1234.5,0.8230" in data_lines
 
     def test_write_results_csv_round_trips_via_csv_module(self, tmp_path):
         import csv as _csv

--- a/tests/test_results_schema_roundtrip.py
+++ b/tests/test_results_schema_roundtrip.py
@@ -208,6 +208,91 @@ def test_save_results_config_name_collision_raises(tmp_path):
         save_results_to_json(colliding, path)
 
 
+def test_save_results_includes_units_block(tmp_path):
+    """#131: save_results_to_json must emit a top-level ``units`` block so
+    consumers reading only the JSON can interpret ambiguous fields like
+    ``knockdown``. The block lives in the envelope (after ``provenance``,
+    before per-config payloads) and maps payload field names to unit
+    strings.
+    """
+    import jsonschema
+
+    path = str(tmp_path / "with_units.json")
+    save_results_to_json(_tiny_results(), path)
+
+    with open(path, encoding="utf-8") as f:
+        on_disk = json.load(f)
+
+    # New envelope contract: units present, schema bumped to 1.1+.
+    assert "units" in on_disk, (
+        "Envelope must carry a self-documenting 'units' block (#131)."
+    )
+    units = on_disk["units"]
+    assert isinstance(units, dict) and units, "units must be a non-empty mapping."
+    # The empirical-sweep payload writes failure_stress (MPa), knockdown
+    # (dimensionless fraction), and void_volume_fraction (dimensionless
+    # fraction) — the three numeric leaves the consumer needs labelled.
+    assert "failure_stress" in units
+    assert units["failure_stress"] == "MPa"
+    assert "knockdown" in units
+    assert "dimensionless" in units["knockdown"].lower()
+    assert "void_volume_fraction" in units
+    assert "dimensionless" in units["void_volume_fraction"].lower()
+
+    # Version bump: this envelope shipped as 1.1.
+    assert on_disk["schema_version"] == JSON_SCHEMA_VERSION
+    assert on_disk["schema_version"] != "1.0"
+    assert on_disk["schema_version"].startswith("1.")
+
+    # Whole envelope must still validate against the schema.
+    jsonschema.validate(instance=on_disk, schema=_load_schema())
+
+
+def test_legacy_json_without_units_block_still_loads(tmp_path):
+    """#131: the ``units`` block is purely additive — consumers reading a
+    file written by an older porosity-fe (no ``units`` key) must still
+    load and validate cleanly. The MAJOR version is unchanged, so the
+    loader accepts both 1.0 and 1.1 envelopes.
+    """
+    import jsonschema
+
+    # Hand-craft a minimal valid 1.0-style envelope (no ``units`` key).
+    legacy = {
+        "schema_version": "1.0",
+        "format": FORMAT_EMPIRICAL_SWEEP,
+        "provenance": {
+            "schema_version": "1.0",
+            "porosity_fe_version": "0.0.0",
+            "python_version": "3.11.0",
+            "platform": "test",
+            "numpy_version": "1.26.0",
+            "scipy_version": "1.11.0",
+            "timestamp_utc": "2026-05-22T00:00:00Z",
+            "seed": None,
+            "git_commit": None,
+            "package_version": "0.0.0",
+            "python": "3.11.0",
+            "numpy": "1.26.0",
+            "scipy": "1.11.0",
+            "generated_utc": "2026-05-22T00:00:00Z",
+            "git_sha": None,
+        },
+        "demo_config": {
+            "void_volume_fraction": 0.03,
+            "empirical": {},
+        },
+    }
+    path = tmp_path / "legacy_no_units.json"
+    path.write_text(json.dumps(legacy), encoding="utf-8")
+
+    # No ``units`` key, but schema validation still passes (additive change).
+    jsonschema.validate(instance=legacy, schema=_load_schema())
+    # And the loader accepts the older minor version (same MAJOR).
+    loaded = load_results_from_json(str(path))
+    assert "units" not in loaded
+    assert loaded["schema_version"] == "1.0"
+
+
 def test_save_results_legacy_dict_shape_still_works(tmp_path):
     """#152: the pre-#103 ``Dict[str, dict]`` shape (raw worker-dict with
     ``porosity_field`` / ``config`` / ``empirical`` keys) must still

--- a/validation/schemas/porosity_results_schema.json
+++ b/validation/schemas/porosity_results_schema.json
@@ -1,13 +1,14 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Porosity Analysis Results",
-  "description": "Output contract for save_results_to_json / FESolver.export_results / the Streamlit empirical exporter / the NCR exporter. The envelope (schema_version, format, provenance) is validated strictly so consumers can detect version/contract drift; the science payload is intentionally permissive so adding result fields is not a breaking schema change. The known top-level format identifiers are listed in the `format` enum (#20).",
+  "description": "Output contract for save_results_to_json / FESolver.export_results / the Streamlit empirical exporter / the NCR exporter. The envelope (schema_version, format, provenance) is validated strictly so consumers can detect version/contract drift; the science payload is intentionally permissive so adding result fields is not a breaking schema change. The known top-level format identifiers are listed in the `format` enum (#20). An optional `units` block (#131) documents the physical units of the numeric leaves in the payload so downstream consumers reading only the JSON can interpret values without consulting external docs.",
   "type": "object",
   "required": ["schema_version", "format", "provenance"],
   "properties": {
     "schema_version": {
       "type": "string",
-      "pattern": "^[0-9]+\\.[0-9]+$"
+      "pattern": "^[0-9]+\\.[0-9]+$",
+      "description": "Envelope schema version (MAJOR.MINOR). Bumped on additive changes; consumers should accept any MINOR within the same MAJOR."
     },
     "format": {
       "type": "string",
@@ -46,7 +47,7 @@
         "scipy_version": {"type": ["string", "null"]},
         "matplotlib_version": {"type": ["string", "null"]},
         "timestamp_utc": {"type": "string"},
-        "seed": {"type": ["integer", "null"]},
+        "seed": {"type": ["integer", "null"], "description": "RNG seed for the run (null when unset or ambiguous). Dimensionless."},
         "git_commit": {"type": ["string", "null"]},
         "package_version": {"type": ["string", "null"]},
         "python": {"type": "string"},
@@ -57,9 +58,54 @@
         "hostname": {"type": ["string", "null"]}
       }
     },
+    "units": {
+      "type": "object",
+      "description": "Optional self-documenting map from payload field name to its physical unit string (#131). Added in schema_version 1.1; consumers on older schemas can safely ignore it. Keys correspond to numeric leaves present in the payload (e.g. 'failure_stress', 'knockdown', 'Vp', 'porosity_percent'); values are human-readable unit strings (e.g. 'MPa', 'dimensionless fraction in (0, 1]', '%').",
+      "additionalProperties": {"type": "string"}
+    },
     "raw_sidecar": {
       "type": "string",
       "description": "Basename of the optional .npz sidecar containing the raw displacement/stress/strain arrays (FESolver.export_results include_raw=True)."
+    },
+    "void_volume_fraction": {
+      "type": "number",
+      "description": "Void volume fraction in [0, 1]. Dimensionless."
+    },
+    "failure_stress_MPa": {
+      "type": "number",
+      "description": "Compressive failure stress in MPa."
+    },
+    "knockdown": {
+      "type": "number",
+      "description": "Strength retained as a fraction of pristine (0 = failed, 1 = pristine). Dimensionless."
+    },
+    "Vp": {
+      "type": "number",
+      "description": "Void volume fraction in [0, 1]. Dimensionless."
+    },
+    "Vp_percent": {
+      "type": "number",
+      "description": "Void volume fraction in percent (%)."
+    },
+    "porosity_percent": {
+      "type": "number",
+      "description": "Value in percent (%)."
+    },
+    "measured_Vp_percent": {
+      "type": "number",
+      "description": "Measured void volume fraction in percent (%)."
+    },
+    "t_ply_mm": {
+      "type": "number",
+      "description": "Ply thickness in millimetres (mm)."
+    },
+    "governing_knockdown": {
+      "type": "number",
+      "description": "Worst-case (lowest) strength retained as a fraction of pristine. Dimensionless."
+    },
+    "governing_residual_strength_MPa": {
+      "type": "number",
+      "description": "Worst-case residual strength in MPa."
     }
   },
   "additionalProperties": true


### PR DESCRIPTION
Four small UX / documentation polish items. All independent.

## Closes

- Closes #128 — format CSV export floats with engineering precision (1 dp stress, 4 dp knockdown)
- Closes #131 — add `units` block to JSON envelope + per-field schema descriptions; bump `JSON_SCHEMA_VERSION` to `1.1`
- Closes #132 — clarify CLI `--applied-stress` is reserved/unused (Option A, no behavior change)
- Closes #139 — document `_F_MD_FLOOR` / `_F_MD_FLOOR_ILSS` empirical tuning constants

## Changes

### #128 — CSV float precision
`_serialise_payload_csv` and `write_results_csv` (both in `porosity_fe/reporting.py`) now route through a shared `_format_csv_row` helper that formats `failure_stress_MPa` as `.1f` and `knockdown` as `.4f`. JSON path is unformatted (raw `json.dumps`), so the issue's 1dp/4dp fallback was used. One existing test assertion updated to track the new zero-padded knockdown.

### #131 — Self-describing JSON
- `JSON_SCHEMA_VERSION` bumped `1.0` → `1.1` (additive minor).
- New `units` block in envelopes for all three JSON formats (empirical sweep via `io.py`, Streamlit empirical, NCR). Envelope order: `schema_version, format, provenance, units, <payload>`.
- `validation/schemas/porosity_results_schema.json` now has a `description` on every numeric leaf and an optional top-level `units` property. Legacy JSON without `units` still validates.
- `units` added to the reserved-key collision set so user configs can't shadow it.
- 2 new tests pin the `units` presence and the legacy-without-units round-trip.
- **Out of scope**: FE-fields envelope (`FORMAT_FE_FIELDS` in `fe/solver.py`) also lacks a `units` block; uses different field names. Worth a separate pass.

### #132 — CLI honesty
Confirmed `--applied-stress` is truly unused: it flows through `compare_configurations` → `_analyze_one` and is never read after entering the worker (no log, no provenance). Help text updated to explicitly say "reserved for future use… currently consumed only by downstream solver hooks; the empirical knockdown sweep does not use it." Docstrings on `compare_configurations` and `_analyze_one` updated for consistency. Option A (preserve the flag for backwards compatibility), not Option B (removal).

### #139 — `_F_MD_FLOOR` documentation
Investigation found the floors were introduced in commit `55affc0` (#10, May 2026) with no derivation note. Option B (honest fallback) applied: a block comment in `porosity_fe/empirical.py` explains (a) the floors prevent `scale → 0` for UD which is physically required, (b) the specific 0.15 / 0.80 values are empirical tuning constants with no published derivation, (c) a future calibration campaign (paired with #140) should validate them against UD / matrix-dominated coupons. Inline tags on the assignment lines. One-line README forward-reference added.

## Test plan

- [x] `pytest tests/ -q` — 557 passed, 1 skipped (was 555 on master; +2 from #131)
- [x] Round-trip a saved JSON: `units` block present, schema validates, `JSON_SCHEMA_VERSION == "1.1"`
- [x] Legacy JSON without `units` still validates against the updated schema
- [x] CSV export produces engineering-precision floats matching the issue's expected output exactly
- [ ] CI green on this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_01L1ovdBYzTQRV4DKwSR4JmC)_