### PR TITLE
Expand test coverage: CLI, viz, transforms, validation guards, and Streamlit UI

### DIFF
--- a/app.py
+++ b/app.py
@@ -716,6 +716,7 @@ def _build_export_tab(result: dict | None, layup_for_title: str):
         file_name=f"{export_stem}.json",
         mime="application/json",
         use_container_width=True,
+        key="dl_export_json",
     )
     st.download_button(
         "Download CSV",
@@ -723,6 +724,7 @@ def _build_export_tab(result: dict | None, layup_for_title: str):
         file_name=f"{export_stem}.csv",
         mime="text/csv",
         use_container_width=True,
+        key="dl_export_csv",
     )
     with st.expander("Preview JSON"):
         st.code(_serialise_payload_json(payload), language="json")
@@ -800,6 +802,7 @@ def _build_export_tab(result: dict | None, layup_for_title: str):
             file_name=f"{stem}.pdf",
             mime="application/pdf",
             use_container_width=True,
+            key="dl_ncr_pdf",
         )
     with dl2:
         st.download_button(
@@ -808,6 +811,7 @@ def _build_export_tab(result: dict | None, layup_for_title: str):
             file_name=f"{stem}.md",
             mime="text/markdown",
             use_container_width=True,
+            key="dl_ncr_md",
         )
     with dl3:
         st.download_button(
@@ -816,6 +820,7 @@ def _build_export_tab(result: dict | None, layup_for_title: str):
             file_name=f"{stem}.json",
             mime="application/json",
             use_container_width=True,
+            key="dl_ncr_json",
         )
     with st.expander("Preview summary"):
         st.markdown(ncr_md)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Tests for the testable (non-Streamlit-runtime) helpers in app.py.
+
+The genuinely pure reporting helpers were extracted to
+``porosity_fe.reporting`` (see #155) and are covered elsewhere. This file
+exercises what still lives in ``app.py`` but does *not* require a live
+Streamlit script-run context:
+
+* ``run_analysis`` — the analysis runner the cached UI entry point wraps;
+* the ``plot_*`` figure builders the tabs hand to ``st.pyplot``;
+* ``_config_to_key`` — the cache-key encoder;
+* ``_validate_layup_inline`` — the layup on-change callback (its only
+  Streamlit dependency is ``st.session_state``, which behaves like a dict
+  and can be swapped for one).
+"""
+
+import matplotlib
+matplotlib.use('Agg')
+import matplotlib.pyplot as plt
+import pytest
+
+import app
+
+
+def _base_cfg(**overrides) -> dict:
+    """A valid analysis config mirroring what ``_build_sidebar_inputs``
+    produces, with a small mesh so the FE solve stays fast."""
+    cfg = {
+        "material_name": "T800_epoxy",
+        "angles": [0.0, 90.0, 90.0, 0.0],
+        "n_plies": 4,
+        "t_ply": 0.183,
+        "Vp": 3.0,
+        "distribution": "uniform",
+        "cluster_location": "midplane",
+        "void_shape": "spherical",
+        "loading_mode": "compression",
+        "nx": 10, "ny": 4, "nz": 6,
+    }
+    cfg.update(overrides)
+    return cfg
+
+
+@pytest.fixture(scope="module")
+def comp_result():
+    """One compression analysis result, reused across the plot tests so the
+    FE solve only runs once."""
+    return app.run_analysis(_base_cfg())
+
+
+class TestConfigToKey:
+    def test_lists_become_tuples_and_key_is_hashable(self):
+        cfg = _base_cfg()
+        key = app._config_to_key(cfg)
+        # The ``angles`` list must be encoded as a tuple so the key hashes.
+        angles_entry = dict(key)["angles"]
+        assert angles_entry == tuple(cfg["angles"])
+        assert isinstance(angles_entry, tuple)
+        assert hash(key)  # must not raise
+
+    def test_key_covers_every_cfg_field_in_order(self):
+        key = app._config_to_key(_base_cfg())
+        assert tuple(k for k, _ in key) == app._CFG_KEYS
+
+    def test_scalar_fields_passed_through(self):
+        key = dict(app._config_to_key(_base_cfg()))
+        assert key["material_name"] == "T800_epoxy"
+        assert key["Vp"] == 3.0
+        assert key["nx"] == 10
+
+
+class TestRunAnalysis:
+    def test_compression_returns_full_result(self, comp_result):
+        for k in ("config", "material", "porosity_field", "mesh",
+                  "empirical", "fe_field", "fe_loading",
+                  "fe_skipped_reason", "f_md"):
+            assert k in comp_result
+        assert comp_result["fe_field"] is not None
+        assert comp_result["fe_loading"] == "compression"
+        assert isinstance(comp_result["f_md"], float)
+        # Empirical table carries the four loading modes.
+        for mode in ("compression", "tension", "shear", "ilss"):
+            assert mode in comp_result["empirical"]
+
+    def test_ilss_takes_force_controlled_branch(self):
+        """``loading_mode='ilss'`` routes through the short-beam-shear
+        (force-controlled) solve rather than the applied-strain branch."""
+        r = app.run_analysis(_base_cfg(loading_mode="ilss"))
+        assert r["fe_loading"] == "ilss"
+        assert r["fe_field"] is not None
+
+    def test_clustered_distribution_branch(self):
+        """A clustered distribution forwards ``cluster_location`` into the
+        PorosityField (the conditional pf_kwargs branch)."""
+        r = app.run_analysis(_base_cfg(distribution="clustered"))
+        assert r["porosity_field"].distribution == "clustered"
+        assert r["fe_field"] is not None
+
+    def test_unknown_material_raises(self):
+        with pytest.raises(ValueError, match="Unknown material"):
+            app.run_analysis(_base_cfg(material_name="unobtainium"))
+
+
+class TestPlots:
+    def test_plot_profile(self, comp_result):
+        fig = app.plot_profile(comp_result)
+        assert fig is not None
+        plt.close(fig)
+
+    def test_plot_mesh(self, comp_result):
+        fig = app.plot_mesh(comp_result)
+        assert fig is not None
+        plt.close(fig)
+
+    def test_plot_results_with_fe(self, comp_result):
+        fig = app.plot_results(comp_result, "0/90/90/0")
+        assert fig is not None
+        plt.close(fig)
+
+    def test_plot_stress_component(self, comp_result):
+        fig = app.plot_stress(comp_result, "σ₁₁ (fiber)")
+        assert fig is not None
+        plt.close(fig)
+
+    def test_plot_stress_von_mises(self, comp_result):
+        fig = app.plot_stress(comp_result, "Von Mises")
+        assert fig is not None
+        plt.close(fig)
+
+    def test_plot_stress_without_fe_field(self):
+        """When no FE field is present the stress plot must short-circuit to
+        an explanatory placeholder rather than indexing a missing field."""
+        fig = app.plot_stress({"fe_field": None}, "Von Mises")
+        assert fig is not None
+        plt.close(fig)
+
+
+class TestValidateLayupInline:
+    """``_validate_layup_inline`` reads/writes ``st.session_state`` only, so a
+    plain dict stands in for the Streamlit session."""
+
+    def test_valid_layup_marks_ok(self, monkeypatch):
+        monkeypatch.setattr(app.st, "session_state",
+                            {"layup_input": "0/90/90/0"})
+        app._validate_layup_inline()
+        level, _ = app.st.session_state["_layup_status"]
+        assert level == "ok"
+
+    def test_empty_layup_marks_error(self, monkeypatch):
+        monkeypatch.setattr(app.st, "session_state",
+                            {"layup_input": "   "})
+        app._validate_layup_inline()
+        level, msg = app.st.session_state["_layup_status"]
+        assert level == "err"
+        assert "empty" in msg.lower()
+
+    def test_invalid_layup_marks_error(self, monkeypatch):
+        monkeypatch.setattr(app.st, "session_state",
+                            {"layup_input": "garbage ###"})
+        app._validate_layup_inline()
+        assert app.st.session_state["_layup_status"][0] == "err"

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -19,6 +19,11 @@ matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 import pytest
 
+# app.py imports streamlit at module scope; the CI `test` matrix installs
+# only the core deps (streamlit lives in the `web` extra), so skip the whole
+# module when it is unavailable rather than erroring at collection.
+pytest.importorskip("streamlit")
+
 import app
 
 
@@ -114,6 +119,15 @@ class TestPlots:
 
     def test_plot_results_with_fe(self, comp_result):
         fig = app.plot_results(comp_result, "0/90/90/0")
+        assert fig is not None
+        plt.close(fig)
+
+    def test_plot_results_fiber_dominated_footnote(self, comp_result):
+        """A low matrix-dominated fraction (f_md < 0.49) adds the
+        layup-scaling footnote to the knockdown chart."""
+        skewed = dict(comp_result)
+        skewed["f_md"] = 0.3
+        fig = app.plot_results(skewed, "0/0/0/0")
         assert fig is not None
         plt.close(fig)
 

--- a/tests/test_app_streamlit.py
+++ b/tests/test_app_streamlit.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Streamlit ``AppTest`` coverage for the app.py UI render paths.
+
+These drive the real Streamlit script (sidebar -> tabs -> render) through
+``streamlit.testing.v1.AppTest``, exercising ``_render``,
+``_build_sidebar_inputs``, the tab builders, and the NCR export form — the
+parts that need a live script-run context and so can't be unit-tested
+directly (see tests/test_app.py for the headless helpers).
+"""
+
+from pathlib import Path
+
+import matplotlib
+matplotlib.use('Agg')
+import pytest
+
+pytest.importorskip("streamlit")
+from streamlit.testing.v1 import AppTest
+
+_APP_PATH = str(Path(__file__).resolve().parent.parent / "app.py")
+
+
+def _fresh_app() -> AppTest:
+    at = AppTest.from_file(_APP_PATH, default_timeout=120)
+    return at.run()
+
+
+def _button(at: AppTest, label: str):
+    return next(b for b in at.button if b.label == label)
+
+
+def _run_small_analysis(at: AppTest) -> AppTest:
+    """Drive a full analysis on a deliberately tiny mesh so the FE solve is
+    fast: enable Expert mode to expose the mesh sliders, shrink them, use a
+    short layup, then press Run."""
+    at.toggle[0].set_value(True).run()          # Expert mode -> mesh sliders
+    at.text_input(key="layup_input").set_value("0/90/90/0").run()
+    at.slider[0].set_value(8)   # nx
+    at.slider[1].set_value(4)   # ny
+    at.slider[2].set_value(4)   # nz
+    at.run()
+    _button(at, "Run analysis").click().run()
+    return at
+
+
+class TestAppRender:
+    def test_initial_render_shows_placeholders(self):
+        at = _fresh_app()
+        assert not at.exception
+        # Six tabs, no analysis yet -> placeholder infos and a valid-layup badge.
+        assert len(at.tabs) == 6
+        assert "result" not in at.session_state or at.session_state["result"] is None
+        assert at.session_state["_layup_status"][0] == "ok"
+        assert len(at.info) >= 5  # overview note + 5 placeholder tabs
+
+    def test_invalid_layup_disables_run_and_aborts_render(self):
+        at = _fresh_app()
+        at.text_input(key="layup_input").set_value("garbage ###").run()
+        assert at.session_state["_layup_status"][0] == "err"
+        # The Run button is disabled and the config build bails out before
+        # any tabs are created (sidebar returns None -> _render returns).
+        assert _button(at, "Run analysis").disabled is True
+        assert len(at.tabs) == 0
+        assert len(at.error) >= 1
+
+    def test_run_populates_result_and_tabs(self):
+        at = _run_small_analysis(_fresh_app())
+        assert not at.exception
+        result = at.session_state["result"]
+        assert result is not None
+        assert result["config"]["nx"] == 8  # the shrunk mesh was used
+        assert result["fe_field"] is not None
+        # With a result present the Stress tab renders its component selector.
+        assert any(sb.label == "Stress component" for sb in at.selectbox)
+        # Export tab offers the JSON/CSV downloads.
+        assert len(at.get("download_button")) >= 2
+
+    def test_ncr_form_submit_generates_summary(self):
+        """Submitting the NCR form with a blank parent reference must not
+        crash. Regression for a StreamlitDuplicateElementId raised when the
+        NCR 'Download JSON' button collided with the export one (both fell
+        back to the same auto-generated id)."""
+        at = _run_small_analysis(_fresh_app())
+        _button(at, "Generate summary").click().run()
+        assert not at.exception
+        # Recommended-disposition guidance is surfaced...
+        assert any("disposition" in w.value.lower() for w in at.warning)
+        # ...and all five download buttons (2 export + 3 NCR) coexist.
+        assert len(at.get("download_button")) == 5

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,6 +8,8 @@ Split out of the monolithic tests/test_porosity_fe.py for issue #124.
 import numpy as np
 import pytest
 import os
+import logging
+from pathlib import Path
 
 import matplotlib
 matplotlib.use('Agg')
@@ -32,6 +34,151 @@ class TestValidateCLISmoke:
         with pytest.raises(SystemExit) as exc:
             main(['--help'])
         assert exc.value.code == 0
+
+
+# A schema-valid dataset whose (fiber, matrix) maps to the
+# AS4_3501_6_epoxy preset, so the whole validate pipeline (load ->
+# predict -> MAE -> report) runs end to end against a single tiny file.
+_MIN_VALID_DATASET = {
+    "reference": "Synthetic (2026). Minimal dataset for validate-CLI coverage.",
+    "material": {
+        "fiber": "AS4 fabric",
+        "matrix": "3501-6 epoxy",
+        "fiber_volume_fraction": 0.55,
+        "n_plies": 16,
+        "ply_angles": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+        "layup_name": "woven (0)16",
+    },
+    "baseline_porosity_pct": 0.3,
+    "properties": {
+        "ilss": {
+            "test_standard": "ASTM D2344",
+            "void_content_pct": [0.3, 1.0, 2.0, 3.0],
+            "normalized_values": [1.000, 0.930, 0.850, 0.770],
+            "digitization_method": "tabulated",
+        }
+    },
+}
+
+
+def _write_min_datasets(dest: Path, *, include_invalid: bool = False) -> Path:
+    """Write a minimal datasets directory for the validate CLI."""
+    dest.mkdir(parents=True, exist_ok=True)
+    (dest / "synthetic_valid.json").write_text(
+        json.dumps(_MIN_VALID_DATASET), encoding="utf-8")
+    if include_invalid:
+        # Fails schema validation (reference too short, no material/
+        # properties) so the pipeline records a dataset-level error the CLI
+        # must count and survive rather than crash on.
+        (dest / "synthetic_invalid.json").write_text(
+            json.dumps({"reference": "x"}), encoding="utf-8")
+    return dest
+
+
+class TestValidatePorosityCLIRun:
+    """End-to-end exercise of ``validate_porosity_cli.main``.
+
+    Previously only ``main(['--help'])`` was covered; the real run path
+    (dataset load -> report generation -> summary) had no test, leaving the
+    shipped standalone executable at ~24% coverage.
+    """
+
+    def test_run_writes_reports(self, tmp_path):
+        from validate_porosity_cli import main
+        ds = _write_min_datasets(tmp_path / "ds")
+        out = tmp_path / "out"
+        rc = main(['--datasets', str(ds), '--output-dir', str(out), '--quiet'])
+        assert rc == 0
+        assert (out / "validation_master_report.png").exists()
+        assert (out / "validation_detail_report.md").exists()
+
+    def test_run_non_quiet_prints_summary(self, tmp_path, capsys):
+        from validate_porosity_cli import main
+        ds = _write_min_datasets(tmp_path / "ds")
+        out = tmp_path / "out"
+        rc = main(['--datasets', str(ds), '--output-dir', str(out)])
+        assert rc == 0
+        printed = capsys.readouterr().out
+        assert "Report:" in printed
+        assert "Datasets processed:" in printed
+        assert "Overall MAE" in printed
+
+    def test_missing_datasets_dir_returns_2(self, tmp_path, capsys):
+        from validate_porosity_cli import main
+        missing = tmp_path / "does_not_exist"
+        rc = main(['--datasets', str(missing),
+                   '--output-dir', str(tmp_path / "out")])
+        assert rc == 2
+        assert "not found" in capsys.readouterr().err.lower()
+
+    def test_failed_dataset_is_counted_not_fatal(self, tmp_path, capsys):
+        from validate_porosity_cli import main
+        ds = _write_min_datasets(tmp_path / "ds", include_invalid=True)
+        out = tmp_path / "out"
+        rc = main(['--datasets', str(ds), '--output-dir', str(out)])
+        # A single bad dataset must not sink the whole run.
+        assert rc == 0
+        assert "1 succeeded, 1 failed" in capsys.readouterr().out
+
+    def test_debug_writes_log(self, tmp_path):
+        from validate_porosity_cli import main
+        ds = _write_min_datasets(tmp_path / "ds")
+        out = tmp_path / "out"
+        # --debug attaches a DEBUG file handler to the root logger; snapshot
+        # and restore it so the handler/level can't leak into later tests.
+        root = logging.getLogger()
+        saved_handlers = root.handlers[:]
+        saved_level = root.level
+        try:
+            rc = main(['--datasets', str(ds), '--output-dir', str(out),
+                       '--quiet', '--debug'])
+            assert rc == 0
+            logs = list(out.glob("validate_porosity_*.log"))
+            assert len(logs) == 1
+            assert logs[0].stat().st_size > 0
+        finally:
+            for h in root.handlers[:]:
+                if h not in saved_handlers:
+                    root.removeHandler(h)
+                    h.close()
+            root.setLevel(saved_level)
+
+
+class TestValidatePorosityCLIHelpers:
+    """Unit coverage for the version / bundled-path resolution helpers."""
+
+    def test_resolve_version_returns_nonempty_string(self):
+        from validate_porosity_cli import _resolve_version
+        v = _resolve_version()
+        assert isinstance(v, str) and v
+
+    def test_resolve_bundled_dirs_source(self):
+        from validate_porosity_cli import (_resolve_bundled_datasets_dir,
+                                            _resolve_bundled_schema_dir)
+        assert _resolve_bundled_datasets_dir().endswith(
+            os.path.join('validation', 'datasets'))
+        assert _resolve_bundled_schema_dir().endswith(
+            os.path.join('validation', 'schemas'))
+
+    def test_resolve_bundled_dirs_frozen(self, tmp_path, monkeypatch):
+        import validate_porosity_cli as vc
+        monkeypatch.setattr(vc.sys, 'frozen', True, raising=False)
+        monkeypatch.setattr(vc.sys, '_MEIPASS', str(tmp_path), raising=False)
+        assert vc._resolve_bundled_datasets_dir() == os.path.join(
+            str(tmp_path), 'validation', 'datasets')
+        assert vc._resolve_bundled_schema_dir() == os.path.join(
+            str(tmp_path), 'validation', 'schemas')
+
+    def test_ensure_validation_imports_frozen_prepends_meipass(
+            self, tmp_path, monkeypatch):
+        import sys as _sys
+        import validate_porosity_cli as vc
+        # Mutate a throwaway copy of sys.path so monkeypatch restores it.
+        monkeypatch.setattr(_sys, 'path', list(_sys.path))
+        monkeypatch.setattr(vc.sys, 'frozen', True, raising=False)
+        monkeypatch.setattr(vc.sys, '_MEIPASS', str(tmp_path), raising=False)
+        vc._ensure_validation_imports()
+        assert _sys.path[0] == str(tmp_path)
 
 
 def _extract_knockdowns(results: dict) -> dict:
@@ -462,3 +609,60 @@ class TestCLIMain:
         # Error message should mention the underlying failure so the user
         # knows what went wrong.
         assert 'denied' in err.lower() or 'permission' in err.lower()
+
+    # --plots rendering path + solver-failure exit codes -----------------
+
+    def test_plots_flag_writes_all_figures(self, tmp_path, monkeypatch):
+        """``--plots`` must render the per-config figures, the per-Vp model
+        comparison, and the cross-Vp knockdown curves. Covers the cli.py
+        --plots branch and, transitively, viz.plot_model_comparison /
+        plot_knockdown_curves (both previously uncovered)."""
+        monkeypatch.setattr(porosity_fe_analysis, 'POROSITY_CONFIGS',
+                            _TINY_CONFIGS)
+        rc = porosity_fe_analysis.main([
+            '--vp', '0.02',
+            '--output-dir', str(tmp_path),
+            '--plots',
+            '--quiet',
+        ])
+        assert rc == 0
+        for fname in (
+            'porosity_profile_uniform_spherical_2pct.png',
+            'porosity_mesh_3d_uniform_spherical_2pct.png',
+            'porosity_mesh_detail_uniform_spherical_2pct.png',
+            'porosity_damage_uniform_spherical_2pct.png',
+            'porosity_comparison_2pct.png',
+            'porosity_knockdown_curves.png',
+        ):
+            assert (tmp_path / fname).exists(), f"missing {fname}"
+
+    def test_compare_value_error_returns_2(self, tmp_path, monkeypatch, capsys):
+        """A ``ValueError`` from the sweep is surfaced as a bad-input exit
+        (return code 2)."""
+        def _bad_input(*args, **kwargs):
+            raise ValueError("bad Vp")
+
+        monkeypatch.setattr(porosity_fe_analysis, 'POROSITY_CONFIGS',
+                            _TINY_CONFIGS)
+        monkeypatch.setattr(porosity_fe_analysis,
+                            'compare_configurations', _bad_input)
+        rc = porosity_fe_analysis.main([
+            '--vp', '0.02', '--output-dir', str(tmp_path), '--quiet'])
+        assert rc == 2
+        assert 'bad input' in capsys.readouterr().err.lower()
+
+    def test_compare_solver_failure_returns_3(self, tmp_path, monkeypatch,
+                                              capsys):
+        """Any other exception from the sweep is surfaced as a solver
+        failure (return code 3)."""
+        def _crash(*args, **kwargs):
+            raise RuntimeError("singular stiffness matrix")
+
+        monkeypatch.setattr(porosity_fe_analysis, 'POROSITY_CONFIGS',
+                            _TINY_CONFIGS)
+        monkeypatch.setattr(porosity_fe_analysis,
+                            'compare_configurations', _crash)
+        rc = porosity_fe_analysis.main([
+            '--vp', '0.02', '--output-dir', str(tmp_path), '--quiet'])
+        assert rc == 3
+        assert 'solver failure' in capsys.readouterr().err.lower()

--- a/tests/test_empirical.py
+++ b/tests/test_empirical.py
@@ -747,3 +747,30 @@ class TestLocalSensitivities:
         with pytest.raises(ValueError, match=r"param must be"):
             self.solver.sensitivity_fd(mode='compression',
                                        model='judd_wright', param='nope')
+
+    def test_power_law_sensitivity_degenerate_at_full_porosity(self):
+        """At Vp=1 the power-law knockdown collapses to 0 and both partials
+        are pinned to 0 (the ``1 - Vp <= 0`` guard branch)."""
+        s = self.solver.local_sensitivities(mode='compression',
+                                            model='power_law', Vp=1.0)
+        assert s['KD'] == 0.0
+        assert s['dKD_dVp'] == 0.0
+        assert s['dKD_dcoef'] == 0.0
+
+    def test_linear_sensitivity_in_clipped_regime(self):
+        """Once the linear law has clipped to 0 (raw <= 0) its gradients are
+        zero. ILSS beta (~9) clips well before Vp=1, so Vp=0.2 is past the
+        knee."""
+        s = self.solver.local_sensitivities(mode='ilss', model='linear',
+                                            Vp=0.2)
+        assert s['KD'] == 0.0
+        assert s['dKD_dVp'] == 0.0
+        assert s['dKD_dcoef'] == 0.0
+
+    def test_sensitivity_fd_unknown_mode(self):
+        with pytest.raises(ValueError, match=r"Unknown loading mode"):
+            self.solver.sensitivity_fd(mode='flexure', model='judd_wright')
+
+    def test_sensitivity_fd_unknown_model(self):
+        with pytest.raises(ValueError, match=r"Unknown knockdown model"):
+            self.solver.sensitivity_fd(mode='compression', model='bogus')

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -65,6 +65,69 @@ class TestFEVisualizer:
         assert fig is not None
         plt.close(fig)
 
+    def _two_vp_results(self):
+        """A ``{Vp_label: {config: ConfigResult}}`` map for the curve plot."""
+        cfgs = {'uniform_spherical': POROSITY_CONFIGS['uniform_spherical']}
+        return {
+            '2pct': compare_configurations(0.02, configs=cfgs),
+            '3pct': compare_configurations(0.03, configs=cfgs),
+        }
+
+    def test_plot_knockdown_curves_returns_fig(self):
+        fig = FEVisualizer.plot_knockdown_curves(self._two_vp_results())
+        assert fig is not None
+        plt.close(fig)
+
+    def test_plot_knockdown_curves_saves(self, tmp_path):
+        path = str(tmp_path / "knockdown.png")
+        FEVisualizer.plot_knockdown_curves(self._two_vp_results(),
+                                           save_path=path)
+        assert os.path.exists(path)
+        plt.close('all')
+
+    def test_plot_model_comparison_returns_fig(self):
+        results = compare_configurations(
+            0.03,
+            configs={'uniform_spherical': POROSITY_CONFIGS['uniform_spherical']})
+        fig = FEVisualizer.plot_model_comparison(results)
+        assert fig is not None
+        plt.close(fig)
+
+    def test_plot_model_comparison_saves(self, tmp_path):
+        results = compare_configurations(
+            0.03,
+            configs={'uniform_spherical': POROSITY_CONFIGS['uniform_spherical']})
+        path = str(tmp_path / "comparison.png")
+        FEVisualizer.plot_model_comparison(results, save_path=path)
+        assert os.path.exists(path)
+        plt.close('all')
+
+    def test_plot_damage_contour_falls_back_to_mesh_reduction(self):
+        """Before ``apply_loading`` populates ``nodal_knockdown`` the
+        midplane map must fall back to ``mesh.stiffness_reduction`` (the
+        else-branch in plot_damage_contour)."""
+        solver = EmpiricalSolver(self.mesh, self.material)
+        assert solver.nodal_knockdown is None
+        fig = FEVisualizer.plot_damage_contour(self.mesh, solver)
+        assert fig is not None
+        plt.close(fig)
+
+    def test_plot_mesh_3d_highlights_voids_and_saves(self, tmp_path):
+        """A field carrying discrete voids yields void elements that the 3D
+        plot highlights in red; also exercises the save_path branch."""
+        lo = self.mesh.nodes.min(axis=0)
+        hi = self.mesh.nodes.max(axis=0)
+        void = VoidGeometry(center=tuple((lo + hi) / 2),
+                            radii=tuple((hi - lo) / 4))
+        pf = PorosityField(self.material, 0.03, distribution='uniform',
+                           discrete_voids=[void])
+        mesh = CompositeMesh(pf, self.material, nx=10, ny=5, nz=6)
+        assert len(mesh.void_elements) > 0
+        path = str(tmp_path / "mesh3d.png")
+        FEVisualizer.plot_mesh_3d(mesh, save_path=path)
+        assert os.path.exists(path)
+        plt.close('all')
+
 
 class TestAnalysisPipeline:
     def test_compare_configurations_returns_all_configs(self):
@@ -254,6 +317,60 @@ class TestCoordinateTransforms:
     def test_rotate_stiffness_wrong_shape(self):
         with pytest.raises(ValueError):
             rotate_stiffness_3d(np.eye(3), 0.0)
+
+    # y-axis transforms (wrinkle/waviness misalignment) were untested ----
+
+    @staticmethod
+    def _voigt_from_tensor(t, *, engineering=False):
+        """Pack a symmetric 3x3 tensor into Voigt order
+        [11, 22, 33, 23, 13, 12]. ``engineering`` doubles the shear terms
+        (engineering strain convention)."""
+        f = 2.0 if engineering else 1.0
+        return np.array([t[0, 0], t[1, 1], t[2, 2],
+                         f * t[1, 2], f * t[0, 2], f * t[0, 1]])
+
+    @pytest.mark.parametrize('axis', ['z', 'y'])
+    @pytest.mark.parametrize('angle', [np.pi / 6, np.pi / 3, -np.pi / 4])
+    def test_stress_transform_matches_tensor_rotation(self, axis, angle):
+        """``T_sigma @ voigt(sigma)`` must equal ``voigt(R sigma R^T)`` for
+        the matching 3x3 rotation R. This pins the hand-written y-axis 6x6
+        against the rotation it is supposed to encode (a transcription error
+        there would otherwise go unnoticed)."""
+        rng = np.random.default_rng(0)
+        a = rng.standard_normal((3, 3))
+        sigma = a + a.T
+        R = rotation_matrix_3d(angle, axis=axis)
+        expected = self._voigt_from_tensor(R @ sigma @ R.T)
+        got = stress_transformation_3d(angle, axis=axis) @ \
+            self._voigt_from_tensor(sigma)
+        np.testing.assert_allclose(got, expected, atol=1e-12)
+
+    @pytest.mark.parametrize('axis', ['z', 'y'])
+    @pytest.mark.parametrize('angle', [np.pi / 6, np.pi / 3, -np.pi / 4])
+    def test_strain_transform_matches_tensor_rotation(self, axis, angle):
+        rng = np.random.default_rng(1)
+        a = rng.standard_normal((3, 3))
+        eps = a + a.T
+        R = rotation_matrix_3d(angle, axis=axis)
+        expected = self._voigt_from_tensor(R @ eps @ R.T, engineering=True)
+        got = strain_transformation_3d(angle, axis=axis) @ \
+            self._voigt_from_tensor(eps, engineering=True)
+        np.testing.assert_allclose(got, expected, atol=1e-12)
+
+    def test_stress_transform_invalid_axis(self):
+        with pytest.raises(ValueError):
+            stress_transformation_3d(0.1, axis='x')
+
+    def test_strain_transform_invalid_axis(self):
+        with pytest.raises(ValueError):
+            strain_transformation_3d(0.1, axis='x')
+
+    def test_rotate_stiffness_y_axis_identity_and_symmetry(self):
+        C = MATERIALS['T800_epoxy'].get_stiffness_matrix()
+        np.testing.assert_allclose(rotate_stiffness_3d(C, 0.0, axis='y'),
+                                   C, atol=1e-6)
+        C_rot = rotate_stiffness_3d(C, np.pi / 5, axis='y')
+        np.testing.assert_allclose(C_rot, C_rot.T, atol=1e-6)
 
 
 class TestGaussQuadrature:

--- a/tests/test_materials.py
+++ b/tests/test_materials.py
@@ -16,6 +16,35 @@ from porosity_fe_analysis import (MaterialProperties, MATERIALS, PorosityField, 
                                    EmpiricalSolver)
 
 
+class TestMaterialPropertiesValidation:
+    """Hygrothermal-field guards in ``__post_init__`` and the additive
+    ('normal') perturbation branch — previously-untested error/edge paths."""
+
+    def test_non_finite_T_service_rejected(self):
+        with pytest.raises(ValueError, match=r"T_service"):
+            dataclasses.replace(MATERIALS['T800_epoxy'], T_service=float('nan'))
+
+    def test_non_finite_T_ref_rejected(self):
+        with pytest.raises(ValueError, match=r"T_ref"):
+            dataclasses.replace(MATERIALS['T800_epoxy'], T_ref=float('inf'))
+
+    def test_negative_M_service_rejected(self):
+        with pytest.raises(ValueError, match=r"M_service"):
+            dataclasses.replace(MATERIALS['T800_epoxy'], M_service=-1.0)
+
+    def test_negative_M_ref_rejected(self):
+        with pytest.raises(ValueError, match=r"M_ref"):
+            dataclasses.replace(MATERIALS['T800_epoxy'], M_ref=-0.5)
+
+    def test_perturbed_value_normal_distribution(self):
+        """Additive-Gaussian perturbation: value = nominal + cov*|nominal|*draw
+        when cov>0, and a short-circuit to nominal when cov<=0."""
+        mat = MATERIALS['T800_epoxy']
+        got = mat._perturbed_value('E11', 1.0, 'normal', 0.1)
+        assert got == pytest.approx(mat.E11 + 0.1 * abs(mat.E11) * 1.0)
+        assert mat._perturbed_value('E11', 1.0, 'normal', 0.0) == mat.E11
+
+
 class TestMaterialProperties:
     def test_dataclass_creation(self):
         mat = MATERIALS['T800_epoxy']

--- a/tests/test_results_schema_roundtrip.py
+++ b/tests/test_results_schema_roundtrip.py
@@ -330,3 +330,21 @@ def test_save_results_legacy_dict_shape_still_works(tmp_path):
         ["knockdown"]
         == cr.empirical["compression"]["judd_wright"]["knockdown"]
     )
+
+
+def test_config_result_dict_shim_unknown_key_get_and_keys():
+    """ConfigResult's dict back-compat shim: an unknown (non-artifact) key
+    raises KeyError, ``get`` swallows that into its default, and ``keys``
+    enumerates the documented fields (results.py)."""
+    r = next(iter(_tiny_results().values()))
+
+    with pytest.raises(KeyError, match="not a known ConfigResult field"):
+        r["no_such_field"]
+
+    assert r.get("no_such_field", "fallback") == "fallback"
+    assert r.get("Vp") == r["Vp"]
+
+    assert set(r.keys()) == {
+        "Vp", "config_name", "config", "failure_stress",
+        "knockdown", "model", "empirical", "seed",
+    }

--- a/tests/test_uq.py
+++ b/tests/test_uq.py
@@ -169,6 +169,57 @@ class TestPropagateUncertainty:
                                   n_samples=self._N)
 
 
+class TestUQInputValidationBranches:
+    """Remaining input-validation guards in _normalize_uq_spec /
+    propagate_uncertainty / _draw_unit_samples that lacked direct tests."""
+
+    _N = 8
+
+    def test_negative_cov_rejected(self):
+        with pytest.raises(ValueError, match=r"CoV"):
+            propagate_uncertainty(0.02, 'T800_epoxy',
+                                  covs={'E11': -0.1}, n_samples=self._N)
+
+    def test_spec_unknown_distribution_rejected(self):
+        with pytest.raises(ValueError, match=r"unknown distribution"):
+            propagate_uncertainty(0.02, 'T800_epoxy',
+                                  spec={'E11': ('weird', 0.1)},
+                                  n_samples=self._N)
+
+    def test_spec_negative_params_rejected(self):
+        with pytest.raises(ValueError, match=r"params must be"):
+            propagate_uncertainty(0.02, 'T800_epoxy',
+                                  spec={'E11': ('normal', -0.1)},
+                                  n_samples=self._N)
+
+    def test_spec_zero_params_drops_field(self):
+        """A zero-params spec entry is dropped (deterministic), not an
+        error — exercises the ``resolved.pop`` else-branch."""
+        r = propagate_uncertainty(0.02, 'T800_epoxy',
+                                  spec={'E11': ('normal', 0.0)},
+                                  n_samples=self._N, seed=0)
+        assert 'E11' not in r['spec']
+
+    def test_negative_vp_cov_rejected(self):
+        with pytest.raises(ValueError, match=r"vp_cov"):
+            propagate_uncertainty(0.02, 'T800_epoxy', covs={'E11': 0.05},
+                                  vp_cov=-0.2, n_samples=self._N)
+
+    def test_accepts_material_instance(self):
+        """A ``MaterialProperties`` instance (not a preset name) is accepted
+        directly (covers the non-string material branch)."""
+        from porosity_fe_analysis import MATERIALS
+        r = propagate_uncertainty(0.02, MATERIALS['T800_epoxy'],
+                                  covs={'E11': 0.05}, n_samples=self._N, seed=0)
+        assert r['samples']['knockdown'].shape == (self._N,)
+
+    def test_draw_unit_samples_unknown_method_rejected(self):
+        from porosity_fe.uq import _draw_unit_samples
+        rng = np.random.default_rng(0)
+        with pytest.raises(ValueError, match=r"Unknown sampling method"):
+            _draw_unit_samples(2, 4, 'bogus', rng)
+
+
 # Issue #65: closed-form local sensitivities + per-point validation bands.
 
 


### PR DESCRIPTION
## Summary

Closes the largest test-coverage gaps surfaced by a coverage audit, and fixes one real UI crash uncovered along the way. No production logic changed except a minimal Streamlit bug fix (see below). 559 → 630 tests, all green.

### Coverage gains
- **`validate_porosity_cli.py`** 19% → 89% — the shipped standalone executable's `main()` run path (report generation, missing-dir/`--debug` log, failed-dataset counting, bundled-path/version helpers) was previously only exercised via `--help`.
- **`viz.py`** 62% → 99% — `plot_knockdown_curves` / `plot_model_comparison` had zero coverage; also the save-path and no-nodal-knockdown branches.
- **`cli.py`** 84% → 95% — the `--plots` rendering path and the solver-failure exit codes (2/3).
- **`transforms.py`** 86% → 100% — the y-axis stress/strain 6×6 matrices, verified against the tensor rotation `R·σ·Rᵀ` so a transcription error would now be caught.
- **`uq.py` / `materials.py`** → 100% — input-validation guards (CoV/spec/vp_cov/sampling-method; hygrothermal fields), plus `empirical` sensitivity edge cases (Vp=1 power-law, clipped linear) and the `ConfigResult` dict shim.
- **`app.py`** 0% → 88% — headless tests for `run_analysis`, the four `plot_*` builders, `_config_to_key`, and `_validate_layup_inline`, plus `streamlit.testing` AppTest coverage of `_render`, the sidebar, the tab builders, and the NCR export form.

### Bug fixed
The AppTest for the NCR export form caught a real crash: submitting **"Generate summary"** with a blank *Parent NCR reference* raised `StreamlitDuplicateElementId` because the NCR "Download JSON" button collided with the export "Download JSON" button (both fell back to the same auto-generated id from matching label/file_name/mime). This would crash the live app on a common path. Fixed by giving every `download_button` an explicit unique `key=`; the AppTest now pins it.

### CI safety
`tests/test_app.py` and `tests/test_app_streamlit.py` are guarded with `pytest.importorskip("streamlit")`, since the CI `test` matrix installs only core deps (streamlit lives in the `web` extra).

## Test plan
- [x] `python -m pytest tests/ -q` → 630 passed, 1 skipped
- [x] `ruff check .` → clean
- [x] Branch coverage of core packages 88% → 95%; `app.py` 0% → 88%
- [x] AppTest confirms the NCR-form crash is fixed

https://claude.ai/code/session_01YGpht1HcETGdXamESe22rp

---
_Generated by [Claude Code](https://claude.ai/code/session_01YGpht1HcETGdXamESe22rp)_