### PR TITLE
test: pin VoidGeometry SCF regimes and center validation

### DIFF
--- a/tests/test_void_geometry.py
+++ b/tests/test_void_geometry.py
@@ -77,6 +77,60 @@ class TestVoidGeometry:
         assert 'ilss' in scf
         assert scf['compression'] > 1.0
 
+    def test_scf_sphere_exact_values(self):
+        """The near-spherical branch (ar < 1.2) returns fixed SCFs."""
+        void = VoidGeometry(center=(0, 0, 0), radii=(1, 1, 1))
+        assert void.stress_concentration_factor() == {
+            'compression': 2.0, 'tension': 2.0, 'shear': 1.5,
+            'ilss': 1.8, 'transverse_tension': 2.0,
+        }
+
+    def test_scf_cylindrical_prolate_values(self):
+        """Prolate ('cylindrical') void: radii[0] > radii[2] and
+        radii[1] < radii[0]/2. Pins the aspect-ratio scaling and the
+        ``VOID_SHAPES['cylindrical']`` preset -> regime mapping."""
+        void = VoidGeometry(center=(0, 0, 0), radii=VOID_SHAPES['cylindrical'])
+        ar = void.aspect_ratio  # (3, 1, 1) -> 3.0
+        assert ar == 3.0
+        scf = void.stress_concentration_factor()
+        assert scf == {
+            'compression': 1.5 + 0.5 * ar,        # 3.0
+            'tension': 1.5 + 0.5 * ar,            # 3.0
+            'shear': 1.3 + 0.3 * ar,              # 2.2
+            'ilss': 1.5 + 0.4 * ar,               # 2.7
+            'transverse_tension': 1.5 + 0.5 * ar,  # 3.0
+        }
+
+    def test_scf_penny_oblate_values(self):
+        """Oblate ('penny') void: radii[0] > radii[2] and
+        radii[1] >= radii[0]/2. Pennies carry the highest SCFs, so a
+        regression in this branch would understate their severity."""
+        void = VoidGeometry(center=(0, 0, 0), radii=VOID_SHAPES['penny'])
+        ar = void.aspect_ratio  # (3, 3, 0.3) -> 10.0
+        assert ar == 10.0
+        scf = void.stress_concentration_factor()
+        assert scf == {
+            'compression': 2.0 + 1.0 * ar,        # 12.0
+            'tension': 2.0 + 1.5 * ar,            # 17.0
+            'shear': 1.5 + 0.8 * ar,              # 9.5
+            'ilss': 2.0 + 1.2 * ar,               # 14.0
+            'transverse_tension': 2.0 + 1.5 * ar,  # 17.0
+        }
+        # Penny tension SCF must exceed an equally-elongated prolate void's.
+        prolate = VoidGeometry(center=(0, 0, 0), radii=(10, 1, 1))
+        assert scf['tension'] > prolate.stress_concentration_factor()['tension']
+
+    def test_scf_through_thickness_falls_back_to_sphere(self):
+        """A void elongated through-thickness (radii[0] <= radii[2]) is not
+        a recognised in-plane regime, so the SCF defaults to the spherical
+        values rather than the prolate/oblate scaling."""
+        void = VoidGeometry(center=(0, 0, 0), radii=(1, 1, 3))
+        assert void.aspect_ratio == 3.0  # >= 1.2, so not the spherical branch
+        assert void.stress_concentration_factor() == {
+            'compression': 2.0, 'tension': 2.0, 'shear': 1.5,
+            'ilss': 1.8, 'transverse_tension': 2.0,
+        }
+
     def test_distance_field_inside_negative(self):
         void = VoidGeometry(center=(0, 0, 0), radii=(1, 1, 1))
         d = void.distance_field(np.array([0.0]), np.array([0.0]), np.array([0.0]))
@@ -116,3 +170,11 @@ class TestVoidGeometry:
         with pytest.raises(ValueError, match=r"orientation"):
             VoidGeometry(center=(0, 0, 0), radii=(1.0, 1.0, 1.0),
                          orientation=float('nan'))
+
+    def test_wrong_center_shape_rejected(self):
+        with pytest.raises(ValueError, match=r"center must have 3 components"):
+            VoidGeometry(center=(0, 0), radii=(1.0, 1.0, 1.0))
+
+    def test_non_finite_center_rejected(self):
+        with pytest.raises(ValueError, match=r"center must be finite"):
+            VoidGeometry(center=(0.0, float('inf'), 0.0), radii=(1.0, 1.0, 1.0))


### PR DESCRIPTION
## Summary

A test-coverage analysis of the codebase found the suite is already strong (96% line / 95% branch). The remaining gaps are mostly defensive paths and a few **untested branching-physics formulas**. This PR closes the highest-value of those in `porosity_fe/void_geometry.py` (**89% → 98%**).

### What was missing

- `stress_concentration_factor()` returns aspect-ratio-dependent SCF magnitudes across four regimes (spherical, prolate/"cylindrical", oblate/"penny", and a through-thickness fall-back). **Only the spherical branch was value-tested**, and only loosely (`scf['compression'] > 1.0`). The prolate (`:153`) and fall-back (`:161`) branches were entirely uncovered — a typo in any `1.5 + 0.5·ar` / `2.0 + 1.5·ar` coefficient would have shipped silently.
- `VoidGeometry.center` shape (`:88`) and finiteness (`:104`) validation had no rejection tests, unlike the existing `radii`/`orientation` ones.

### What this adds (6 tests)

- Exact-value SCF tests for the **prolate** and **oblate** branches, driven off the `VOID_SHAPES` presets so they also pin the preset → regime mapping; plus a cross-check that a penny's tension SCF exceeds an equally-elongated prolate void's.
- A test that a through-thickness-elongated void (`radii[0] ≤ radii[2]`) falls back to the spherical SCFs.
- Exact-value test for the spherical branch (replacing the loose inequality).
- `center` wrong-shape and non-finite rejection tests.

All 636 tests pass (was 630); `ruff` clean.

## Follow-ups (not in this PR)

The coverage analysis also flagged, in rough priority order:

1. **Extrapolation flagging is documented but not enforced.** `CLAUDE.md` states empirical coefficients are validated to `Vp ≲ 0.05` and extrapolations should be "flagged explicitly", but no runtime warning exists in `empirical.py`. Needs a decision: add a `UserWarning` (+test) or update the docs.
2. **FE-internal defensive guards** — non-finite porosity / failure-index raises (`fe/solver.py:932, 1076`) and `to_vtk` shape-mismatch raises (`:258, :276`) are uncovered. These need heavier fixtures (a solved `FieldResults`), so they were left out of this focused PR.
3. **No property-based testing** — invariants (KD monotonicity/bounds, stiffness symmetry/PD) are checked at a handful of hardcoded points; `hypothesis` would broaden this.
4. **`io.py` provenance fallbacks** (version/git-SHA failure paths) are untested.

https://claude.ai/code/session_018h6s3TVwye8d3brbmYu7zx

---
_Generated by [Claude Code](https://claude.ai/code/session_018h6s3TVwye8d3brbmYu7zx)_