### PR TITLE
Frozen results (#110), pathlib migration (#113), pipeline factory (#120), Calibration namespace (#121)

### DIFF
--- a/examples/clustered_midplane.py
+++ b/examples/clustered_midplane.py
@@ -27,10 +27,8 @@ matplotlib.use("Agg")
 
 from porosity_fe import (  # noqa: E402
     MATERIALS,
-    CompositeMesh,
-    EmpiricalSolver,
     FEVisualizer,
-    PorosityField,
+    build_empirical_pipeline,
 )
 
 OUT_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "output")
@@ -39,12 +37,13 @@ os.makedirs(OUT_DIR, exist_ok=True)
 
 def main() -> None:
     material = MATERIALS["T800_epoxy"]
-    pf = PorosityField(material, void_volume_fraction=0.03,
-                       distribution="clustered",
-                       void_shape="spherical",
-                       cluster_location="midplane")
-    mesh = CompositeMesh(pf, material, nx=30, ny=10, nz=24)
-    solver = EmpiricalSolver(mesh, material)
+    pf, mesh, solver = build_empirical_pipeline(
+        material, 0.03,
+        mesh_res=(30, 10, 24),
+        porosity_config=dict(distribution="clustered",
+                             void_shape="spherical",
+                             cluster_location="midplane"),
+    )
     result = solver.get_failure_load(mode="ilss", model="judd_wright")
 
     z, Vp_z = pf.effective_porosity_profile(nz=100)

--- a/examples/discrete_voids.py
+++ b/examples/discrete_voids.py
@@ -25,11 +25,9 @@ matplotlib.use("Agg")
 
 from porosity_fe import (  # noqa: E402
     MATERIALS,
-    CompositeMesh,
-    EmpiricalSolver,
     FEVisualizer,
-    PorosityField,
     VoidGeometry,
+    build_empirical_pipeline,
 )
 
 OUT_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "output")
@@ -46,11 +44,12 @@ def main() -> None:
         VoidGeometry(center=(35.0,  6.0, 2.20),
                      radii=(2.5, 2.0, 0.6)),
     ]
-    pf = PorosityField(material, void_volume_fraction=0.005,
-                       distribution="uniform", void_shape="spherical",
-                       discrete_voids=voids)
-    mesh = CompositeMesh(pf, material, nx=40, ny=15, nz=12)
-    solver = EmpiricalSolver(mesh, material)
+    pf, mesh, solver = build_empirical_pipeline(
+        material, 0.005,
+        mesh_res=(40, 15, 12),
+        porosity_config=dict(distribution="uniform", void_shape="spherical",
+                             discrete_voids=voids),
+    )
     result = solver.get_failure_load(mode="compression", model="judd_wright")
 
     print("Material:        T800_epoxy")

--- a/examples/distribution_comparison.py
+++ b/examples/distribution_comparison.py
@@ -47,9 +47,9 @@ import numpy as np  # noqa: E402
 from porosity_fe import (  # noqa: E402
     MATERIALS,
     CompositeMesh,
-    EmpiricalSolver,
     FESolver,
     PorosityField,
+    build_empirical_pipeline,
 )
 
 OUT_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "output")
@@ -88,8 +88,11 @@ def _empirical_table(material):
     """Empirical KD for every (distribution, mode, model) at VP_MEAN."""
     rows = []
     for label, kwargs in DISTRIBUTIONS:
-        pf, mesh = _build(material, kwargs)
-        solver = EmpiricalSolver(mesh, material)
+        _pf, _mesh, solver = build_empirical_pipeline(
+            material, VP_MEAN,
+            mesh_res=(12, 4, 12),
+            porosity_config=kwargs,
+        )
         kds = solver.get_all_failure_loads()
         for mode in MODES:
             for model in MODELS:

--- a/examples/interface_penny.py
+++ b/examples/interface_penny.py
@@ -26,10 +26,8 @@ matplotlib.use("Agg")
 
 from porosity_fe import (  # noqa: E402
     MATERIALS,
-    CompositeMesh,
-    EmpiricalSolver,
     FEVisualizer,
-    PorosityField,
+    build_empirical_pipeline,
 )
 
 OUT_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "output")
@@ -38,11 +36,11 @@ os.makedirs(OUT_DIR, exist_ok=True)
 
 def main() -> None:
     material = MATERIALS["T800_epoxy"]
-    pf = PorosityField(material, void_volume_fraction=0.03,
-                       distribution="interface",
-                       void_shape="penny")
-    mesh = CompositeMesh(pf, material, nx=30, ny=10, nz=24)
-    solver = EmpiricalSolver(mesh, material)
+    pf, mesh, solver = build_empirical_pipeline(
+        material, 0.03,
+        mesh_res=(30, 10, 24),
+        porosity_config=dict(distribution="interface", void_shape="penny"),
+    )
     res_ilss = solver.get_failure_load(mode="ilss", model="judd_wright")
     res_comp = solver.get_failure_load(mode="compression", model="judd_wright")
 

--- a/examples/uniform_spherical.py
+++ b/examples/uniform_spherical.py
@@ -27,10 +27,8 @@ matplotlib.use("Agg")
 
 from porosity_fe import (  # noqa: E402
     MATERIALS,
-    CompositeMesh,
-    EmpiricalSolver,
     FEVisualizer,
-    PorosityField,
+    build_empirical_pipeline,
 )
 
 OUT_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "output")
@@ -39,10 +37,11 @@ os.makedirs(OUT_DIR, exist_ok=True)
 
 def main() -> None:
     material = MATERIALS["T800_epoxy"]
-    pf = PorosityField(material, void_volume_fraction=0.03,
-                       distribution="uniform", void_shape="spherical")
-    mesh = CompositeMesh(pf, material, nx=30, ny=10, nz=12)
-    solver = EmpiricalSolver(mesh, material)
+    pf, mesh, solver = build_empirical_pipeline(
+        material, 0.03,
+        mesh_res=(30, 10, 12),
+        porosity_config=dict(distribution="uniform", void_shape="spherical"),
+    )
     result = solver.get_failure_load(mode="compression", model="judd_wright")
 
     sigma_0 = material.sigma_1c

--- a/porosity_fe/__init__.py
+++ b/porosity_fe/__init__.py
@@ -68,6 +68,7 @@ from .cli import _configure_cli_logging as _configure_cli_logging  # noqa: F401,
 from .cli import _DynamicStdoutHandler as _DynamicStdoutHandler  # noqa: F401, E402
 from .cli import _vp_label as _vp_label  # noqa: F401, E402
 from .cli import main as main  # noqa: F401, E402
+from .empirical import Calibration as Calibration  # noqa: F401, E402
 from .empirical import EmpiricalSolver as EmpiricalSolver  # noqa: F401, E402
 from .fatigue import _FATIGUE_B_QI as _FATIGUE_B_QI  # noqa: F401, E402
 from .fatigue import _FATIGUE_KD_FLOOR as _FATIGUE_KD_FLOOR  # noqa: F401, E402
@@ -157,6 +158,7 @@ __all__ = [
     "ConfigResult",
     "FailureResult",
     # Empirical / fatigue / UQ
+    "Calibration",
     "EmpiricalSolver",
     "FatigueModel",
     "propagate_uncertainty",

--- a/porosity_fe/__init__.py
+++ b/porosity_fe/__init__.py
@@ -107,6 +107,7 @@ from .pipeline import _analyze_one as _analyze_one  # noqa: F401, E402
 from .pipeline import _build_config_artifacts as _build_config_artifacts  # noqa: F401, E402
 from .pipeline import _build_config_result as _build_config_result  # noqa: F401, E402
 from .pipeline import _resolve_n_jobs as _resolve_n_jobs  # noqa: F401, E402
+from .pipeline import build_empirical_pipeline as build_empirical_pipeline  # noqa: F401, E402
 from .pipeline import compare_configurations as compare_configurations  # noqa: F401, E402
 from .porosity_field import POROSITY_CONFIGS as POROSITY_CONFIGS  # noqa: F401, E402
 from .porosity_field import PorosityField as PorosityField  # noqa: F401, E402
@@ -187,6 +188,7 @@ __all__ = [
     "load_results_from_json",
     "save_results_to_json",
     # Pipeline / CLI
+    "build_empirical_pipeline",
     "compare_configurations",
     "main",
     # Version

--- a/porosity_fe/_ply_angles.py
+++ b/porosity_fe/_ply_angles.py
@@ -10,11 +10,13 @@ from typing import List, Optional, Tuple, Union
 
 #: Canonical QI baseline layup (8-ply symmetric ``[0/90/45/-45]_s``).
 #: Used to expand the ``ply_angles='QI'`` sentinel (#44 item 2).
+#: Also exposed as :attr:`Calibration.PLY_ANGLES_QI` (#121).
 _PLY_ANGLES_QI: Tuple[float, ...] = (0.0, 90.0, 45.0, -45.0, -45.0, 45.0, 90.0, 0.0)
 
 #: Canonical UD baseline (4 plies, all 0 deg). Used to expand the
 #: ``ply_angles='UD'`` sentinel; the FE / empirical scaling only cares about
 #: the angle distribution, so a short list is fine.
+#: Also exposed as :attr:`Calibration.PLY_ANGLES_UD` (#121).
 _PLY_ANGLES_UD: Tuple[float, ...] = (0.0, 0.0, 0.0, 0.0)
 
 

--- a/porosity_fe/cli.py
+++ b/porosity_fe/cli.py
@@ -1,9 +1,11 @@
 """argparse-driven CLI (``porosity-analyze``)."""
 
+from __future__ import annotations
+
 import argparse
 import logging
-import os
 import sys
+from pathlib import Path
 from typing import List, Optional
 
 from . import __version__
@@ -284,11 +286,11 @@ def main(argv: Optional[List[str]] = None) -> int:
                 f"{hint}"
             )
 
-    output_dir = args.output_dir
+    output_dir = Path(args.output_dir)
     try:
-        os.makedirs(output_dir, exist_ok=True)
+        output_dir.mkdir(parents=True, exist_ok=True)
     except OSError as exc:
-        print(f"ERROR: cannot create output directory {output_dir!r}: {exc}",
+        print(f"ERROR: cannot create output directory {str(output_dir)!r}: {exc}",
               file=sys.stderr)
         return 2
 
@@ -334,34 +336,28 @@ def main(argv: Optional[List[str]] = None) -> int:
                 art = artifacts[name]
                 viz.plot_porosity_field(
                     art.porosity_field,
-                    save_path=os.path.join(
-                        output_dir, f"porosity_profile_{name}_{Vp_label}.png"))
+                    save_path=output_dir / f"porosity_profile_{name}_{Vp_label}.png")
                 viz.plot_mesh_3d(
                     art.mesh,
-                    save_path=os.path.join(
-                        output_dir, f"porosity_mesh_3d_{name}_{Vp_label}.png"))
+                    save_path=output_dir / f"porosity_mesh_3d_{name}_{Vp_label}.png")
                 viz.plot_mesh_detail(
                     art.mesh,
-                    save_path=os.path.join(
-                        output_dir, f"porosity_mesh_detail_{name}_{Vp_label}.png"))
+                    save_path=output_dir / f"porosity_mesh_detail_{name}_{Vp_label}.png")
                 viz.plot_damage_contour(
                     art.mesh,
                     art.empirical_solver,
-                    save_path=os.path.join(
-                        output_dir, f"porosity_damage_{name}_{Vp_label}.png"))
+                    save_path=output_dir / f"porosity_damage_{name}_{Vp_label}.png")
             viz.plot_model_comparison(
                 results,
-                save_path=os.path.join(
-                    output_dir, f"porosity_comparison_{Vp_label}.png"))
+                save_path=output_dir / f"porosity_comparison_{Vp_label}.png")
 
-        out_path = os.path.join(
-            output_dir, f"porosity_analysis_results_{Vp_label}.json")
+        out_path = output_dir / f"porosity_analysis_results_{Vp_label}.json"
         save_fn(results, out_path, artifacts=artifacts)
 
     if args.plots and all_results:
         viz.plot_knockdown_curves(
             all_results,
-            save_path=os.path.join(output_dir, "porosity_knockdown_curves.png"))
+            save_path=output_dir / "porosity_knockdown_curves.png")
 
     _bar = "=" * 70
     logger.info("\n%s", _bar)
@@ -371,5 +367,5 @@ def main(argv: Optional[List[str]] = None) -> int:
     logger.info("Porosity levels analyzed: %s",
                 [f"{v*100:.2f}%" for v in args.vp])
     logger.info("Configurations: %s", list(porosity_configs.keys()))
-    logger.info("Output directory: %s", os.path.abspath(output_dir))
+    logger.info("Output directory: %s", output_dir.resolve())
     return 0

--- a/porosity_fe/cli.py
+++ b/porosity_fe/cli.py
@@ -6,7 +6,7 @@ import argparse
 import logging
 import sys
 from pathlib import Path
-from typing import List, Optional
+from typing import List
 
 from . import __version__
 from .io import save_results_to_json
@@ -35,7 +35,7 @@ def _vp_label(Vp: float) -> str:
     return f"{pct:.4f}".rstrip('0').rstrip('.').replace('.', 'p') + "pct"
 
 
-def _build_arg_parser() -> 'argparse.ArgumentParser':
+def _build_arg_parser() -> argparse.ArgumentParser:
     """Construct the argparse driver for the analysis pipeline."""
     parser = argparse.ArgumentParser(
         prog="porosity-analyze",
@@ -235,7 +235,7 @@ def _resolve_via_shim(name: str, fallback):
     return getattr(shim, name, fallback)
 
 
-def main(argv: Optional[List[str]] = None) -> int:
+def main(argv: List[str] | None = None) -> int:
     """Argparse-driven entry point.
 
     Returns

--- a/porosity_fe/empirical.py
+++ b/porosity_fe/empirical.py
@@ -5,7 +5,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import numpy as np
 
-from ._ply_angles import _resolve_ply_angles
+from ._ply_angles import _PLY_ANGLES_QI, _PLY_ANGLES_UD, _resolve_ply_angles
 from .fatigue import FatigueModel
 from .materials import MaterialProperties
 from .mesh import CompositeMesh
@@ -13,22 +13,28 @@ from .results import FailureResult
 
 logger = logging.getLogger("porosity_fe_analysis")
 
-class EmpiricalSolver:
-    """Fast analytical solver using empirical porosity-strength models.
 
-    Coefficients are calibrated against quasi-isotropic data and scaled by
-    a layup-dependent matrix-dominated fraction so that fiber-dominated
-    layups (e.g. UD [0]_n) see a smaller porosity penalty than QI layups.
+class Calibration:
+    """All empirical knockdown & fatigue calibration constants in one place.
 
-    Knockdowns are evaluated at the specimen-average porosity (Vp_mean),
-    matching how the original correlations were calibrated — not at the
-    local peak Vp that clustered distributions produce.
+    Single source of truth for tuning surfaces. See issue #121.
+    Override per material by passing kwargs to :class:`EmpiricalSolver`
+    (``judd_wright_alpha``, ``power_law_n``, ``linear_beta``) or to the
+    relevant solver entry points.
+
+    The previously scattered module-level / class-level names
+    (``_JUDD_WRIGHT_ALPHA_QI``, ``_FATIGUE_B_QI``, ``_PLY_ANGLES_QI``,
+    ``_UQ_DEFAULT_PERCENTILES``, etc.) remain available as deprecated
+    aliases pointing back at the attributes defined here.
     """
 
+    # ------------------------------------------------------------------
+    # Empirical Vp -> strength knockdown coefficients (QI-calibrated)
+    # ------------------------------------------------------------------
     # QI-calibrated coefficients (Elhajjar 2025, Sci. Rep. 15:25977).
-    # `_F_MD_REF = 0.5` below is the LAYUP-SCALING reference (scale = 1.0 at
+    # ``F_MD_REF = 0.5`` below is the LAYUP-SCALING reference (scale = 1.0 at
     # f_md = 0.5), NOT a property of the Elhajjar coupon layup itself
-    # (`[0/45/90/-45/0]_s`, which the binning rule below puts at f_md = 0.4).
+    # (``[0/45/90/-45/0]_s``, which the binning rule below puts at f_md = 0.4).
     # The coefficients were tuned with the layup-scaling already applied,
     # so they represent the model's effective f_md = 0.5 baseline rather
     # than the raw fit on a single layup.
@@ -41,31 +47,41 @@ class EmpiricalSolver:
     # 'transverse_tension' (sigma_2t, in-plane transverse, matrix-dominated;
     # alpha matched to ilss because both fail by matrix/interface-dominated
     # mechanisms — see issue #35).
-    _JUDD_WRIGHT_ALPHA_QI = {
+    JUDD_WRIGHT_ALPHA_QI: Dict[str, float] = {
         'compression': 6.9, 'tension': 3.9, 'shear': 8.0, 'ilss': 10.0,
         'transverse_tension': 10.0,
     }
-    _POWER_LAW_N_QI = {
+    POWER_LAW_N_QI: Dict[str, float] = {
         'compression': 2.8, 'tension': 1.8, 'shear': 3.5, 'ilss': 4.5,
         'transverse_tension': 4.5,
     }
-    _LINEAR_BETA_QI = {
+    LINEAR_BETA_QI: Dict[str, float] = {
         'compression': 5.5, 'tension': 3.5, 'shear': 7.0, 'ilss': 9.0,
         'transverse_tension': 9.0,
     }
-    PRISTINE_STRENGTH_KEY = {
-        'compression': 'sigma_1c', 'tension': 'sigma_1t',
-        'shear': 'tau_12', 'ilss': 'tau_ilss',
-        'transverse_tension': 'sigma_2t',
-    }
+
+    # ------------------------------------------------------------------
+    # Fatigue S-N surface (issue #104 / #59) — mirrored from
+    # :mod:`porosity_fe.fatigue` to keep ``Calibration`` a single
+    # discovery point. The fatigue module remains the implementation
+    # site (FatigueModel uses these); the values here are the same
+    # objects (assigned at the bottom of this module to break the
+    # ``fatigue -> empirical`` import cycle).
+    # ------------------------------------------------------------------
+    FATIGUE_B_QI: Dict[str, float]
+    FATIGUE_KD_FLOOR: float
+
+    # ------------------------------------------------------------------
+    # Layup scaling (matrix-dominated fraction)
+    # ------------------------------------------------------------------
     # Modes whose porosity sensitivity is matrix-/interface-dominated even in
     # UD layups (where the longitudinal-fiber metric would otherwise drive
-    # f_md to ~0).  These modes use the elevated ``_F_MD_FLOOR_ILSS`` floor.
-    _MATRIX_DOMINATED_MODES = frozenset({'ilss', 'transverse_tension'})
+    # f_md to ~0). These modes use the elevated ``F_MD_FLOOR_ILSS`` floor.
+    MATRIX_DOMINATED_MODES = frozenset({'ilss', 'transverse_tension'})
     # QI reference fraction and minimum floor
-    _F_MD_REF = 0.5    # f_md for the QI layup used in calibration
-    # ``_F_MD_FLOOR`` / ``_F_MD_FLOOR_ILSS`` are hard floors on the layup-scale
-    # multiplier ``scale = f_md / _F_MD_REF`` returned by ``_layup_scale``.
+    F_MD_REF: float = 0.5    # f_md for the QI layup used in calibration
+    # ``F_MD_FLOOR`` / ``F_MD_FLOOR_ILSS`` are hard floors on the layup-scale
+    # multiplier ``scale = f_md / F_MD_REF`` returned by ``_layup_scale``.
     # Without them ``scale -> 0`` for pure UD ([0]_n, f_md = 0.0), which would
     # imply zero porosity sensitivity for fiber-dominated layups — physically
     # wrong, since even UD coupons show measurable porosity knockdown at high
@@ -80,19 +96,72 @@ class EmpiricalSolver:
     # refactor (#136). No coupon-dataset regression, optimization, or
     # physical-argument origin has been located for either value — see
     # issue #139 for the calibration gap. A future calibration campaign
-    # should validate ``_F_MD_FLOOR`` against UD coupon data across
+    # should validate ``F_MD_FLOOR`` against UD coupon data across
     # Vp in [0, 5%] (per-mode, since compression vs tension UD sensitivities
-    # differ) and ``_F_MD_FLOOR_ILSS`` against matrix-dominated coupons in
+    # differ) and ``F_MD_FLOOR_ILSS`` against matrix-dominated coupons in
     # the same range. Issue #140 (which already pinned a ~33% linearity gap
     # in ``_layup_scale`` itself) and #139 should be addressed together so
     # the replacement rule and its floors are calibrated against the same
     # reference dataset.
-    _F_MD_FLOOR = 0.15  # even UD retains some matrix sensitivity; empirical, see #139
+    F_MD_FLOOR: float = 0.15  # even UD retains some matrix sensitivity; empirical, see #139
     # ILSS and transverse-tension are matrix-/interface-dominated regardless
     # of fiber-direction layup (the void-dominated stress component is in the
     # matrix), so the floor preserves most of the QI calibration. 0.80 is an
     # empirical tuning constant — not derived from published validation data.
-    _F_MD_FLOOR_ILSS = 0.80  # ILSS / transverse-tension floor; empirical, see #139
+    F_MD_FLOOR_ILSS: float = 0.80  # ILSS / transverse-tension floor; empirical, see #139
+
+    # ------------------------------------------------------------------
+    # Canonical ply-angle baselines (sentinel expansion for 'QI' / 'UD')
+    # ------------------------------------------------------------------
+    #: Canonical QI baseline layup (8-ply symmetric ``[0/90/45/-45]_s``).
+    PLY_ANGLES_QI: Tuple[float, ...] = _PLY_ANGLES_QI
+    #: Canonical UD baseline (4 plies, all 0 deg).
+    PLY_ANGLES_UD: Tuple[float, ...] = _PLY_ANGLES_UD
+
+    # ------------------------------------------------------------------
+    # Numerical floors / reporting defaults
+    # ------------------------------------------------------------------
+    #: Lower clamp on per-element strengths (MPa) inside the FE failure
+    #: index loop. Prevents the 1/X reciprocals in Tsai-Wu / Hashin from
+    #: overflowing to ``inf`` for heavily degraded elements.
+    STRENGTH_FLOOR_MPA: float = 1e-3
+    #: Default percentiles reported by the UQ helpers (5/50/95 band, the
+    #: spread an A-/B-basis workflow typically wants to see first).
+    UQ_DEFAULT_PERCENTILES: Tuple[float, ...] = (5.0, 50.0, 95.0)
+
+
+class EmpiricalSolver:
+    """Fast analytical solver using empirical porosity-strength models.
+
+    Coefficients are calibrated against quasi-isotropic data and scaled by
+    a layup-dependent matrix-dominated fraction so that fiber-dominated
+    layups (e.g. UD [0]_n) see a smaller porosity penalty than QI layups.
+
+    Knockdowns are evaluated at the specimen-average porosity (Vp_mean),
+    matching how the original correlations were calibrated — not at the
+    local peak Vp that clustered distributions produce.
+    """
+
+    # Calibration constants now live on :class:`Calibration` (#121). The
+    # class-level names below are deprecated back-compat aliases preserved
+    # so existing tests and downstream callers that read
+    # ``EmpiricalSolver._JUDD_WRIGHT_ALPHA_QI`` continue to work. New code
+    # should reference ``Calibration.JUDD_WRIGHT_ALPHA_QI`` etc. directly.
+    # See the ``Calibration`` docstring for the full list and the inline
+    # commentary on each constant (Judd-Wright derivation, F_MD floor
+    # provenance, etc.).
+    _JUDD_WRIGHT_ALPHA_QI = Calibration.JUDD_WRIGHT_ALPHA_QI
+    _POWER_LAW_N_QI = Calibration.POWER_LAW_N_QI
+    _LINEAR_BETA_QI = Calibration.LINEAR_BETA_QI
+    PRISTINE_STRENGTH_KEY = {
+        'compression': 'sigma_1c', 'tension': 'sigma_1t',
+        'shear': 'tau_12', 'ilss': 'tau_ilss',
+        'transverse_tension': 'sigma_2t',
+    }
+    _MATRIX_DOMINATED_MODES = Calibration.MATRIX_DOMINATED_MODES
+    _F_MD_REF = Calibration.F_MD_REF
+    _F_MD_FLOOR = Calibration.F_MD_FLOOR
+    _F_MD_FLOOR_ILSS = Calibration.F_MD_FLOOR_ILSS
 
     def __init__(self, mesh: CompositeMesh, material: MaterialProperties,
                  ply_angles: Optional[Union[List[float], str]] = 'QI',
@@ -148,11 +217,11 @@ class EmpiricalSolver:
 
         # Resolve coefficient dicts: per-mode merge of class default with override.
         alpha_qi = self._merge_coefficient_override(
-            self._JUDD_WRIGHT_ALPHA_QI, judd_wright_alpha, 'judd_wright_alpha')
+            Calibration.JUDD_WRIGHT_ALPHA_QI, judd_wright_alpha, 'judd_wright_alpha')
         n_qi = self._merge_coefficient_override(
-            self._POWER_LAW_N_QI, power_law_n, 'power_law_n')
+            Calibration.POWER_LAW_N_QI, power_law_n, 'power_law_n')
         beta_qi = self._merge_coefficient_override(
-            self._LINEAR_BETA_QI, linear_beta, 'linear_beta')
+            Calibration.LINEAR_BETA_QI, linear_beta, 'linear_beta')
 
         # Compute layup-dependent scaling
         self.f_md = self._matrix_dominated_fraction(ply_angles_resolved)
@@ -224,10 +293,10 @@ class EmpiricalSolver:
                 total += 0.5
         return total / len(ply_angles)
 
-    # TODO(#140): The linear f_md / _F_MD_REF scaling is preserved here for
-    # historical compatibility. Investigation in #140 measured a relative
-    # error of up to 33.5% against a CLT-derived stiffness-retention proxy
-    # (sqrt(Ex_layup(Vp)/Ex_layup(0)) / sqrt(Ex_QI(Vp)/Ex_QI(0)) over
+    # TODO(#140): The linear f_md / Calibration.F_MD_REF scaling is preserved
+    # here for historical compatibility. Investigation in #140 measured a
+    # relative error of up to 33.5% against a CLT-derived stiffness-retention
+    # proxy (sqrt(Ex_layup(Vp)/Ex_layup(0)) / sqrt(Ex_QI(Vp)/Ex_QI(0)) over
     # Vp in [0.005, 0.05]) for a UD [0,0,0]_s layup; >5% error also seen
     # on UD-heavy [0_2,90]_s and off-axis [0,15,-15]_s layups. A
     # polynomial or interpolated lookup should be evaluated against an
@@ -243,9 +312,10 @@ class EmpiricalSolver:
         - f_md = 0 (UD) -> scale = floor (0.15 for most modes, 0.80 for ILSS)
         - f_md > f_md_ref -> scale > 1.0 (more matrix-dominated than QI)
         """
-        floor = (self._F_MD_FLOOR_ILSS if mode in self._MATRIX_DOMINATED_MODES
-                 else self._F_MD_FLOOR)
-        ref = self._F_MD_REF
+        floor = (Calibration.F_MD_FLOOR_ILSS
+                 if mode in Calibration.MATRIX_DOMINATED_MODES
+                 else Calibration.F_MD_FLOOR)
+        ref = Calibration.F_MD_REF
         if ref < 1e-12:
             return 1.0
         raw = self.f_md / ref
@@ -842,4 +912,16 @@ class EmpiricalSolver:
             return float((f(Vp0 + h, coef0) - f(Vp0 - h, coef0)) / (2.0 * h))
         # param == 'coef'
         return float((f(Vp0, coef0 + h) - f(Vp0, coef0 - h)) / (2.0 * h))
+
+
+# Wire the fatigue calibration into ``Calibration`` after the fatigue
+# module has finished importing. This breaks the
+# ``fatigue -> empirical -> fatigue`` cycle: ``fatigue.py`` defines the
+# canonical dict/floor, and ``Calibration`` exposes the same objects so
+# callers can discover every tuning surface from one namespace (#121).
+from .fatigue import _FATIGUE_B_QI as _FATIGUE_B_QI_SRC  # noqa: E402
+from .fatigue import _FATIGUE_KD_FLOOR as _FATIGUE_KD_FLOOR_SRC  # noqa: E402
+
+Calibration.FATIGUE_B_QI = _FATIGUE_B_QI_SRC
+Calibration.FATIGUE_KD_FLOOR = _FATIGUE_KD_FLOOR_SRC
 

--- a/porosity_fe/fatigue.py
+++ b/porosity_fe/fatigue.py
@@ -21,12 +21,19 @@ import numpy as np
 # WWFE-III fatigue exercise. These are screening-level values; production
 # allowables should use a fully populated S-N matrix per CMH-17 Vol. 2.
 #
+# These are the canonical objects; ``Calibration.FATIGUE_B_QI`` /
+# ``Calibration.FATIGUE_KD_FLOOR`` in :mod:`porosity_fe.empirical`
+# re-export them so every tuning surface is discoverable from one
+# namespace (#121). Update values here; the alias picks them up.
+#
 # References:
 # - Mandell, J. F., "Fatigue Behavior of Fiber-Resin Composites,"
 #   Developments in Reinforced Plastics 2, 1991.
 # - Curtis, P. T., "The fatigue behaviour of fibrous composite materials,"
 #   J. Strain Analysis, 1989.
 # ============================================================
+# Back-compat alias retained for direct importers (tests, downstream code).
+# New code should reference ``Calibration.FATIGUE_B_QI``.
 _FATIGUE_B_QI: Dict[str, float] = {
     'tension': 0.10,
     'compression': 0.10,
@@ -39,6 +46,7 @@ _FATIGUE_B_QI: Dict[str, float] = {
 # extrapolation predicts a negative knockdown. Clamp to 1% of static so
 # downstream multiplications stay well-behaved, and emit a warning so the
 # caller knows they are off the calibration range.
+# Back-compat alias; canonical reference is ``Calibration.FATIGUE_KD_FLOOR``.
 _FATIGUE_KD_FLOOR = 0.01
 
 

--- a/porosity_fe/fe/solver.py
+++ b/porosity_fe/fe/solver.py
@@ -15,6 +15,7 @@ import scipy.sparse
 import scipy.sparse.linalg
 
 from .._ply_angles import _resolve_ply_angles
+from ..empirical import Calibration
 from ..homogenization import _mt_effective_stiffness
 from ..io import (
     FORMAT_FE_FIELDS,
@@ -880,8 +881,8 @@ class FESolver:
         # Strengths approaching zero make the 1/X reciprocals overflow to
         # inf; clamp to a numerical floor so a heavily-degraded element
         # produces a large-but-finite failure index instead of poisoning the
-        # global max with inf/NaN.
-        strength_floor = 1e-3  # MPa
+        # global max with inf/NaN. Canonical value in Calibration (#121).
+        strength_floor = Calibration.STRENGTH_FLOOR_MPA  # MPa
         return (max(Xt, strength_floor),
                 max(Xc, strength_floor),
                 max(Yt, strength_floor),

--- a/porosity_fe/fe/solver.py
+++ b/porosity_fe/fe/solver.py
@@ -8,7 +8,7 @@ import os
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, List, Literal, Optional, Tuple, Union
+from typing import Dict, List, Literal, Tuple
 
 import numpy as np
 import scipy.sparse
@@ -94,9 +94,9 @@ class FieldResults:
     strain_local: np.ndarray
     max_failure_index: float
     knockdown: float
-    per_element_failure_index: Optional[np.ndarray] = None
+    per_element_failure_index: np.ndarray | None = None
     failure_criterion: str = 'tsai_wu'
-    failure_mode_indices: Optional[Dict[str, float]] = None
+    failure_mode_indices: Dict[str, float] | None = None
 
     def __repr__(self) -> str:
         n_nodes = self.displacement.shape[0] if self.displacement is not None else 0
@@ -105,8 +105,8 @@ class FieldResults:
                 f"max_FI={self.max_failure_index:.4f}, "
                 f"knockdown={self.knockdown:.4f})")
 
-    def summary(self, sigma_pristine: Optional[float] = None,
-                model_label: Optional[str] = None) -> 'FailureResult':
+    def summary(self, sigma_pristine: float | None = None,
+                model_label: str | None = None) -> FailureResult:
         """Distill the field result into a :class:`FailureResult`.
 
         Unifies the FE return shape with the empirical solver (#44 item 1)
@@ -153,7 +153,7 @@ class FieldResults:
             },
         )
 
-    def to_vtk(self, mesh: 'CompositeMesh',
+    def to_vtk(self, mesh: CompositeMesh,
                filename: str | os.PathLike) -> None:
         """Write the hex mesh and per-element FE fields to a legacy ASCII VTK
         file (``UNSTRUCTURED_GRID``) for inspection in ParaView / VisIt / PyVista.
@@ -384,7 +384,7 @@ class FESolver:
 
     def __init__(self, mesh: CompositeMesh, material: MaterialProperties,
                  porosity_field: PorosityField,
-                 ply_angles: Optional[Union[List[float], str]] = 'QI',
+                 ply_angles: List[float] | str | None = 'QI',
                  failure_criterion: Literal[
                      'tsai_wu', 'hashin', 'max_stress'] = 'tsai_wu') -> None:
         self.mesh = mesh
@@ -411,8 +411,7 @@ class FESolver:
               applied_strain: float = -0.01,
               applied_load: float = -10.0,
               verbose: bool = False,
-              failure_criterion: Optional[Literal[
-                  'tsai_wu', 'hashin', 'max_stress']] = None,
+              failure_criterion: Literal['tsai_wu', 'hashin', 'max_stress'] | None = None,
               solver: Literal['direct', 'cg', 'minres'] = 'direct',
               rtol: float = 1e-9,
               diag_scale: bool = False,
@@ -1212,10 +1211,10 @@ class FESolver:
         }
 
     @staticmethod
-    def export_results(field_results: 'FieldResults',
+    def export_results(field_results: FieldResults,
                        filename: str | os.PathLike,
                        fmt: str = 'json',
-                       mesh: Optional['CompositeMesh'] = None,
+                       mesh: CompositeMesh | None = None,
                        include_raw: bool = False) -> None:
         """Export FE results to a JSON summary or a VTK field file.
 

--- a/porosity_fe/fe/solver.py
+++ b/porosity_fe/fe/solver.py
@@ -32,7 +32,7 @@ logger = logging.getLogger("porosity_fe_analysis")
 # SECTION 7g: FE SOLVER AND FIELD RESULTS
 # ============================================================
 
-@dataclass
+@dataclass(frozen=True)
 class FieldResults:
     """Results from a finite element solve.
 

--- a/porosity_fe/fe/solver.py
+++ b/porosity_fe/fe/solver.py
@@ -1,10 +1,13 @@
 """FE solver and FieldResults dataclass."""
 
+from __future__ import annotations
+
 import json
 import logging
 import os
 import time
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Dict, List, Literal, Optional, Tuple, Union
 
 import numpy as np
@@ -149,7 +152,8 @@ class FieldResults:
             },
         )
 
-    def to_vtk(self, mesh: 'CompositeMesh', filename: str) -> None:
+    def to_vtk(self, mesh: 'CompositeMesh',
+               filename: str | os.PathLike) -> None:
         """Write the hex mesh and per-element FE fields to a legacy ASCII VTK
         file (``UNSTRUCTURED_GRID``) for inspection in ParaView / VisIt / PyVista.
 
@@ -179,9 +183,10 @@ class FieldResults:
         mesh : CompositeMesh
             The mesh that produced these results (supplies geometry,
             connectivity, porosity and ply metadata).
-        filename : str
-            Output ``.vtk`` file path.
+        filename : str or os.PathLike
+            Output ``.vtk`` file path. ``pathlib.Path`` objects are accepted.
         """
+        filename = Path(filename)
         nodes = np.asarray(mesh.nodes, dtype=float)
         elements = np.asarray(mesh.elements, dtype=np.int64)
         n_nodes = nodes.shape[0]
@@ -1206,7 +1211,8 @@ class FESolver:
         }
 
     @staticmethod
-    def export_results(field_results: 'FieldResults', filename: str,
+    def export_results(field_results: 'FieldResults',
+                       filename: str | os.PathLike,
                        fmt: str = 'json',
                        mesh: Optional['CompositeMesh'] = None,
                        include_raw: bool = False) -> None:
@@ -1228,8 +1234,9 @@ class FESolver:
         ----------
         field_results : FieldResults
             Results from FESolver.solve().
-        filename : str
-            Output file path (``.json`` or ``.vtk``).
+        filename : str or os.PathLike
+            Output file path (``.json`` or ``.vtk``). ``pathlib.Path``
+            objects are accepted.
         fmt : str
             ``'json'`` (default) or ``'vtk'``.
         mesh : CompositeMesh, optional
@@ -1242,6 +1249,7 @@ class FESolver:
             bloated (#55).
         """
         fmt = str(fmt).lower()
+        filename = Path(filename)
         if fmt == 'vtk':
             if mesh is None:
                 raise ValueError(
@@ -1314,7 +1322,7 @@ class FESolver:
         if include_raw:
             # Sidecar file path lives next to the JSON so users see them
             # together; ``np.savez`` will append ``.npz`` if missing.
-            npz_path = f"{filename}.npz"
+            npz_path = filename.with_name(filename.name + ".npz")
             arrays = {
                 'displacement': np.asarray(field_results.displacement),
                 'stress_global': np.asarray(field_results.stress_global),
@@ -1326,7 +1334,7 @@ class FESolver:
                 arrays['per_element_failure_index'] = np.asarray(
                     field_results.per_element_failure_index)
             np.savez(npz_path, **arrays)
-            output['raw_sidecar'] = os.path.basename(npz_path)
+            output['raw_sidecar'] = npz_path.name
         with open(filename, 'w', encoding='utf-8') as f:
             json.dump(output, f, indent=2, default=_json_default)
         logger.info("Saved FE results: %s", filename)

--- a/porosity_fe/io.py
+++ b/porosity_fe/io.py
@@ -11,7 +11,7 @@ import platform
 import subprocess
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING, Dict, Optional
+from typing import TYPE_CHECKING, Dict
 
 import numpy as np
 
@@ -82,7 +82,7 @@ _UNITS_STREAMLIT_EMPIRICAL = {
 }
 
 
-def _build_provenance(seed: Optional[int] = None) -> dict:
+def _build_provenance(seed: int | None = None) -> dict:
     """Return a provenance metadata dict for JSON output reproducibility.
 
     Captures software versions, platform, timestamp, optional git commit,
@@ -100,7 +100,7 @@ def _build_provenance(seed: Optional[int] = None) -> dict:
     """
     try:
         import importlib.metadata as _ilm
-        pfe_version: Optional[str] = _ilm.version("porosity-fe")
+        pfe_version: str | None = _ilm.version("porosity-fe")
     except Exception:
         # Source checkout not pip-installed: fall back to the package
         # ``__version__`` attribute (defined in ``porosity_fe/__init__.py``).
@@ -110,7 +110,7 @@ def _build_provenance(seed: Optional[int] = None) -> dict:
     vi = sys.version_info
     python_version = f"{vi.major}.{vi.minor}.{vi.micro}"
 
-    def _pkg_version(module_name: str) -> Optional[str]:
+    def _pkg_version(module_name: str) -> str | None:
         mod = sys.modules.get(module_name)
         return getattr(mod, "__version__", None) if mod else None
 
@@ -123,7 +123,7 @@ def _build_provenance(seed: Optional[int] = None) -> dict:
             capture_output=True, text=True, timeout=5,
             cwd=Path(__file__).resolve().parent,
         )
-        git_commit: Optional[str] = result.stdout.strip() if result.returncode == 0 else None
+        git_commit: str | None = result.stdout.strip() if result.returncode == 0 else None
     except (subprocess.CalledProcessError, FileNotFoundError, Exception):
         git_commit = None
 
@@ -169,7 +169,7 @@ def _build_provenance(seed: Optional[int] = None) -> dict:
 
 
 def save_results_to_json(results: Dict, filename: str | os.PathLike,
-                         artifacts: Optional[Dict[str, 'ConfigArtifacts']] = None):
+                         artifacts: Dict[str, ConfigArtifacts] | None = None):
     """Export numerical results to JSON.
 
     Parameters

--- a/porosity_fe/io.py
+++ b/porosity_fe/io.py
@@ -1,5 +1,7 @@
 """JSON / VTK I/O helpers and provenance."""
 
+from __future__ import annotations
+
 import dataclasses
 import datetime
 import json
@@ -8,6 +10,7 @@ import os
 import platform
 import subprocess
 import sys
+from pathlib import Path
 from typing import TYPE_CHECKING, Dict, Optional
 
 import numpy as np
@@ -118,7 +121,7 @@ def _build_provenance(seed: Optional[int] = None) -> dict:
         result = subprocess.run(
             ["git", "rev-parse", "HEAD"],
             capture_output=True, text=True, timeout=5,
-            cwd=os.path.dirname(os.path.abspath(__file__)),
+            cwd=Path(__file__).resolve().parent,
         )
         git_commit: Optional[str] = result.stdout.strip() if result.returncode == 0 else None
     except (subprocess.CalledProcessError, FileNotFoundError, Exception):
@@ -165,7 +168,7 @@ def _build_provenance(seed: Optional[int] = None) -> dict:
     return prov
 
 
-def save_results_to_json(results: Dict, filename: str,
+def save_results_to_json(results: Dict, filename: str | os.PathLike,
                          artifacts: Optional[Dict[str, 'ConfigArtifacts']] = None):
     """Export numerical results to JSON.
 
@@ -176,8 +179,8 @@ def save_results_to_json(results: Dict, filename: str,
         :func:`compare_configurations`, or the legacy worker-dict shape
         (``Dict[str, dict]``). Both keep the same on-disk JSON shape so
         the published JSON schema is unchanged (#44 item 3).
-    filename : str
-        Output JSON path.
+    filename : str or os.PathLike
+        Output JSON path. ``pathlib.Path`` objects are accepted.
     artifacts : dict, optional
         Parallel ``Dict[str, ConfigArtifacts]`` from
         ``compare_configurations(..., return_artifacts=True)``. Used
@@ -206,6 +209,8 @@ def save_results_to_json(results: Dict, filename: str,
             if pf is not None:
                 seeds.add(getattr(pf, 'seed', None))
     seed = seeds.pop() if len(seeds) == 1 else None
+
+    filename = Path(filename)
 
     output = {
         'schema_version': JSON_SCHEMA_VERSION,
@@ -261,13 +266,16 @@ def save_results_to_json(results: Dict, filename: str,
     logger.info("Saved: %s", filename)
 
 
-def load_results_from_json(filename: str) -> Dict:
+def load_results_from_json(filename: str | os.PathLike) -> Dict:
     """Round-trip loader for save_results_to_json / export_results outputs.
 
     Validates schema_version compatibility and format identifier. Raises
     ValueError on missing or incompatible envelope so callers don't silently
     consume the wrong shape.
+
+    Accepts either a ``str`` path or any ``os.PathLike`` (e.g. ``pathlib.Path``).
     """
+    filename = Path(filename)
     with open(filename, encoding='utf-8') as f:
         data = json.load(f)
     if not isinstance(data, dict):

--- a/porosity_fe/pipeline.py
+++ b/porosity_fe/pipeline.py
@@ -3,15 +3,82 @@
 import concurrent.futures
 import logging
 import os
-from typing import Dict, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from .empirical import EmpiricalSolver
-from .materials import MATERIALS
+from .materials import MATERIALS, MaterialProperties
 from .mesh import CompositeMesh
 from .porosity_field import POROSITY_CONFIGS, PorosityField
 from .results import ConfigArtifacts, ConfigResult
 
 logger = logging.getLogger("porosity_fe_analysis")
+
+# Layup descriptor accepted by both ``CompositeMesh`` and ``EmpiricalSolver``:
+# either a sentinel string (``'QI'`` / ``'UD'``) or an explicit list of ply
+# angles in degrees. ``tuple`` is included for callers that build the layup
+# from an immutable sequence.
+LayupSpec = Union[str, List[float], Tuple[float, ...]]
+
+# Default mesh resolution used by the production sweep (``_analyze_one``) so
+# every call site picks up the same defaults.
+_DEFAULT_MESH_RES: Tuple[int, int, int] = (30, 10, 12)
+
+
+def build_empirical_pipeline(
+    material: MaterialProperties,
+    void_volume_fraction: float,
+    *,
+    ply_angles: LayupSpec = 'QI',
+    mesh_res: Tuple[int, int, int] = _DEFAULT_MESH_RES,
+    porosity_config: Optional[Dict[str, Any]] = None,
+    seed: Optional[int] = None,
+) -> Tuple[PorosityField, CompositeMesh, EmpiricalSolver]:
+    """Factory: ``(material, Vp) -> (PorosityField, CompositeMesh, EmpiricalSolver)``.
+
+    Single point of change for mesh defaults and ply-angle handling. The
+    three-step construction recurs in :func:`_analyze_one`, the UQ helper
+    in :mod:`porosity_fe.uq`, every script in ``examples/``, and several
+    tests; channeling them through this factory means future tweaks to the
+    mesh defaults or ply-angle handling happen exactly once. See issue
+    #120.
+
+    Parameters
+    ----------
+    material : MaterialProperties
+        Pristine composite material.
+    void_volume_fraction : float
+        Specimen-average void volume fraction in ``[0, 1]``.
+    ply_angles : str or list of float, optional
+        Layup descriptor passed to both :class:`CompositeMesh` and
+        :class:`EmpiricalSolver`. Defaults to ``'QI'``.
+    mesh_res : (int, int, int), optional
+        ``(nx, ny, nz)`` element counts. Defaults to the production sweep
+        resolution ``(30, 10, 12)``.
+    porosity_config : dict, optional
+        Extra keyword arguments forwarded to :class:`PorosityField` (e.g.
+        ``distribution``, ``void_shape``, ``cluster_location``,
+        ``discrete_voids``). ``seed`` may be set here or via the dedicated
+        ``seed`` parameter — the explicit ``seed=`` argument wins.
+    seed : int, optional
+        Recorded into the porosity field for reproducibility provenance.
+        Overrides any ``seed`` key in ``porosity_config``.
+
+    Returns
+    -------
+    (PorosityField, CompositeMesh, EmpiricalSolver)
+        The fully-constructed pipeline ready for ``get_failure_load`` /
+        ``get_all_failure_loads`` calls.
+    """
+    pf_kwargs: Dict[str, Any] = dict(porosity_config or {})
+    if seed is not None:
+        pf_kwargs['seed'] = seed
+    pf = PorosityField(material, void_volume_fraction, **pf_kwargs)
+    nx, ny, nz = mesh_res
+    mesh = CompositeMesh(pf, material, nx=nx, ny=ny, nz=nz,
+                         ply_angles=ply_angles)
+    emp = EmpiricalSolver(mesh, material, ply_angles=ply_angles)
+    return pf, mesh, emp
+
 
 # ============================================================
 # SECTION 8: ANALYSIS PIPELINE
@@ -65,9 +132,9 @@ def _analyze_one(Vp: float,
         re-assemble results even when the worker pool reorders completion.
     """
     material = MATERIALS[material_name]
-    porosity_field = PorosityField(material, Vp, seed=seed, **config)
-    mesh = CompositeMesh(porosity_field, material, nx=30, ny=10, nz=12)
-    empirical = EmpiricalSolver(mesh, material)
+    porosity_field, mesh, empirical = build_empirical_pipeline(
+        material, Vp, porosity_config=config, seed=seed,
+    )
     emp_results = empirical.get_all_failure_loads()
 
     result = {

--- a/porosity_fe/results.py
+++ b/porosity_fe/results.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
     from .mesh import CompositeMesh
     from .porosity_field import PorosityField
 
-@dataclass
+@dataclass(frozen=True)
 class FailureResult:
     """Unified failure-load summary returned by empirical and FE solvers.
 
@@ -129,7 +129,7 @@ class ConfigArtifacts:
     field_results: Optional['FieldResults'] = None
 
 
-@dataclass
+@dataclass(frozen=True)
 class ConfigResult:
     """Lightweight (numbers-only) per-configuration result from
     :func:`compare_configurations`.

--- a/porosity_fe/uq.py
+++ b/porosity_fe/uq.py
@@ -7,7 +7,7 @@ from typing import Dict, List, Optional, Tuple, Union
 
 import numpy as np
 
-from .empirical import EmpiricalSolver  # noqa: F401 (forward-ref in _build_solver annotation)
+from .empirical import Calibration, EmpiricalSolver  # noqa: F401 (EmpiricalSolver used as forward-ref in _build_solver annotation)
 from .materials import MATERIALS, MaterialProperties
 from .pipeline import build_empirical_pipeline
 
@@ -15,9 +15,9 @@ from .pipeline import build_empirical_pipeline
 # SECTION 6b: UNCERTAINTY PROPAGATION (MONTE CARLO / LHS)
 # ============================================================
 
-# Default percentiles reported by the UQ helpers (a 5%/50%/95% band, the
-# spread an A-/B-basis workflow typically wants to see first).
-_UQ_DEFAULT_PERCENTILES = (5.0, 50.0, 95.0)
+# Back-compat alias for the default percentiles surface — canonical
+# definition lives on ``Calibration.UQ_DEFAULT_PERCENTILES`` (#121).
+_UQ_DEFAULT_PERCENTILES = Calibration.UQ_DEFAULT_PERCENTILES
 _UQ_METHODS = ('monte_carlo', 'lhs')
 # Distributions that consume a standard-normal unit draw vs. a U(0,1) draw.
 _UQ_NORMAL_DISTS = ('lognormal', 'normal')
@@ -126,7 +126,7 @@ def propagate_uncertainty(void_volume_fraction: float,
                           n_samples: int = 1000,
                           method: str = 'monte_carlo',
                           seed: Optional[int] = None,
-                          percentiles: Tuple[float, ...] = _UQ_DEFAULT_PERCENTILES,
+                          percentiles: Tuple[float, ...] = Calibration.UQ_DEFAULT_PERCENTILES,
                           ply_angles: Optional[Union[List[float], str]] = 'QI',
                           config: Optional[Dict] = None) -> Dict:
     """Propagate input uncertainty through ``EmpiricalSolver.get_failure_load``.

--- a/porosity_fe/uq.py
+++ b/porosity_fe/uq.py
@@ -7,7 +7,10 @@ from typing import Dict, List, Optional, Tuple, Union
 
 import numpy as np
 
-from .empirical import Calibration, EmpiricalSolver  # noqa: F401 (EmpiricalSolver used as forward-ref in _build_solver annotation)
+from .empirical import (  # noqa: F401 (EmpiricalSolver used as forward-ref in _build_solver annotation)
+    Calibration,
+    EmpiricalSolver,
+)
 from .materials import MATERIALS, MaterialProperties
 from .pipeline import build_empirical_pipeline
 

--- a/porosity_fe/uq.py
+++ b/porosity_fe/uq.py
@@ -7,10 +7,9 @@ from typing import Dict, List, Optional, Tuple, Union
 
 import numpy as np
 
-from .empirical import EmpiricalSolver
+from .empirical import EmpiricalSolver  # noqa: F401 (forward-ref in _build_solver annotation)
 from .materials import MATERIALS, MaterialProperties
-from .mesh import CompositeMesh
-from .porosity_field import PorosityField
+from .pipeline import build_empirical_pipeline
 
 # ============================================================
 # SECTION 6b: UNCERTAINTY PROPAGATION (MONTE CARLO / LHS)
@@ -225,10 +224,14 @@ def propagate_uncertainty(void_volume_fraction: float,
         # builds one mesh per draw, so silence it (additive: we do not touch
         # CompositeMesh itself).
         with contextlib.redirect_stdout(io.StringIO()):
-            pf = PorosityField(material_obj, vp_value, **config)
-            msh = CompositeMesh(pf, material_obj, nx=4, ny=3, nz=3,
-                                ply_angles=ply_angles)
-            return EmpiricalSolver(msh, material_obj, ply_angles=ply_angles)
+            _pf, _mesh, emp = build_empirical_pipeline(
+                material_obj,
+                vp_value,
+                ply_angles=ply_angles,
+                mesh_res=(4, 3, 3),
+                porosity_config=config,
+            )
+            return emp
 
     # Deterministic nominal (no perturbation): the mean must land near this.
     nominal = _build_solver(mat, float(void_volume_fraction)).get_failure_load(

--- a/tests/test_porosity_fe.py
+++ b/tests/test_porosity_fe.py
@@ -4818,19 +4818,19 @@ class TestCLIMain:
 
     def test_cli_main_output_dir_permission_error(
             self, tmp_path, monkeypatch, capsys):
-        """If ``os.makedirs`` raises OSError (e.g. permission denied or an
-        invalid path), the CLI must surface the failure on stderr and
-        return exit code 2 rather than crashing with a traceback. Covers
-        cli.py lines ~284-287."""
+        """If output-directory creation raises OSError (e.g. permission
+        denied or an invalid path), the CLI must surface the failure on
+        stderr and return exit code 2 rather than crashing with a
+        traceback. Covers cli.py lines ~284-287."""
         def _raise_permission_error(*args, **kwargs):
             raise PermissionError("denied")
 
-        # Patch ``os.makedirs`` on the cli module so the call inside
-        # main() picks up the raising stub. The shim doesn't re-export
-        # the cli submodule, so import it via the package directly.
-        from porosity_fe import cli as _cli_mod
+        # The CLI now uses ``Path.mkdir`` (issue #113 modernisation), so
+        # patch the directory-creation primitive on the Path class so the
+        # call inside main() picks up the raising stub.
+        from pathlib import Path as _Path
         monkeypatch.setattr(
-            _cli_mod.os, 'makedirs',
+            _Path, 'mkdir',
             _raise_permission_error,
         )
         rc = porosity_fe_analysis.main([

--- a/validate_porosity_cli.py
+++ b/validate_porosity_cli.py
@@ -11,11 +11,14 @@ Usage:
     validate_porosity --quiet            # suppress per-dataset output
 """
 
+from __future__ import annotations
+
 import argparse
 import logging
 import os
 import sys
 from datetime import datetime, timezone
+from pathlib import Path
 
 
 def _resolve_version() -> str:
@@ -45,31 +48,32 @@ def _resolve_bundled_datasets_dir() -> str:
     if getattr(sys, 'frozen', False):
         # Running inside a PyInstaller bundle
         base = sys._MEIPASS
-        return os.path.join(base, 'validation', 'datasets')
+        return str(Path(base) / 'validation' / 'datasets')
     # Running from source
-    here = os.path.dirname(os.path.abspath(__file__))
-    return os.path.join(here, 'validation', 'datasets')
+    here = Path(__file__).resolve().parent
+    return str(here / 'validation' / 'datasets')
 
 
 def _resolve_bundled_schema_dir() -> str:
     """Return path to the bundled schemas directory."""
     if getattr(sys, 'frozen', False):
         base = sys._MEIPASS
-        return os.path.join(base, 'validation', 'schemas')
-    here = os.path.dirname(os.path.abspath(__file__))
-    return os.path.join(here, 'validation', 'schemas')
+        return str(Path(base) / 'validation' / 'schemas')
+    here = Path(__file__).resolve().parent
+    return str(here / 'validation' / 'schemas')
 
 
-def _configure_debug_logging(output_dir: str) -> str:
+def _configure_debug_logging(output_dir: str | os.PathLike) -> str:
     """Attach a DEBUG file handler so a failed run leaves a diagnosable log.
 
     Returns the path of the log file. The validation pipeline already calls
     ``logger.exception(...)`` on swallowed errors (#19); without a handler at
     DEBUG those tracebacks go nowhere.
     """
-    os.makedirs(output_dir, exist_ok=True)
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
     stamp = datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%SZ')
-    log_path = os.path.join(output_dir, f'validate_porosity_{stamp}.log')
+    log_path = output_dir / f'validate_porosity_{stamp}.log'
     handler = logging.FileHandler(log_path, encoding='utf-8')
     handler.setLevel(logging.DEBUG)
     handler.setFormatter(logging.Formatter(
@@ -82,7 +86,7 @@ def _configure_debug_logging(output_dir: str) -> str:
     # validation-pipeline tracebacks this log exists to capture (#19).
     for noisy in ('matplotlib', 'PIL', 'fontTools'):
         logging.getLogger(noisy).setLevel(logging.WARNING)
-    return log_path
+    return str(log_path)
 
 
 def _ensure_validation_imports():
@@ -97,7 +101,7 @@ def _ensure_validation_imports():
         # Append, not insert(0, ...): a file dropped next to this script
         # must not be able to shadow a stdlib / site-packages module of the
         # same name on import (#29).
-        here = os.path.dirname(os.path.abspath(__file__))
+        here = str(Path(__file__).resolve().parent)
         if here not in sys.path:
             sys.path.append(here)
 
@@ -157,7 +161,7 @@ def main(argv=None) -> int:
 
     # Resolve dataset directory
     datasets_dir = args.datasets or _resolve_bundled_datasets_dir()
-    if not os.path.isdir(datasets_dir):
+    if not Path(datasets_dir).is_dir():
         print(f"ERROR: Datasets directory not found: {datasets_dir}",
               file=sys.stderr)
         return 2
@@ -175,7 +179,7 @@ def main(argv=None) -> int:
         print(f"Loaded {len(results)} datasets. Generating report...")
 
     # Ensure output dir exists
-    os.makedirs(args.output_dir, exist_ok=True)
+    Path(args.output_dir).mkdir(parents=True, exist_ok=True)
 
     # Generate report
     plot_path, md_path = generate_master_report(results,


### PR DESCRIPTION
Three refactors + one defensive-correctness change. Touches results / IO / pipeline / empirical modules.

## Closes

- Closes #110 — mark `FailureResult` / `ConfigResult` / `FieldResults` as `frozen` dataclasses
- Closes #113 — migrate `os.path` → `pathlib`, accept `os.PathLike` in public I/O signatures
- Closes #120 — add `build_empirical_pipeline` factory; dedupe `PorosityField → CompositeMesh → EmpiricalSolver` across pipeline / uq / examples
- Closes #121 — consolidate calibration constants into a `Calibration` namespace class

## Changes

### #110 — frozen dataclasses (defensive correctness)
`@dataclass(frozen=True)` added to all three result classes in `porosity_fe/results.py` and `porosity_fe/fe/solver.py`. Verified by grep that no code reassigns fields on these instances post-construction. No `__post_init__` exists on any of them, so no `object.__setattr__` conversion was needed. The dict-style back-compat shim (`__getitem__`, `__contains__`, `get`, `keys`, `to_dict`) is read-only and unaffected. Existing `dataclasses.replace` call sites in tests confirmed compatible.

### #113 — pathlib migration
~21 `os.path.*` call sites migrated across `porosity_fe/cli.py`, `porosity_fe/io.py`, `porosity_fe/fe/solver.py`, and the root `validate_porosity_cli.py`. Public I/O signatures now accept `str | os.PathLike` with `Path(...)` normalization at entry:
- `save_results_to_json`, `load_results_from_json`
- `FESolver.export_results`, `FieldResults.to_vtk`
- `_configure_debug_logging` (semi-public)

`from __future__ import annotations` added where needed. `os` import dropped from `cli.py` (no longer needed); retained elsewhere for `os.environ`, `os.getcwd`, and `os.PathLike` annotations. Intentionally skipped: `porosity_fe_analysis.py` shim, the `POROSITY_FE_INCLUDE_HOSTNAME` env-var access, `app.py` (already modern), and tests that already use `tmp_path`.

### #120 — `build_empirical_pipeline` factory
New factory in `porosity_fe/pipeline.py` (exported from `porosity_fe/__init__.py`) that produces `(PorosityField, CompositeMesh, EmpiricalSolver)` from `(material, Vp, ply_angles, mesh_res, porosity_config, seed)`. Single point of change for mesh defaults and ply-angle handling. Migrated:
- `_analyze_one` in `pipeline.py`
- `_build_solver` in `uq.py` (and pruned now-unused imports)
- 4 example scripts: `uniform_spherical.py`, `clustered_midplane.py`, `discrete_voids.py`, `interface_penny.py`
- The empirical path of `distribution_comparison.py`; its FE-path `_build` helper kept (different 3-step pattern)

Deliberately NOT migrated: `tests/test_porosity_fe.py` — no existing local `_build_solver` helper to dedupe; the many `PorosityField(...)` / `EmpiricalSolver(...)` test sites exercise individual layers (Vp validation, void-shape errors, coefficient overrides) and don't follow the canonical 3-step pattern.

### #121 — `Calibration` namespace
New `class Calibration` in `porosity_fe/empirical.py` aggregates 13 tuning constants previously scattered across `empirical.py`, `fatigue.py`, `fe/solver.py`, and `uq.py`:
- Knockdown coeffs: `JUDD_WRIGHT_ALPHA_QI`, `POWER_LAW_N_QI`, `LINEAR_BETA_QI`
- Fatigue: `FATIGUE_B_QI`, `FATIGUE_KD_FLOOR`
- Layup scaling: `MATRIX_DOMINATED_MODES`, `F_MD_REF`, `F_MD_FLOOR`, `F_MD_FLOOR_ILSS`
- Ply-angle baselines: `PLY_ANGLES_QI`, `PLY_ANGLES_UD`
- Numerical floors: `STRENGTH_FLOOR_MPA` (replaces inline `1e-3` in `_degraded_strengths`), `UQ_DEFAULT_PERCENTILES`

Back-compat aliases kept for `EmpiricalSolver._JUDD_WRIGHT_ALPHA_QI` etc., `porosity_fe.fatigue._FATIGUE_B_QI`, `porosity_fe._ply_angles._PLY_ANGLES_QI`, and `porosity_fe.uq._UQ_DEFAULT_PERCENTILES` — to avoid breaking any test or downstream importer. The TODO comment near `_layup_scale` (#140 / PR #165) and the `_F_MD_FLOOR` provenance commentary (#139 / PR #166) are preserved verbatim inside the `Calibration` body.

`Calibration` is exported from `porosity_fe/__init__.py`.

## Merge notes

One conflict during cherry-pick in `porosity_fe/uq.py` — both #120 and #121 modified the imports. Resolved by combining: `from .empirical import Calibration, EmpiricalSolver` with the existing `noqa: F401` for the `EmpiricalSolver` forward-ref.

## Test plan

- [x] `pytest tests/ -q` — 559 passed, 1 skipped (unchanged — these are all refactors, no new tests)
- [x] `python -c "import app"` smoke check passes
- [x] `python examples/uniform_spherical.py` produces the expected `knockdown=0.8130 / 1219.5 MPa` output
- [x] `ruff check porosity_fe/ examples/` clean
- [ ] CI green on this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_01L1ovdBYzTQRV4DKwSR4JmC)_