### PR TITLE
Pipeline logging dedup (#122) + Streamlit UX polish (#129, #130, #133)

### DIFF
--- a/app.py
+++ b/app.py
@@ -532,6 +532,21 @@ def _render():
             nx = st.slider("nx", min_value=2, max_value=200, value=30, step=1)
             ny = st.slider("ny", min_value=2, max_value=100, value=10, step=1)
             nz = st.slider("nz", min_value=2, max_value=100, value=12, step=1)
+            total_elems = nx * ny * nz
+            if total_elems < 100:
+                st.warning(
+                    f"⚠ Mesh is very coarse ({total_elems} elements). "
+                    f"FE results from meshes below ~100 elements are unreliable. "
+                    f"Defaults (30×10×12 = 3600 elements) are recommended."
+                )
+            elif total_elems > 50_000:
+                # Very rough time estimate; tune from real benchmarks if available.
+                est_min = total_elems / 8000
+                st.warning(
+                    f"⚠ Mesh is very fine ({total_elems} elements). "
+                    f"Estimated solve time: ~{est_min:.0f} minutes. "
+                    f"Consider reducing for iteration."
+                )
         else:
             nx, ny, nz = 30, 10, 12
             st.caption(f"Default mesh: {nx} × {ny} × {nz} (enable Expert mode to change).")

--- a/app.py
+++ b/app.py
@@ -50,6 +50,12 @@ from porosity_fe import (
 # rcParams nudges, so the Streamlit plots match the static PNGs (#53).
 _configure_matplotlib_style()
 
+# Repo README link for in-app guidance (e.g. when FE solve is skipped, #129).
+_README_URL = (
+    "https://github.com/ranipdx-glitch/PorosityFE"
+    "#solver-selection-fe-vs-empirical"
+)
+
 
 # ======================================================================
 # Pure helpers (extracted to porosity_fe.reporting so tests can import them
@@ -625,7 +631,15 @@ def _render():
                 f"{cfg_r['distribution']}, mesh {cfg_r['nx']}×{cfg_r['ny']}×{cfg_r['nz']}."
             )
             if result.get("fe_skipped_reason"):
-                st.warning(f"FE skipped: {result['fe_skipped_reason']}")
+                reason = result["fe_skipped_reason"]
+                st.warning(
+                    f"⚠ FE solve was skipped: {reason}\n\n"
+                    f"**Empirical knockdown results are still valid** and are shown in the "
+                    f"other tabs. FE would have added per-element stress fields; you don't "
+                    f"need it for the headline knockdown numbers.\n\n"
+                    f"To retry with FE: adjust the mesh (Expert tab) or pick a different "
+                    f"loading mode. See the [README]({_README_URL}) for the FE-supported modes."
+                )
 
     def _placeholder():
         st.info("Run an analysis to populate this tab.")

--- a/app.py
+++ b/app.py
@@ -58,10 +58,12 @@ _configure_matplotlib_style()
 
 from porosity_fe.reporting import (  # noqa: E402, F401  re-exported for the Streamlit UI
     STRUCTURAL_CLASSES,
+    _sanitise_filename_component,
     _serialise_payload_csv,
     _serialise_payload_json,
     build_export_payload,
     build_ncr_record,
+    download_filename_stem,
     governing_failure,
     parse_layup,
     recommend_disposition,
@@ -667,17 +669,18 @@ def _render():
             _placeholder()
         else:
             payload = build_export_payload(result)
+            export_stem = download_filename_stem(payload)
             st.download_button(
                 "Download JSON",
                 data=_serialise_payload_json(payload),
-                file_name="porosity_results.json",
+                file_name=f"{export_stem}.json",
                 mime="application/json",
                 use_container_width=True,
             )
             st.download_button(
                 "Download CSV",
                 data=_serialise_payload_csv(payload),
-                file_name="porosity_results.csv",
+                file_name=f"{export_stem}.csv",
                 mime="text/csv",
                 use_container_width=True,
             )
@@ -744,8 +747,8 @@ def _render():
 
                 ncr_md = serialise_ncr_markdown(ncr)
                 stem = (
-                    ncr_reference.strip().replace(" ", "_")
-                    or "porosity_analysis_summary"
+                    _sanitise_filename_component(ncr_reference.strip())
+                    or export_stem
                 )
                 dl1, dl2, dl3 = st.columns(3)
                 with dl1:

--- a/porosity_fe/pipeline.py
+++ b/porosity_fe/pipeline.py
@@ -132,6 +132,55 @@ def _resolve_n_jobs(n_jobs: Optional[int]) -> int:
     return int(n_jobs)
 
 
+def _log_result_summary(name: str, result: Dict, *, is_parallel: bool) -> None:
+    """Emit the per-config result-summary log lines.
+
+    Both branches of :func:`compare_configurations` (serial + parallel)
+    surface the same headline numbers — Judd-Wright compression /ILSS
+    knockdowns and the closed-form local sensitivities (#65). Keeping the
+    formatting in one place means future log-format tweaks happen once
+    (#122).
+
+    Parameters
+    ----------
+    name : str
+        Configuration name (used in the message text).
+    result : dict
+        The raw worker dict returned by :func:`_analyze_one`. Contains the
+        nested ``empirical`` table and the live ``empirical_solver``.
+    is_parallel : bool
+        ``True`` formats a single-line "Configuration X done — ..." line
+        suitable for interleaved parallel completions. ``False`` uses the
+        indented multi-line serial UX. The tornado line is always emitted
+        last when sensitivities are available.
+    """
+    comp_kd = result['empirical']['compression']['judd_wright']['knockdown']
+    ilss_kd = result['empirical']['ilss']['judd_wright']['knockdown']
+    if is_parallel:
+        logger.info("  Configuration %s done — "
+                    "compression KD (J-W) %.3f, ILSS KD (J-W) %.3f",
+                    name, comp_kd, ilss_kd)
+    else:
+        logger.info("    Compression KD (J-W): %.3f", comp_kd)
+        logger.info("    ILSS KD (J-W):        %.3f", ilss_kd)
+
+    # Issue #65: surface the closed-form local sensitivities at the same
+    # Vp_mean used for the headline KD. The empirical solver only lives
+    # on the worker dict (post-#103 it moves to ConfigArtifacts), so when
+    # the caller has stripped artifacts we degrade gracefully rather than
+    # raise.
+    solver = result.get('empirical_solver')
+    if solver is None:
+        logger.info(
+            "    Tornado [%s]: (sensitivities unavailable: "
+            "re-run with return_artifacts=True)", name)
+        return
+    s = solver.local_sensitivities(mode='compression', model='judd_wright')
+    logger.info(
+        "    Tornado [%s]: dKD/dVp=%.3g, dKD/dcoef=%.3g",
+        name, s['dKD_dVp'], s['dKD_dcoef'])
+
+
 def compare_configurations(void_volume_fraction: float,
                            material_name: str = 'T800_epoxy',
                            applied_stress: float = -1500.0,
@@ -221,18 +270,7 @@ def compare_configurations(void_volume_fraction: float,
             Vp_out, name_out, result = _analyze_one(
                 Vp, name, config, mat, stress, sd)
             raw_results[(Vp_out, name_out)] = result
-            comp_kd = result['empirical']['compression']['judd_wright']['knockdown']
-            ilss_kd = result['empirical']['ilss']['judd_wright']['knockdown']
-            logger.info("    Compression KD (J-W): %.3f", comp_kd)
-            logger.info("    ILSS KD (J-W):        %.3f", ilss_kd)
-            # Issue #65: surface the closed-form local sensitivities at
-            # the same Vp_mean used for the headline KD. This is a free
-            # diagnostic — the partials are analytic.
-            s = result['empirical_solver'].local_sensitivities(
-                mode='compression', model='judd_wright')
-            logger.info(
-                "    Tornado [%s]: dKD/dVp=%.3g, dKD/dcoef=%.3g",
-                name_out, s['dKD_dVp'], s['dKD_dcoef'])
+            _log_result_summary(name_out, result, is_parallel=False)
     else:
         logger.info("Parallel sweep: %d task(s) across %d worker process(es)",
                     len(tasks), workers)
@@ -241,16 +279,7 @@ def compare_configurations(void_volume_fraction: float,
             for fut in concurrent.futures.as_completed(futures):
                 Vp_out, name_out, result = fut.result()
                 raw_results[(Vp_out, name_out)] = result
-                comp_kd = result['empirical']['compression']['judd_wright']['knockdown']
-                ilss_kd = result['empirical']['ilss']['judd_wright']['knockdown']
-                logger.info("  Configuration %s done — "
-                            "compression KD (J-W) %.3f, ILSS KD (J-W) %.3f",
-                            name_out, comp_kd, ilss_kd)
-                s = result['empirical_solver'].local_sensitivities(
-                    mode='compression', model='judd_wright')
-                logger.info(
-                    "    Tornado [%s]: dKD/dVp=%.3g, dKD/dcoef=%.3g",
-                    name_out, s['dKD_dVp'], s['dKD_dcoef'])
+                _log_result_summary(name_out, result, is_parallel=True)
 
     # Re-assemble in the original config insertion order so callers see a
     # deterministic dict regardless of which worker finished first.

--- a/porosity_fe/reporting.py
+++ b/porosity_fe/reporting.py
@@ -84,6 +84,32 @@ def parse_layup(text: str) -> list:
     return angles
 
 
+def _sanitise_filename_component(value: str) -> str:
+    """Replace filesystem-unfriendly characters in a filename fragment.
+
+    Slashes and spaces are the common offenders in material codes and
+    user-typed NCR references (e.g. ``"T800/epoxy"``, ``"NCR 12"``); both
+    become underscores so the resulting filename is portable across
+    Windows, macOS and Linux.
+    """
+    return str(value).replace("/", "_").replace(" ", "_")
+
+
+def download_filename_stem(payload: dict) -> str:
+    """Build a templated download filename stem from the export payload.
+
+    Encodes material, fibre-volume-porosity and today's date so users who
+    run many analyses do not collide on generic names like
+    ``porosity_results.json`` (#130). The returned stem has no extension —
+    callers append ``.json``/``.csv``/``.pdf`` etc.
+    """
+    cfg = payload["config"]
+    Vp_pct = float(cfg.get("Vp_percent", cfg.get("Vp", 0.0) * 100))
+    material = _sanitise_filename_component(cfg.get("material", "unknown"))
+    today = datetime.date.today().strftime("%Y%m%d")
+    return f"porosity_{material}_Vp{Vp_pct:.1f}pct_{today}"
+
+
 def build_export_payload(result: dict) -> dict:
     """Flatten an analysis result into the export payload structure.
 

--- a/tests/test_porosity_fe.py
+++ b/tests/test_porosity_fe.py
@@ -3748,6 +3748,23 @@ class TestExportHelpers:
             float(row[2])
             float(row[3])
 
+    def test_download_filename_stem_templates_material_vp_date(self):
+        """Stem encodes material, Vp%, and today's date (#130)."""
+        import datetime as _dt
+        from porosity_fe.reporting import build_export_payload, download_filename_stem
+        stem = download_filename_stem(build_export_payload(self._sample_result()))
+        today = _dt.date.today().strftime("%Y%m%d")
+        assert stem == f"porosity_T800_epoxy_Vp3.0pct_{today}"
+
+    def test_download_filename_stem_sanitizes_material_slashes(self):
+        """Slashes/spaces in material codes become underscores (#130)."""
+        from porosity_fe.reporting import download_filename_stem
+        payload = {"config": {"material": "T800/epoxy", "Vp_percent": 2.5}}
+        stem = download_filename_stem(payload)
+        assert "/" not in stem
+        assert "T800_epoxy" in stem
+        assert "Vp2.5pct" in stem
+
 
 class TestNCRExport:
     """NCR validation-summary attachment for MRB disposition support."""


### PR DESCRIPTION
One pipeline refactor + three Streamlit UX polish items. All independent.

## Closes

- Closes #122 — extract `_log_result_summary` helper, dedupe serial/parallel logging in `compare_configurations`
- Closes #129 — explain that empirical results are still valid when the FE solve is skipped
- Closes #130 — template Streamlit download filenames with material / Vp / date stem
- Closes #133 — warn on degenerate (<100 elements) and runaway (>50k) mesh sizes in the Expert tab

## Changes

### #122 — `pipeline.py` logging dedup
New private helper `_log_result_summary(name, result, *, is_parallel)` pulls `comp_kd`, `ilss_kd`, and the tornado sensitivities, then formats them as either a single-line "Configuration X done — …" (parallel) or the multi-line indented serial form. Both branches of `compare_configurations` now call the helper. Sensitivities access is guarded: at the in-loop logging point the worker dict still carries `empirical_solver`, so `local_sensitivities` is available directly without `return_artifacts=True`; if a future caller passes a stripped dict, the helper logs `"(sensitivities unavailable: re-run with return_artifacts=True)"` instead of raising.

### #129 — FE-skipped warning
The single-line `st.warning("FE skipped: …")` in `app.py` is now a multi-line warning explaining (a) what happened, (b) that **empirical knockdown results are still valid**, (c) how to retry with FE (adjust mesh in the Expert tab or pick a different loading mode). Links to the README's existing `### Solver selection: FE vs. empirical` section (which #141 added in PR #165).

### #130 — Download filename templates
New helpers `_sanitise_filename_component()` and `download_filename_stem(payload)` in `porosity_fe/reporting.py` (kept out of `app.py` so they're unit-testable without Streamlit). JSON / CSV download buttons now produce e.g. `porosity_T800_epoxy_Vp3.0pct_20260523.json`. NCR exports prefer the user-typed `ncr_reference` (now sanitized) and fall back to the templated stem instead of the generic `porosity_analysis_summary`. Two new unit tests pin the template format and the slash-sanitization.

### #133 — Mesh-size warnings
Right after the Expert-tab nx/ny/nz sliders, a non-blocking warning fires on `nx * ny * nz < 100` ("very coarse, defaults are 30×10×12 = 3600") or `> 50_000` ("very fine, est. ~N min, consider reducing"). Run button stays enabled — power users can ignore.

## Test plan

- [x] `pytest tests/ -q` — 559 passed, 1 skipped (was 557 on master; +2 from #130)
- [x] `python -c "import app"` smoke check passes
- [x] `_log_result_summary` produces identical log content to the pre-refactor branches (manually verified at `logging.INFO`)
- [ ] CI green on this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_01L1ovdBYzTQRV4DKwSR4JmC)_