### PR TITLE
Add Claude Code guidance and skills for project collaboration

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# SessionStart hook for Claude Code on the web.
+#
+# Installs PorosityFE in editable mode with the [all] extras (web +
+# dev + docs) so a fresh container can immediately run the project's
+# real gate: `pytest tests/`, `ruff check .`, `mypy porosity_fe
+# porosity_fe_analysis.py`, and `streamlit run app.py`.
+#
+# Mirrors the CI lint job's `numpy<2` pin so local mypy runs reproduce
+# CI's signal (numpy 2.x stubs surface unrelated errors -- see the
+# pinning comment in .github/workflows/tests.yml).
+set -euo pipefail
+
+# Only run inside the remote (Claude Code on the web) container. Local
+# dev environments manage their own venv.
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+cd "${CLAUDE_PROJECT_DIR:-$(pwd)}"
+
+# Skip the `pip install --upgrade pip` that CI runs: the web-session
+# container uses a Debian-managed pip that can't uninstall itself
+# ("Cannot uninstall pip ..., RECORD file not found"). The shipped pip
+# is new enough to resolve our deps.
+pip install -e ".[all]"
+# Lint-env pin: matches .github/workflows/tests.yml so `mypy` produces
+# the same diagnostics locally as in CI.
+pip install "numpy<2"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -10,5 +10,12 @@
         ]
       }
     ]
+  },
+  "permissions": {
+    "allow": [
+      "Bash(python -m pytest *)",
+      "Bash(ruff check *)",
+      "Bash(mypy *)"
+    ]
   }
 }

--- a/.claude/skills/add-material-preset/SKILL.md
+++ b/.claude/skills/add-material-preset/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: add-material-preset
+description: Add a new composite material system to the MATERIALS preset registry. Use when the user says things like "add T1100/epoxy as a preset", "register a new material", or "add an HM63 carbon system" — anything that needs a new keyed entry under porosity_fe/materials.py:MATERIALS so it shows up in the Streamlit sidebar dropdown and is selectable by name from compare_configurations / build_empirical_pipeline.
+---
+
+# Add a material preset
+
+A preset is a `MaterialProperties(...)` value stored under a string key in
+the `MATERIALS` dict in `porosity_fe/materials.py`. The Streamlit sidebar
+reads `list(MATERIALS.keys())` (`app.py:479`) and the analysis pipeline
+resolves names via `MATERIALS[cfg["material_name"]]` (`app.py:120-125`),
+so a single registry entry covers both the UI dropdown and the CLI.
+
+## Required information from the user
+
+Get all of these before writing — `MaterialProperties` has no defaults
+for the engineering constants, so a missing field is a hard error:
+
+- **Identity**: short snake_case key (e.g. `T1100_epoxy`), fiber name,
+  matrix resin name, and a citation for the lamina properties (Daniel &
+  Ishai, WWFE, manufacturer data sheet, etc.).
+- **Stiffness (MPa)**: `E11, E22, E33, G12, G13, G23, nu12, nu13, nu23`.
+- **Strength (MPa)**: `sigma_1c, sigma_1t, sigma_2t, sigma_2c, tau_12, tau_ilss`.
+- **Geometry (mm / count)**: `t_ply`, `n_plies`.
+- **Constituents** (used by the FE Eshelby/Mori-Tanaka micromechanics path —
+  populate even if the user only plans to run the empirical solver, both
+  paths read from the same dataclass): `matrix_modulus, matrix_poisson,
+  fiber_modulus, fiber_volume_fraction`.
+
+If the user only has a partial spec, ask for the missing fields before
+editing — don't invent values.
+
+## Steps
+
+1. **Sanity-check the inputs.** Confirm:
+   - `E11 > E22` (fiber direction stiffer than transverse).
+   - `nu12 < 0.5` and the orthotropic compliance is positive-definite
+     (rough check: `1 - nu12*nu21 - nu23*nu32 - nu13*nu31 - 2*nu21*nu32*nu13 > 0`,
+     using `nu21 = nu12 * E22 / E11` etc.).
+   - `fiber_volume_fraction` in `[0.3, 0.8]` (the validation-dataset
+     schema enforces this bound for a reason — quote that to the user
+     if their `Vf` is outside it).
+
+2. **Edit `porosity_fe/materials.py`.** Add the entry to the `MATERIALS`
+   dict near line 495, keeping the existing style (multiline block with
+   the same field ordering as the surrounding presets). Include a
+   one-line citation comment above the entry pointing at the source
+   (e.g. `# AS4/3501-6 — Soden, Hinton & Kaddour, WWFE-I, CST 1998`).
+
+3. **Wire it into the existence-check test.** In
+   `tests/test_materials.py`, the `TestMATERIALS` block (around line 31)
+   asserts each preset key is in `MATERIALS` and pulls representative
+   fields. Add an analogous assertion for the new key so a future
+   accidental deletion fails CI.
+
+4. **Run the gate locally:**
+   ```bash
+   python -m pytest tests/test_materials.py -v
+   ruff check porosity_fe/materials.py
+   mypy porosity_fe/materials.py
+   ```
+   (Use `python -m pytest` rather than bare `pytest` — the web-container
+   `pytest` is uv-isolated and can't see the project deps; see
+   `CLAUDE.md`.)
+
+5. **Don't touch `app.py`, `compare_configurations`, or the validation
+   datasets.** The Streamlit dropdown picks up new keys automatically
+   from `list(MATERIALS.keys())`; `compare_configurations` resolves the
+   name through the same dict; validation datasets describe what was
+   experimentally tested and aren't tied to the preset registry.
+
+## What this skill does NOT cover
+
+- **Calibrating empirical `alpha`/`n`/`beta` for the new material.** Those
+  live on `EmpiricalSolver` (not on `MaterialProperties`) and need
+  coupon data to fit. See README "Calibrating `alpha` / `n` for a custom
+  material". If the user wants the new preset to ship with non-QI
+  coefficients, surface that as a separate follow-up.
+- **Adding a validation dataset for the new material.** Use the
+  `add-validation-dataset` skill for that.

--- a/.claude/skills/add-validation-dataset/SKILL.md
+++ b/.claude/skills/add-validation-dataset/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: add-validation-dataset
+description: Add a new peer-reviewed experimental porosity dataset to the validation database. Use when the user says things like "add the Smith 2024 dataset", "digitize Fig 3 from Liu 2018 and add it", or "add a new ILSS validation paper" — anything that creates a new JSON file under validation/datasets/ that the validate_porosity CLI and validation/validate_all.py runner will consume.
+---
+
+# Add a validation dataset
+
+The validation database is a directory of per-paper JSON files under
+`validation/datasets/`, schema-checked against
+`validation/schemas/validation_dataset_schema.json`. The
+`validate_porosity` CLI iterates the directory and runs each dataset
+through the empirical pipeline to produce `validation_master_report.png`
++ `validation_detail_report.md`. The PyInstaller spec
+(`ValidatePorosity.spec`) bundles every `*.json` under
+`validation/datasets/` into the distributed executable, so a new dataset
+ships automatically with the next release build.
+
+The whole `validation/` tree is gitignored (the digitized values come
+from published figures and stay out of the repo). New datasets are
+shared via the bundled executable or by hand-off, not via git.
+
+## Required information from the user
+
+- **Paper identity**: full citation string, DOI, and the specific figure
+  or table the data came from (e.g. "Fig 5a, digitized with
+  WebPlotDigitizer" or "Table 2, tabulated").
+- **Material**: fiber, matrix, fiber volume fraction (must be in
+  `[0.3, 0.8]` — the schema enforces this), layup (`ply_angles` as a
+  list of degrees), `n_plies`, and an optional human-readable
+  `layup_name` (`"[0/45/90/-45]_s"`).
+- **Porosity measurement method**: `acid digestion`, `matrix burnoff`,
+  `μCT`, `ultrasonic C-scan`, etc.
+- **Baseline porosity**: the void content `pct` (0–15) of the
+  near-zero-porosity coupon group used to normalize the data.
+- **At least one property block.** The schema accepts these keys (and
+  nothing else, by `patternProperties`): `compression_strength`,
+  `tensile_strength`, `transverse_tensile_strength`, `ilss`,
+  `shear_strength`, `tensile_modulus`, `transverse_tensile_modulus`,
+  `flexural_modulus`, `shear_modulus`. Each property block needs:
+  - `test_standard` (ASTM / ISO / EN designation),
+  - `void_content_pct` (list of numbers in `[0, 15]`),
+  - `normalized_values` (list of the same length, values in `[0, 1.2]` —
+    `σ(Vp)/σ(baseline)`),
+  - and optionally `test_config`, `void_content_uncertainty`,
+    `normalized_uncertainty`, `absolute_values_MPa`,
+    `digitization_method` (`tabulated` | `webplotdigitizer` | `direct`).
+
+If a property block is missing `void_content_pct` or `normalized_values`,
+or their lengths don't match, refuse to write the file — the schema will
+reject it.
+
+## Steps
+
+1. **Pick a filename.** Use the convention already in the directory:
+   `<firstauthor>_<year>.json` lower-case (e.g. `liu_2018.json`,
+   `zhang_peek_2025.json`). If the same first-author/year is already
+   present, qualify with a one-word system tag like the existing
+   `zhang_peek_2025.json`.
+
+2. **Write the JSON.** Use `validation/datasets/elhajjar_2025.json` as
+   the canonical template — it exercises the full schema (two property
+   blocks, `test_config`, `digitization_method`, `notes`). Required
+   top-level keys: `reference`, `material`, `properties`. Recommended
+   extras: `doi`, `data_source`, `porosity_measurement`,
+   `baseline_porosity_pct`, `notes`.
+
+3. **Validate the JSON against the schema before saving** (the runner
+   will reject it otherwise — see `validation/validate_all.py:load_dataset`):
+   ```bash
+   python -c "
+   import json, jsonschema
+   schema = json.load(open('validation/schemas/validation_dataset_schema.json'))
+   data   = json.load(open('validation/datasets/<new_file>.json'))
+   jsonschema.validate(data, schema)
+   print('schema OK')"
+   ```
+
+4. **Run the full validation pipeline** to confirm the new dataset
+   loads and predicts cleanly end-to-end:
+   ```bash
+   validate_porosity --output-dir /tmp/poros-val
+   # Or in-process:
+   python -m validation.validate_all
+   ```
+   Check `validation_detail_report.md` for the new dataset's
+   per-property MAE row.
+
+5. **Run the database test** so the dataset count / discoverability
+   stays green:
+   ```bash
+   python -m pytest tests/test_validation_database.py -v
+   ```
+
+6. **Update README.md only if the dataset count changes a headline
+   number** — the "13 peer-reviewed experimental datasets" line in
+   `README.md` and the per-property MAE table in the "Validation"
+   section both depend on the database contents. Re-run
+   `validate_porosity` and copy the new aggregate MAEs (property- and
+   point-weighted) from its run summary.
+
+## What this skill does NOT cover
+
+- **Adding a new material preset.** Validation datasets describe what
+  was tested; the preset registry is independent. Use the
+  `add-material-preset` skill if the new paper uses a system that isn't
+  already in `MATERIALS`.
+- **Schema changes.** If the user has data that doesn't fit any of the
+  nine `patternProperties` keys, that's a schema edit, not a dataset
+  add — surface it as a follow-up and don't widen the schema silently.
+- **Committing or pushing the JSON.** The `validation/` tree is
+  gitignored on purpose (digitized data from published figures). The
+  dataset travels with the next PyInstaller build, not via git.

--- a/.claude/skills/release-checklist/SKILL.md
+++ b/.claude/skills/release-checklist/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: release-checklist
+description: Cut a new PorosityFE release — bump the version, update the changelog, run the full lint/type/test gate, and rebuild the standalone validate_porosity executable. Use when the user says things like "cut a 1.3.0 release", "prepare a patch release", "ship v1.2.1", or "tag the next version".
+---
+
+# Release checklist
+
+PorosityFE has two version sources of truth and one bundled binary:
+
+- `pyproject.toml` → `[project] version` — the canonical version.
+- `porosity_fe/__init__.py:__version__` — the fallback used in source
+  checkouts that aren't pip-installed. **Keep these two in lockstep.**
+- `dist/validate_porosity/validate_porosity` — the PyInstaller-built CLI
+  with the bundled validation database. CI builds this automatically per
+  push (see `.github/workflows/build-executables.yml`), but a local
+  rebuild verifies the spec still works before tagging.
+
+The CI matrix (`.github/workflows/tests.yml`) runs on Ubuntu/macOS/Windows
+× Python 3.10/3.11/3.12/3.13 plus a decoupled Streamlit smoke job and a
+lint job (`ruff` + `mypy` with `numpy<2`). Mirror it locally before tagging.
+
+## Get from the user first
+
+- **Target version** (semver: e.g. `1.3.0`).
+- **Release kind** (patch / minor / major) and a one-line headline for
+  the changelog.
+
+## Steps
+
+1. **Confirm the working tree is clean** and you're on the release
+   branch the user expects:
+   ```bash
+   git status
+   git log --oneline -10
+   ```
+
+2. **Bump the version in both files.**
+   - `pyproject.toml`: `version = "<new>"` under `[project]`.
+   - `porosity_fe/__init__.py`: the `__version__ = "<new>"` fallback
+     (the comment there explicitly says "keep in sync with
+     pyproject.toml on each release").
+
+3. **Update `CHANGELOG.md`.** Add a dated section for the new version
+   following the existing style. Pull the entries from `git log
+   <previous-tag>..HEAD --oneline` and group them into Added / Changed /
+   Fixed / Removed. Don't invent entries — every line should map to a
+   landed commit.
+
+4. **Run the local gate** (must mirror `.github/workflows/tests.yml`):
+   ```bash
+   # Lint job (mypy uses numpy<2 to match CI stubs)
+   ruff check .
+   pip install "numpy<2"
+   mypy porosity_fe porosity_fe_analysis.py
+
+   # Restore the runtime numpy and run tests
+   pip install "numpy>=1.20"
+   python -m pytest tests/ -v
+
+   # Streamlit smoke (decoupled in CI to protect the lib matrix from
+   # streamlit wheel issues on 3.13 — see issue #157)
+   python -c "import app; print('app imports OK')"
+   ```
+
+5. **Rebuild the standalone CLI** to verify the PyInstaller spec still
+   works and the validation datasets bundle cleanly:
+   ```bash
+   pip install pyinstaller
+   python -m PyInstaller ValidatePorosity.spec --noconfirm --clean
+   ./dist/validate_porosity/validate_porosity --help
+   ./dist/validate_porosity/validate_porosity --output-dir /tmp/rel-check
+   ```
+   Confirm `validation_master_report.png` + `validation_detail_report.md`
+   are produced and the aggregate MAEs match what the README claims (if
+   they drift past a tenth of a percent, update the README before
+   tagging).
+
+6. **Stop here and hand back to the user for the actual tag + push.**
+   Do *not* run `git tag` or `git push --tags` from the skill. Print
+   the suggested commands instead:
+   ```
+   git add pyproject.toml porosity_fe/__init__.py CHANGELOG.md
+   git commit -m "release: v<new>"
+   git tag -a v<new> -m "v<new>"
+   git push origin <branch> --follow-tags
+   ```
+   Confirm the version, changelog headline, and gate results in your
+   reply so the user can sanity-check before pushing.
+
+## What this skill does NOT cover
+
+- **Pushing tags or creating GitHub releases.** That's a deliberate
+  manual step — the user should review the staged commit + changelog
+  entry before any tag goes public.
+- **Cutting a PyPI release.** This project doesn't publish to PyPI from
+  CI; if/when it does, that step belongs here as a follow-up.
+- **Editing `CITATION.cff`.** Update it manually if the citation year
+  rolls over; the existing block already pins `year = {2026}`.

--- a/.claude/skills/screenshot-streamlit/SKILL.md
+++ b/.claude/skills/screenshot-streamlit/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: screenshot-streamlit
+description: Run the PorosityFE Streamlit app headlessly and capture screenshots for the README. Use when the user says things like "regenerate the screenshots", "update the knockdown_curves.png", "grab a fresh screenshot of the FE stress tab", or "the README screenshot is out of date".
+---
+
+# Screenshot the Streamlit app
+
+The README embeds three PNGs from `screenshots/`:
+`knockdown_curves.png`, `porosity_distributions.png`, and `void_scf.png`.
+They're hand-curated, not auto-generated, so regenerating them is a
+deliberate "I changed the UI / a default / a curve and want the README
+to match" step.
+
+`app.py` calls `matplotlib.use("Agg")` and adjusts `sys.path` before
+importing `pyplot`, so it runs cleanly in a headless container. The web
+extra (`streamlit`) is optional — install it explicitly before driving
+the UI.
+
+## Required first
+
+- **Which screenshot(s)** to regenerate (or "all three").
+- **Whether the user wants the same defaults** as the existing PNGs
+  (material `T800_epoxy`, layup QI, the canonical sweep), or different
+  inputs. The existing screenshots aren't pinned to a config in
+  source — confirm before clobbering them.
+
+## Steps
+
+1. **Install the web extra and start the app headlessly:**
+   ```bash
+   pip install -e ".[web]"
+   streamlit run app.py \
+     --server.headless true \
+     --server.port 8501 \
+     --browser.gatherUsageStats false &
+   # Wait for "You can now view your Streamlit app in your browser."
+   curl -sf http://localhost:8501/_stcore/health && echo "up"
+   ```
+
+2. **Capture screenshots.** Two viable paths depending on the host:
+   - **Playwright** (preferred — installable in the web container, no
+     display server needed):
+     ```bash
+     pip install playwright && playwright install chromium
+     python - <<'PY'
+     from playwright.sync_api import sync_playwright
+     with sync_playwright() as p:
+         browser = p.chromium.launch()
+         page = browser.new_page(viewport={"width": 1440, "height": 900})
+         page.goto("http://localhost:8501")
+         page.wait_for_selector("button:has-text('Run analysis')", timeout=15000)
+         # Drive the sidebar here: select material, set Vp, click Run.
+         page.click("button:has-text('Run analysis')")
+         page.wait_for_selector("[data-testid='stTabs']", timeout=30000)
+         # Switch tabs and screenshot each one into screenshots/.
+         page.screenshot(path="screenshots/knockdown_curves.png", full_page=False)
+         browser.close()
+     PY
+     ```
+   - **Selenium + headless Chrome**: fall back to this only if
+     Playwright is blocked by the environment. Same flow.
+
+3. **Match the existing PNG dimensions/aspect** so the README layout
+   doesn't shift. The current files were taken at roughly 1440×900;
+   honor that unless the user explicitly wants a different viewport.
+
+4. **Kill the streamlit process** when done:
+   ```bash
+   pkill -f "streamlit run app.py" || true
+   ```
+
+5. **Verify the new PNGs render** by checking file size and dimensions —
+   a 0-byte or 100-byte PNG means the selector waited on the wrong
+   element:
+   ```bash
+   for f in screenshots/*.png; do
+     printf '%s  ' "$f"; identify "$f" 2>/dev/null || stat -c '%s bytes' "$f"
+   done
+   ```
+
+6. **Show the user the new PNGs** (the `SendUserFile` tool surfaces them
+   in chat) before committing — these are user-facing assets and the
+   user should eyeball them.
+
+## Gotchas
+
+- **Don't reorder `app.py` imports.** It deliberately calls
+  `matplotlib.use("Agg")` and sets `sys.path` before importing `pyplot`
+  and sibling modules; `pyproject.toml` adds `E402` / `I001` to
+  ruff's per-file ignores for exactly that reason. Reordering will
+  silently break the headless run on hosts without a display.
+- **The Streamlit FE stress tab can take 30–60s to render** at the
+  production mesh resolution (`_DEFAULT_MESH_RES = (30, 10, 12)`).
+  Use a longer `page.wait_for_selector` timeout for the FE tabs than
+  for the Profile / Mesh tabs.
+- **Streamlit Community Cloud's tier is 1 GB RAM.** If you're trying to
+  capture an expert-mode mesh and the page never finishes, that's an
+  OOM — reduce `nx*ny*nz` in the sidebar before screenshotting.

--- a/.gitignore
+++ b/.gitignore
@@ -9,8 +9,10 @@ __pycache__/
 # Unpublished manuscript
 JOSS/
 
-# Claude Code project files
-CLAUDE.md
+# Claude Code project files. CLAUDE.md and the tracked bits of .claude/
+# (skills, hooks, settings.json) are shared with collaborators and fresh
+# web-session containers; session metadata under .claude/ is excluded
+# at the bottom of this file.
 docs/superpowers/
 
 # Validation data (digitized from published figures)
@@ -48,5 +50,9 @@ validation_master_report.png
 docs/_build/
 docs/api/
 
-# Claude worktrees and session metadata
-.claude/
+# Claude worktrees and session metadata. Skills, hooks, and project
+# settings.json are shared; everything else under .claude/ stays local.
+.claude/*
+!.claude/skills/
+!.claude/hooks/
+!.claude/settings.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,9 @@ pip install -e ".[all]"
 pytest tests/ -v                              # full suite
 pytest tests/test_homogenization.py -v        # one module
 pytest tests/test_fe_solver.py::TestName::test_x -v   # one test
+# In Claude Code on the web containers, `pytest` is uv-isolated and
+# cannot see the project deps installed by the SessionStart hook. Use
+# `python -m pytest ...` there.
 
 # Lint / type-check (matches .github/workflows/tests.yml)
 ruff check .

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,168 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+```bash
+# Dev install (core + web + dev + docs)
+pip install -e ".[all]"
+
+# Tests
+pytest tests/ -v                              # full suite
+pytest tests/test_homogenization.py -v        # one module
+pytest tests/test_fe_solver.py::TestName::test_x -v   # one test
+
+# Lint / type-check (matches .github/workflows/tests.yml)
+ruff check .
+mypy porosity_fe porosity_fe_analysis.py
+# The mypy job in CI pins `numpy<2` because the type stubs were validated
+# against numpy 1.x; numpy 2.x stubs surface unrelated errors. Runtime
+# stays unpinned. Install `pip install "numpy<2"` before running mypy
+# locally if you want to reproduce the CI signal.
+
+# Streamlit web app (requires the `web` extra)
+pip install -e ".[web]"
+streamlit run app.py                          # http://localhost:8501
+
+# Batch analysis CLI (entry points from pyproject.toml [project.scripts])
+porosity-analyze                              # sweep 5 Vp × 5 configs, PNG + JSON
+validate_porosity --help                      # run vs. bundled validation datasets
+
+# Standalone CLI executable (PyInstaller)
+python -m PyInstaller ValidatePorosity.spec --noconfirm --clean
+
+# Docs (Sphinx)
+cd docs && make html                          # output under docs/_build/html
+```
+
+## Architecture
+
+### Package layout (post #119 split)
+
+The implementation lives in the `porosity_fe/` package. The top-level
+`porosity_fe_analysis.py` is a 62-line **compatibility shim** that re-exports
+everything from `porosity_fe` so legacy `from porosity_fe_analysis import X`
+callers keep working. **New code should import from `porosity_fe` directly**;
+do not add new symbols to `porosity_fe_analysis.py`.
+
+The package re-exports its full public API from `porosity_fe/__init__.py` — the
+`__all__` list there is the authoritative public surface and what the Sphinx
+API page documents. Adding a public symbol means adding it both to its
+module and to `__init__.py` (re-export + `__all__` entry).
+
+### Two solver paths, one mesh
+
+Both solvers consume the same `PorosityField` + `CompositeMesh` + `MaterialProperties`
+triple but apply degradation differently. **They are designed to give
+different numerical answers for the same inputs**, not the same answer:
+
+- `EmpiricalSolver` (`porosity_fe/empirical.py`) — closed-form
+  knockdown applied **once at the laminate level** using the
+  specimen-average `Vp`. The distribution shape (`uniform` vs `clustered`
+  vs `interface`) has **no effect** here because all are renormalized to
+  the same mean. Layup enters via a matrix-dominated fraction `f_md`
+  computed from ply angles (`alpha_eff = alpha_QI · (f_md / 0.5)`, with
+  floors `_F_MD_FLOOR` / `_F_MD_FLOOR_ILSS`).
+- `FESolver` (`porosity_fe/fe/solver.py`) — builds a hex8 mesh and
+  applies stiffness degradation **per element** via Eshelby/Mori-Tanaka
+  micromechanics on the local `Vp(x, y, z)`. Strength degradation uses a
+  heuristic `strength ~ sqrt(stiffness_retention)` scaling (see
+  `_degraded_strengths`). The FE path **does** pick up distribution-shape
+  differences.
+
+When changing one solver, check whether the matching behavior in the
+other is intentional or needs to move in lockstep — they're independent
+implementations of the same physical claim.
+
+### `Vp` is always a fraction, never a percent
+
+`PorosityField.__init__` enforces `Vp ∈ [0, 1]` and emits a percent-vs-fraction
+hint when the value looks like a percent (`Vp ≥ 1.001`). Any new API that
+accepts porosity input must keep that convention; plotting may multiply by
+100 for display only. See "Inputs and Conventions" in README.md for the
+full table.
+
+### Ply-angle resolution
+
+`ply_angles` is a single string sentinel (`'QI'` / `'UD'`) or an explicit
+list, resolved through `porosity_fe._ply_angles._resolve_ply_angles`.
+`EmpiricalSolver`, `CompositeMesh`, and `FESolver` all funnel through this
+helper to avoid divergent defaults (the bug #44 item 2 fixed). Don't
+re-implement sentinel handling at a call site.
+
+### Sweep orchestration
+
+`porosity_fe/pipeline.py` owns the multi-config sweep. `_analyze_one` is
+the parallel worker invoked by `compare_configurations`; `_DEFAULT_MESH_RES
+= (30, 10, 12)` is the single source of truth for production mesh size.
+`build_empirical_pipeline` is the canonical factory used by examples,
+tests, and the UQ helper — when changing mesh defaults or ply-angle
+handling, change it here, not at the call sites.
+
+### Validation database
+
+`validation/datasets/*.json` holds 13 peer-reviewed experimental
+datasets, schema-validated against
+`validation/schemas/validation_dataset_schema.json`. The whole tree is
+gitignored (digitized from published figures, kept out of the repo); the
+PyInstaller spec bundles it into the CLI executable so end users get an
+offline-runnable validator. `validate_porosity_cli.py` calls
+`validation/validate_all.py` to run every dataset through the empirical
+pipeline and emit `validation_master_report.png` + `validation_detail_report.md`.
+
+### Streamlit app bootstrap
+
+`app.py` calls `matplotlib.use("Agg")` and adjusts `sys.path` **before**
+importing `pyplot` and sibling modules — this is why
+`pyproject.toml` adds `E402` / `I001` to `[tool.ruff.lint.per-file-ignores]`
+for `app.py`. Don't reorder those imports.
+
+### Test conftest layout
+
+The repo-root `conftest.py` adjusts `sys.path` so tests can find
+`porosity_fe`, `app`, `validate_porosity_cli`, and `validation` without an
+editable install (CI installs deps but historically not the package
+itself). `tests/conftest.py` adds the `_restore_porosity_logger`
+autouse fixture that undoes `_configure_cli_logging`'s
+`propagate = False` between tests — required because alphabetical
+collection puts `test_cli.py` first.
+
+## Units and conventions
+
+- **Stiffnesses and strengths: MPa. Thicknesses: mm.** Documented at the
+  API surface; look for the `Notes` block on
+  `MaterialProperties.get_stiffness_matrix`, `Hex8Element.B_matrix`,
+  `FieldResults`, and `EmpiricalSolver.apply_loading` for Voigt order,
+  engineering vs. tensor strain, and compression-sign conventions.
+- **Tsai-Wu `F_12`**: default is Tsai's `F_12 = -0.5·√(F_11·F_22)`; users
+  can override via `MaterialProperties(tsai_wu_F12=...)` (must be in
+  `[-1, 0]`).
+- **Calibration scope**: empirical coefficients are validated to
+  `Vp ≲ 0.05`; flag extrapolations explicitly.
+
+## CI matrix
+
+`.github/workflows/tests.yml` runs three jobs: `lint` (ruff + mypy on
+Python 3.12 with `numpy<2`), `test` (pytest on `{ubuntu, macos, windows}` ×
+`{3.10, 3.11, 3.12, 3.13}`), and `streamlit_smoke` (decoupled
+single-OS/Python import-only check — Streamlit wheel availability on 3.13
+can't be allowed to drop the whole library matrix red, see issue #157).
+`security.yml` runs `pip-audit` weekly. Match the matrix when adding
+version-sensitive code.
+
+## Adding materials and empirical coefficients
+
+- **New material preset**: add a `MaterialProperties(...)` entry to the
+  `MATERIALS` dict in `porosity_fe/materials.py`. All orthotropic
+  constants are required — there are no defaults. Both the FE
+  micromechanics path and the empirical path read from the same dataclass,
+  so populate constituent fields (`matrix_modulus`, `fiber_volume_fraction`,
+  etc.) even if you only plan to exercise the empirical solver.
+- **New empirical correlation**: add to `EmpiricalSolver`. Take `Vp` as a
+  fraction in `[0, 1]`, return `KD ∈ (0, 1]`. Document the calibration
+  set, the regression form (`ln(KD)` vs `Vp` for Judd-Wright,
+  `ln(KD)` vs `ln(1-Vp)` for power law), and the validity bound. Custom
+  per-mode overrides go through the keyword-only `judd_wright_alpha=` /
+  `power_law_n=` / `linear_beta=` constructor args, which layer on top of
+  the QI defaults with the same `f_md` scaling.


### PR DESCRIPTION
## Summary

This PR adds comprehensive Claude Code integration files to support collaborative development and AI-assisted workflows. It includes project guidance documentation, reusable skills for common tasks, session initialization hooks, and configuration for the Claude Code web environment.

## Key Changes

- **CLAUDE.md**: Comprehensive project guide covering:
  - Development commands (install, test, lint, run app, build docs)
  - Architecture overview (package layout, solver paths, conventions)
  - Units and conventions (MPa/mm, Tsai-Wu defaults, calibration scope)
  - CI matrix and version management
  - Material and empirical coefficient addition guidelines

- **.claude/skills/**: Four reusable task skills for common workflows:
  - `add-validation-dataset/`: Guidance for digitizing and adding peer-reviewed experimental datasets to the validation database
  - `add-material-preset/`: Instructions for registering new composite material systems in the MATERIALS registry
  - `release-checklist/`: Step-by-step release process covering version bumping, changelog updates, testing, and executable building
  - `screenshot-streamlit/`: Headless Streamlit app screenshot capture for README assets

- **.claude/hooks/session-start.sh**: Automated setup for Claude Code web containers that installs the project in editable mode with all extras and pins numpy<2 to match CI lint environment

- **.claude/settings.json**: Configuration for Claude Code web environment with SessionStart hook registration and permission allowlist for pytest, ruff, and mypy

- **.gitignore**: Updated to track shared Claude Code files (skills, hooks, settings.json) while excluding session-local metadata

## Implementation Details

- The CLAUDE.md guidance explicitly documents the empirical vs. FE solver design differences, ply-angle resolution through `_resolve_ply_angles`, and the single source of truth for mesh resolution (`_DEFAULT_MESH_RES`)
- Skills are designed to be self-contained and reference the exact file paths and code locations (e.g., line numbers in materials.py, schema paths)
- The session-start hook mirrors CI's numpy<2 pin to ensure local mypy diagnostics match the CI lint job
- .gitignore changes preserve the gitignore status of digitized validation data while sharing project configuration with collaborators

https://claude.ai/code/session_01YQmwsvX1zEnNtMqDnvZGL6