### PR TITLE
refactor: modernize typing to PEP 604/585 across porosity_fe (#107)

### DIFF
--- a/porosity_fe/_ply_angles.py
+++ b/porosity_fe/_ply_angles.py
@@ -5,27 +5,28 @@ Extracted into its own module so :mod:`porosity_fe.mesh`,
 consume the same sentinel-resolution logic without an import cycle.
 """
 
+from __future__ import annotations
+
 import warnings
-from typing import List, Optional, Tuple, Union
 
 #: Canonical QI baseline layup (8-ply symmetric ``[0/90/45/-45]_s``).
 #: Used to expand the ``ply_angles='QI'`` sentinel (#44 item 2).
 #: Also exposed as :attr:`Calibration.PLY_ANGLES_QI` (#121).
-_PLY_ANGLES_QI: Tuple[float, ...] = (0.0, 90.0, 45.0, -45.0, -45.0, 45.0, 90.0, 0.0)
+_PLY_ANGLES_QI: tuple[float, ...] = (0.0, 90.0, 45.0, -45.0, -45.0, 45.0, 90.0, 0.0)
 
 #: Canonical UD baseline (4 plies, all 0 deg). Used to expand the
 #: ``ply_angles='UD'`` sentinel; the FE / empirical scaling only cares about
 #: the angle distribution, so a short list is fine.
 #: Also exposed as :attr:`Calibration.PLY_ANGLES_UD` (#121).
-_PLY_ANGLES_UD: Tuple[float, ...] = (0.0, 0.0, 0.0, 0.0)
+_PLY_ANGLES_UD: tuple[float, ...] = (0.0, 0.0, 0.0, 0.0)
 
 
 def _resolve_ply_angles(
-    ply_angles: Optional[Union[List[float], Tuple[float, ...], str]],
+    ply_angles: list[float] | tuple[float, ...] | str | None,
     *,
     none_means: str = 'QI',
     caller: str = 'ply_angles',
-) -> Optional[List[float]]:
+) -> list[float] | None:
     """Resolve the ``ply_angles`` sentinel to a concrete list of angles.
 
     Unifies the three previously divergent ``ply_angles=None`` defaults

--- a/porosity_fe/cli.py
+++ b/porosity_fe/cli.py
@@ -6,7 +6,6 @@ import argparse
 import logging
 import sys
 from pathlib import Path
-from typing import List
 
 from . import __version__
 from .io import save_results_to_json
@@ -235,7 +234,7 @@ def _resolve_via_shim(name: str, fallback):
     return getattr(shim, name, fallback)
 
 
-def main(argv: List[str] | None = None) -> int:
+def main(argv: list[str] | None = None) -> int:
     """Argparse-driven entry point.
 
     Returns

--- a/porosity_fe/empirical.py
+++ b/porosity_fe/empirical.py
@@ -1,7 +1,9 @@
 """Empirical (analytical) porosity-strength knockdown solver."""
 
+from __future__ import annotations
+
 import logging
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable
 
 import numpy as np
 
@@ -47,15 +49,15 @@ class Calibration:
     # 'transverse_tension' (sigma_2t, in-plane transverse, matrix-dominated;
     # alpha matched to ilss because both fail by matrix/interface-dominated
     # mechanisms — see issue #35).
-    JUDD_WRIGHT_ALPHA_QI: Dict[str, float] = {
+    JUDD_WRIGHT_ALPHA_QI: dict[str, float] = {
         'compression': 6.9, 'tension': 3.9, 'shear': 8.0, 'ilss': 10.0,
         'transverse_tension': 10.0,
     }
-    POWER_LAW_N_QI: Dict[str, float] = {
+    POWER_LAW_N_QI: dict[str, float] = {
         'compression': 2.8, 'tension': 1.8, 'shear': 3.5, 'ilss': 4.5,
         'transverse_tension': 4.5,
     }
-    LINEAR_BETA_QI: Dict[str, float] = {
+    LINEAR_BETA_QI: dict[str, float] = {
         'compression': 5.5, 'tension': 3.5, 'shear': 7.0, 'ilss': 9.0,
         'transverse_tension': 9.0,
     }
@@ -68,7 +70,7 @@ class Calibration:
     # objects (assigned at the bottom of this module to break the
     # ``fatigue -> empirical`` import cycle).
     # ------------------------------------------------------------------
-    FATIGUE_B_QI: Dict[str, float]
+    FATIGUE_B_QI: dict[str, float]
     FATIGUE_KD_FLOOR: float
 
     # ------------------------------------------------------------------
@@ -114,9 +116,9 @@ class Calibration:
     # Canonical ply-angle baselines (sentinel expansion for 'QI' / 'UD')
     # ------------------------------------------------------------------
     #: Canonical QI baseline layup (8-ply symmetric ``[0/90/45/-45]_s``).
-    PLY_ANGLES_QI: Tuple[float, ...] = _PLY_ANGLES_QI
+    PLY_ANGLES_QI: tuple[float, ...] = _PLY_ANGLES_QI
     #: Canonical UD baseline (4 plies, all 0 deg).
-    PLY_ANGLES_UD: Tuple[float, ...] = _PLY_ANGLES_UD
+    PLY_ANGLES_UD: tuple[float, ...] = _PLY_ANGLES_UD
 
     # ------------------------------------------------------------------
     # Numerical floors / reporting defaults
@@ -127,7 +129,7 @@ class Calibration:
     STRENGTH_FLOOR_MPA: float = 1e-3
     #: Default percentiles reported by the UQ helpers (5/50/95 band, the
     #: spread an A-/B-basis workflow typically wants to see first).
-    UQ_DEFAULT_PERCENTILES: Tuple[float, ...] = (5.0, 50.0, 95.0)
+    UQ_DEFAULT_PERCENTILES: tuple[float, ...] = (5.0, 50.0, 95.0)
 
 
 class EmpiricalSolver:
@@ -164,11 +166,11 @@ class EmpiricalSolver:
     _F_MD_FLOOR_ILSS = Calibration.F_MD_FLOOR_ILSS
 
     def __init__(self, mesh: CompositeMesh, material: MaterialProperties,
-                 ply_angles: Optional[Union[List[float], str]] = 'QI',
+                 ply_angles: list[float] | str | None = 'QI',
                  *,
-                 judd_wright_alpha: Optional[Dict[str, float]] = None,
-                 power_law_n: Optional[Dict[str, float]] = None,
-                 linear_beta: Optional[Dict[str, float]] = None):
+                 judd_wright_alpha: dict[str, float] | None = None,
+                 power_law_n: dict[str, float] | None = None,
+                 linear_beta: dict[str, float] | None = None):
         """Empirical knockdown solver.
 
         Parameters
@@ -229,9 +231,9 @@ class EmpiricalSolver:
         # Build scaled coefficient dicts. Explicit annotations let static
         # checkers narrow `self.JUDD_WRIGHT_ALPHA[mode]` etc. to `float`
         # at the vectorized call sites in `apply_loading` (#114/#115).
-        self.JUDD_WRIGHT_ALPHA: Dict[str, float] = {}
-        self.POWER_LAW_N: Dict[str, float] = {}
-        self.LINEAR_BETA: Dict[str, float] = {}
+        self.JUDD_WRIGHT_ALPHA: dict[str, float] = {}
+        self.POWER_LAW_N: dict[str, float] = {}
+        self.LINEAR_BETA: dict[str, float] = {}
         for mode in ['compression', 'tension', 'shear', 'ilss',
                      'transverse_tension']:
             s = self._layup_scale(mode)
@@ -240,9 +242,9 @@ class EmpiricalSolver:
             self.LINEAR_BETA[mode] = beta_qi[mode] * s
 
     @classmethod
-    def _merge_coefficient_override(cls, defaults: Dict[str, float],
-                                    override: Optional[Dict[str, float]],
-                                    name: str) -> Dict[str, float]:
+    def _merge_coefficient_override(cls, defaults: dict[str, float],
+                                    override: dict[str, float] | None,
+                                    name: str) -> dict[str, float]:
         """Validate ``override`` and merge it onto ``defaults``."""
         if override is None:
             return dict(defaults)
@@ -271,7 +273,7 @@ class EmpiricalSolver:
         return {**defaults, **override}
 
     @staticmethod
-    def _matrix_dominated_fraction(ply_angles: Optional[List[float]]) -> float:
+    def _matrix_dominated_fraction(ply_angles: list[float] | None) -> float:
         """Fraction of matrix-dominated plies in the layup (0 to 1).
 
         - 0-degree plies contribute 0 (fiber-dominated)
@@ -416,7 +418,7 @@ class EmpiricalSolver:
         return getattr(self.material, self.PRISTINE_STRENGTH_KEY[mode])
 
     def _environment_knockdown_factor(self, mode: str,
-                                      environment: Optional[Dict[str, float]]
+                                      environment: dict[str, float] | None
                                       ) -> float:
         """Resolve the hygrothermal knockdown factor (issue #59).
 
@@ -445,8 +447,8 @@ class EmpiricalSolver:
         return float(self.material.environment_knockdown(mode, T=T, M=M))
 
     def _fatigue_knockdown_factor(self, mode: str,
-                                  cycles: Optional[float],
-                                  R: Optional[float]) -> float:
+                                  cycles: float | None,
+                                  R: float | None) -> float:
         """Resolve the S-N fatigue knockdown factor (issue #59).
 
         Returns ``1.0`` (back-compat no-op) when ``cycles`` is ``None``.
@@ -472,8 +474,8 @@ class EmpiricalSolver:
         return kd
 
     def _resolve_knockdown_model(
-            self, model: Union[str, Callable[[float, str], float]], mode: str
-    ) -> Tuple[Callable[[float, str], float], bool]:
+            self, model: str | Callable[[float, str], float], mode: str
+    ) -> tuple[Callable[[float, str], float], bool]:
         """Resolve ``model`` to a ``(callable, is_user_supplied)`` pair.
 
         Built-in string names dispatch to the corresponding ``_judd_wright``
@@ -500,11 +502,11 @@ class EmpiricalSolver:
         return model, True
 
     def apply_loading(self, mode: str = 'compression',
-                      model: Union[str, Callable[[float, str], float]] = 'judd_wright',
+                      model: str | Callable[[float, str], float] = 'judd_wright',
                       *,
-                      cycles: Optional[float] = None,
-                      environment: Optional[Dict[str, float]] = None,
-                      R: Optional[float] = None):
+                      cycles: float | None = None,
+                      environment: dict[str, float] | None = None,
+                      R: float | None = None):
         """Compute per-node knockdown for a given loading mode and model.
 
         Populates ``self.nodal_knockdown`` (shape ``(n_nodes,)``, values in
@@ -602,12 +604,12 @@ class EmpiricalSolver:
         self.nodal_knockdown = kd  # type: ignore[assignment]  # lazy-init attr starts None
 
     def get_failure_load(self, mode: str = 'compression',
-                         model: Union[str, Callable[[float, str], float]]
+                         model: str | Callable[[float, str], float]
                          = 'judd_wright',
                          *,
-                         cycles: Optional[float] = None,
-                         environment: Optional[Dict[str, float]] = None,
-                         R: Optional[float] = None) -> 'FailureResult':
+                         cycles: float | None = None,
+                         environment: dict[str, float] | None = None,
+                         R: float | None = None) -> FailureResult:
         """Compute failure load using specimen-average porosity.
 
         The knockdown is evaluated at the mean Vp (matching how the original
@@ -681,7 +683,7 @@ class EmpiricalSolver:
         model_label = model if isinstance(model, str) else getattr(
             model, '__name__', 'user_callable')
 
-        details: Dict[str, Any] = {
+        details: dict[str, Any] = {
             'critical_location': [0.0, 0.0, 0.0],
             'mode': mode,
         }
@@ -701,11 +703,11 @@ class EmpiricalSolver:
 
     def get_all_failure_loads(
             self,
-            extra_models: Optional[Dict[str, Callable[[float, str], float]]] = None,
+            extra_models: dict[str, Callable[[float, str], float]] | None = None,
             *,
-            cycles: Optional[float] = None,
-            environment: Optional[Dict[str, float]] = None,
-            R: Optional[float] = None,
+            cycles: float | None = None,
+            environment: dict[str, float] | None = None,
+            R: float | None = None,
     ) -> dict:
         """Compute failure loads for all modes against all built-in models.
 
@@ -728,8 +730,8 @@ class EmpiricalSolver:
         R : float, optional
             Stress ratio for the fatigue knockdown (informational).
         """
-        results: Dict[str, Dict[str, FailureResult]] = {}
-        all_models: List[Tuple[str, Union[str, Callable[[float, str], float]]]] = [
+        results: dict[str, dict[str, FailureResult]] = {}
+        all_models: list[tuple[str, str | Callable[[float, str], float]]] = [
             ('judd_wright', 'judd_wright'),
             ('power_law', 'power_law'),
             ('linear', 'linear'),
@@ -749,7 +751,7 @@ class EmpiricalSolver:
 
     def local_sensitivities(self, mode: str = 'compression',
                             model: str = 'judd_wright',
-                            Vp: Optional[float] = None) -> Dict[str, float]:
+                            Vp: float | None = None) -> dict[str, float]:
         """Closed-form local sensitivities of the empirical knockdown.
 
         Returns the analytic partials ``dKD/dVp`` and ``dKD/dcoef`` (the

--- a/porosity_fe/fatigue.py
+++ b/porosity_fe/fatigue.py
@@ -1,8 +1,9 @@
 """S-N (fatigue) knockdown model (#59)."""
 
+from __future__ import annotations
+
 import warnings
 from dataclasses import dataclass
-from typing import Dict, Optional
 
 import numpy as np
 
@@ -34,7 +35,7 @@ import numpy as np
 # ============================================================
 # Back-compat alias retained for direct importers (tests, downstream code).
 # New code should reference ``Calibration.FATIGUE_B_QI``.
-_FATIGUE_B_QI: Dict[str, float] = {
+_FATIGUE_B_QI: dict[str, float] = {
     'tension': 0.10,
     'compression': 0.10,
     'shear': 0.08,
@@ -82,7 +83,7 @@ class FatigueModel:
     come from a fully populated test matrix per the applicable spec
     (e.g. CMH-17 Vol. 2 fatigue protocols).
     """
-    b: Optional[Dict[str, float]] = None
+    b: dict[str, float] | None = None
 
     def _slope(self, mode: str) -> float:
         if mode not in _FATIGUE_B_QI:

--- a/porosity_fe/fe/assembler.py
+++ b/porosity_fe/fe/assembler.py
@@ -1,7 +1,8 @@
 """Global FE assembler + boundary handler."""
 
+from __future__ import annotations
+
 import logging
-from typing import Dict, Optional, Tuple
 
 import numpy as np
 import scipy.sparse
@@ -43,7 +44,7 @@ class GlobalAssembler:
         self._C_m = material.get_isotropic_matrix_stiffness()
         self._nu_m = material.matrix_poisson
         self._void_shape = porosity_field.void_shape_radii
-        self._ke_cache: Dict[tuple, np.ndarray] = {}
+        self._ke_cache: dict[tuple, np.ndarray] = {}
         self._cache_hits = 0
         self._cache_misses = 0
 
@@ -71,7 +72,7 @@ class GlobalAssembler:
             material=self.material,
         )
 
-    def _element_cache_key(self, elem_idx: int) -> Optional[tuple]:
+    def _element_cache_key(self, elem_idx: int) -> tuple | None:
         """Return a cache key if this element can reuse a cached Ke.
 
         Elements can share stiffness matrices when they have:
@@ -249,7 +250,7 @@ class BoundaryHandler:
         return self.mesh.nodes_on_face(face)
 
     def compression_bcs(self, applied_strain: float = -0.01
-                        ) -> Tuple[Dict[int, float], np.ndarray]:
+                        ) -> tuple[dict[int, float], np.ndarray]:
         """Standard uniaxial compression boundary conditions.
 
         - x_min: ux = 0
@@ -273,7 +274,7 @@ class BoundaryHandler:
         Lx = self.mesh.L_x
         prescribed_disp = applied_strain * Lx
 
-        constrained: Dict[int, float] = {}
+        constrained: dict[int, float] = {}
 
         # Fix ux on x_min
         for nid in self.mesh.nodes_on_face('x_min'):
@@ -301,12 +302,12 @@ class BoundaryHandler:
         return constrained, F
 
     def tension_bcs(self, applied_strain: float = 0.01
-                    ) -> Tuple[Dict[int, float], np.ndarray]:
+                    ) -> tuple[dict[int, float], np.ndarray]:
         """Uniaxial tension boundary conditions (same structure, positive strain)."""
         return self.compression_bcs(applied_strain=applied_strain)
 
     def shear_bcs(self, applied_strain: float = 0.01
-                  ) -> Tuple[Dict[int, float], np.ndarray]:
+                  ) -> tuple[dict[int, float], np.ndarray]:
         """Pure shear boundary conditions for engineering shear strain gamma_12.
 
         Prescribes the deformation field consistent with pure shear on ALL four
@@ -336,7 +337,7 @@ class BoundaryHandler:
         gamma = applied_strain
         nodes = self.mesh.nodes  # shape (n_nodes, 3)
 
-        constrained: Dict[int, float] = {}
+        constrained: dict[int, float] = {}
 
         # ±x faces: u = gamma/2 * y_node,  v = gamma/2 * x_node
         for face in ('x_min', 'x_max'):
@@ -370,7 +371,7 @@ class BoundaryHandler:
         return constrained, F
 
     def ilss_bcs(self, applied_load: float = -10.0
-                 ) -> Tuple[Dict[int, float], np.ndarray]:
+                 ) -> tuple[dict[int, float], np.ndarray]:
         """ILSS (interlaminar short-beam shear) boundary conditions, ASTM D2344.
 
         Three-point short-beam-shear setup:
@@ -431,7 +432,7 @@ class BoundaryHandler:
                 "Check mesh generation."
             )
 
-        constrained: Dict[int, float] = {}
+        constrained: dict[int, float] = {}
         for nid in np.concatenate([support_left, support_right]):
             nid = int(nid)
             constrained[3 * nid]     = 0.0  # ux
@@ -456,9 +457,9 @@ class BoundaryHandler:
 
     @staticmethod
     def apply_penalty(K: scipy.sparse.csc_matrix, F: np.ndarray,
-                      constrained_dofs: Dict[int, float],
+                      constrained_dofs: dict[int, float],
                       penalty_factor: float = 1e6
-                      ) -> Tuple[scipy.sparse.csc_matrix, np.ndarray]:
+                      ) -> tuple[scipy.sparse.csc_matrix, np.ndarray]:
         """Apply penalty method for prescribed displacements.
 
         For each constrained DOF ``i`` with value ``v``,

--- a/porosity_fe/fe/element.py
+++ b/porosity_fe/fe/element.py
@@ -1,6 +1,6 @@
 """Hex8 isoparametric element with porosity degradation."""
 
-from typing import Tuple
+from __future__ import annotations
 
 import numpy as np
 
@@ -56,9 +56,9 @@ class Hex8Element:
 
     def __init__(self, node_coords: np.ndarray, C_base: np.ndarray,
                  ply_angle_deg: float, node_porosities: np.ndarray,
-                 void_shape_radii: Tuple, nu_m: float,
+                 void_shape_radii: tuple, nu_m: float,
                  C_m: np.ndarray, is_void: bool = False,
-                 material: 'MaterialProperties' = None) -> None:
+                 material: MaterialProperties = None) -> None:
         self.node_coords = np.asarray(node_coords, dtype=float)
         if self.node_coords.shape != (8, 3):
             raise ValueError(f"node_coords must be (8,3), got {self.node_coords.shape}.")

--- a/porosity_fe/fe/solver.py
+++ b/porosity_fe/fe/solver.py
@@ -8,7 +8,7 @@ import os
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, List, Literal, Tuple
+from typing import Literal
 
 import numpy as np
 import scipy.sparse
@@ -96,7 +96,7 @@ class FieldResults:
     knockdown: float
     per_element_failure_index: np.ndarray | None = None
     failure_criterion: str = 'tsai_wu'
-    failure_mode_indices: Dict[str, float] | None = None
+    failure_mode_indices: dict[str, float] | None = None
 
     def __repr__(self) -> str:
         n_nodes = self.displacement.shape[0] if self.displacement is not None else 0
@@ -379,12 +379,12 @@ class FESolver:
 
     #: Supported failure criteria for :meth:`solve`. Used both at runtime
     #: (for validation) and as the documented enumeration.
-    SUPPORTED_FAILURE_CRITERIA: Tuple[str, ...] = (
+    SUPPORTED_FAILURE_CRITERIA: tuple[str, ...] = (
         'tsai_wu', 'hashin', 'max_stress')
 
     def __init__(self, mesh: CompositeMesh, material: MaterialProperties,
                  porosity_field: PorosityField,
-                 ply_angles: List[float] | str | None = 'QI',
+                 ply_angles: list[float] | str | None = 'QI',
                  failure_criterion: Literal[
                      'tsai_wu', 'hashin', 'max_stress'] = 'tsai_wu') -> None:
         self.mesh = mesh
@@ -785,7 +785,7 @@ class FESolver:
 
     #: Empty per-mode failure-index dict used when an element is skipped
     #: (void) or for criteria that do not populate a particular mode.
-    _EMPTY_MODE_FI: Dict[str, float] = {
+    _EMPTY_MODE_FI: dict[str, float] = {
         'max_fi': 0.0,
         'fiber_t': 0.0,
         'fiber_c': 0.0,
@@ -795,7 +795,7 @@ class FESolver:
     }
 
     def _degraded_strengths(self, elem_Vp: float
-                            ) -> Tuple[float, float, float, float, float, float]:
+                            ) -> tuple[float, float, float, float, float, float]:
         """Return per-element porosity-degraded ply strengths.
 
         Implements the strength-degradation block shared by all failure
@@ -891,7 +891,7 @@ class FESolver:
 
     def _evaluate_failure(self, stress_local: np.ndarray,
                           criterion: str = 'tsai_wu'
-                          ) -> Tuple[float, np.ndarray, Dict[str, float]]:
+                          ) -> tuple[float, np.ndarray, dict[str, float]]:
         """Evaluate the chosen failure criterion at every Gauss point.
 
         Dispatches to :meth:`_evaluate_tsai_wu`, :meth:`_evaluate_hashin`,
@@ -945,7 +945,7 @@ class FESolver:
         )
 
         max_fi = 0.0
-        best_mode_indices: Dict[str, float] = dict(self._EMPTY_MODE_FI)
+        best_mode_indices: dict[str, float] = dict(self._EMPTY_MODE_FI)
         if criterion == 'tsai_wu':
             # Tsai-Wu polynomial couples all components — per-mode breakdown
             # is undefined. Surface NaN sentinels so downstream consumers see
@@ -1007,7 +1007,7 @@ class FESolver:
         return float(max_fi), per_elem_fi, best_mode_indices
 
     def _evaluate_tsai_wu(self, s_all: np.ndarray,
-                          strengths: Tuple[float, float, float, float, float, float],
+                          strengths: tuple[float, float, float, float, float, float],
                           e: int, elem_Vp: float) -> np.ndarray:
         """Tsai-Wu polynomial evaluated for one element's Gauss points.
 
@@ -1084,8 +1084,8 @@ class FESolver:
         return fi_per_gp
 
     def _evaluate_hashin(self, s_all: np.ndarray,
-                         strengths: Tuple[float, float, float, float, float, float]
-                         ) -> Dict[str, np.ndarray]:
+                         strengths: tuple[float, float, float, float, float, float]
+                         ) -> dict[str, np.ndarray]:
         """2D Hashin failure indices for unidirectional plies.
 
         Implements the Hashin (1980) 2D criterion with separate fiber/matrix
@@ -1163,8 +1163,8 @@ class FESolver:
         }
 
     def _evaluate_max_stress(self, s_all: np.ndarray,
-                             strengths: Tuple[float, float, float, float, float, float]
-                             ) -> Dict[str, np.ndarray]:
+                             strengths: tuple[float, float, float, float, float, float]
+                             ) -> dict[str, np.ndarray]:
         """Maximum-stress failure indices.
 
         ``FI_i = |σ_i| / X_i_allowable`` per component (signed split for

--- a/porosity_fe/gauss.py
+++ b/porosity_fe/gauss.py
@@ -1,6 +1,6 @@
 """Gauss quadrature points and weights."""
 
-from typing import Tuple
+from __future__ import annotations
 
 import numpy as np
 
@@ -8,7 +8,7 @@ import numpy as np
 # SECTION 7c: GAUSS QUADRATURE
 # ============================================================
 
-def gauss_points_1d(n: int) -> Tuple[np.ndarray, np.ndarray]:
+def gauss_points_1d(n: int) -> tuple[np.ndarray, np.ndarray]:
     """1D Gauss-Legendre points and weights on [-1, 1].
 
     Parameters
@@ -33,7 +33,7 @@ def gauss_points_1d(n: int) -> Tuple[np.ndarray, np.ndarray]:
         raise ValueError(f"Only n=1, 2, 3 supported, got n={n}.")
 
 
-def gauss_points_hex(order: int = 2) -> Tuple[np.ndarray, np.ndarray]:
+def gauss_points_hex(order: int = 2) -> tuple[np.ndarray, np.ndarray]:
     """3D Gauss-Legendre quadrature for a hexahedron [-1,1]^3.
 
     Parameters

--- a/porosity_fe/homogenization.py
+++ b/porosity_fe/homogenization.py
@@ -1,7 +1,8 @@
 """Mori-Tanaka homogenization, MT-cache, and CLT effective moduli."""
 
+from __future__ import annotations
+
 from functools import lru_cache
-from typing import Dict, List, Tuple
 
 import numpy as np
 
@@ -17,7 +18,7 @@ _MT_CACHE_MAXSIZE = 4096
 
 
 def _mt_effective_stiffness(C_m: np.ndarray, Vp: float,
-                            void_shape_radii: Tuple,
+                            void_shape_radii: tuple,
                             nu_m: float) -> np.ndarray:
     """Mori-Tanaka effective stiffness for void inclusions (C_inclusion = 0).
 
@@ -75,7 +76,7 @@ def _mt_effective_stiffness(C_m: np.ndarray, Vp: float,
 
 @lru_cache(maxsize=_MT_CACHE_MAXSIZE)
 def _mt_effective_stiffness_cached(C_m_00: float, C_m_33: float, Vp: float,
-                                   void_shape_radii: Tuple[float, ...],
+                                   void_shape_radii: tuple[float, ...],
                                    nu_m: float) -> np.ndarray:
     """LRU-cached core of :func:`_mt_effective_stiffness` (#112).
 
@@ -197,8 +198,8 @@ def _mt_effective_stiffness_cached(C_m_00: float, C_m_33: float, Vp: float,
     return C_eff
 
 
-def _degraded_composite_stiffness(Vp: float, void_shape_radii: Tuple,
-                                  mat: 'MaterialProperties') -> np.ndarray:
+def _degraded_composite_stiffness(Vp: float, void_shape_radii: tuple,
+                                  mat: MaterialProperties) -> np.ndarray:
     """Build porosity-degraded composite stiffness via component-wise micromechanics.
 
     Rather than applying a single scalar degradation ratio, this function:
@@ -320,7 +321,7 @@ def _degraded_composite_stiffness(Vp: float, void_shape_radii: Tuple,
 # ============================================================
 
 def compute_clt_effective_modulus(material: MaterialProperties,
-                                  ply_angles: List[float]) -> float:
+                                  ply_angles: list[float]) -> float:
     """Compute effective laminate longitudinal modulus using CLT (ABD matrix).
 
     Builds the full A-matrix (in-plane stiffness) from Classical Lamination
@@ -373,8 +374,8 @@ def compute_clt_effective_modulus(material: MaterialProperties,
     return float(E_x)
 
 
-def _build_clt_abd(material: MaterialProperties, ply_angles: List[float],
-                   C_base: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
+def _build_clt_abd(material: MaterialProperties, ply_angles: list[float],
+                   C_base: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
     """Build CLT A (membrane) and D (bending) matrices from a 6x6 stiffness."""
     n_plies = len(ply_angles)
     t_ply = material.t_ply
@@ -415,9 +416,9 @@ def _build_clt_abd(material: MaterialProperties, ply_angles: List[float],
 
 
 def compute_degraded_clt_moduli(material: MaterialProperties,
-                                ply_angles: List[float],
+                                ply_angles: list[float],
                                 Vp: float,
-                                method: str = 'mori_tanaka') -> Dict[str, float]:
+                                method: str = 'mori_tanaka') -> dict[str, float]:
     """Compute effective laminate in-plane moduli (Ex, Ey, Gxy) with porosity.
 
     Uses Mori-Tanaka-degraded ply stiffness via _degraded_composite_stiffness,
@@ -452,9 +453,9 @@ def compute_degraded_clt_moduli(material: MaterialProperties,
 
 
 def compute_degraded_clt_flexural_modulus(material: MaterialProperties,
-                                          ply_angles: List[float],
+                                          ply_angles: list[float],
                                           Vp: float,
-                                          method: str = 'mori_tanaka') -> Dict[str, float]:
+                                          method: str = 'mori_tanaka') -> dict[str, float]:
     """Compute effective laminate flexural modulus Ef_x with porosity.
 
     Uses the CLT D-matrix (bending stiffness) to compute the flexural modulus.

--- a/porosity_fe/io.py
+++ b/porosity_fe/io.py
@@ -11,7 +11,7 @@ import platform
 import subprocess
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING, Dict
+from typing import TYPE_CHECKING
 
 import numpy as np
 
@@ -168,8 +168,8 @@ def _build_provenance(seed: int | None = None) -> dict:
     return prov
 
 
-def save_results_to_json(results: Dict, filename: str | os.PathLike,
-                         artifacts: Dict[str, ConfigArtifacts] | None = None):
+def save_results_to_json(results: dict, filename: str | os.PathLike,
+                         artifacts: dict[str, ConfigArtifacts] | None = None):
     """Export numerical results to JSON.
 
     Parameters
@@ -266,7 +266,7 @@ def save_results_to_json(results: Dict, filename: str | os.PathLike,
     logger.info("Saved: %s", filename)
 
 
-def load_results_from_json(filename: str | os.PathLike) -> Dict:
+def load_results_from_json(filename: str | os.PathLike) -> dict:
     """Round-trip loader for save_results_to_json / export_results outputs.
 
     Validates schema_version compatibility and format identifier. Raises

--- a/porosity_fe/materials.py
+++ b/porosity_fe/materials.py
@@ -1,7 +1,8 @@
 """Material properties dataclass and built-in presets."""
 
+from __future__ import annotations
+
 from dataclasses import dataclass
-from typing import Dict, Optional, Tuple
 
 import numpy as np
 
@@ -151,16 +152,16 @@ class MaterialProperties:
     # ``T_service`` / ``M_service`` / ``T_g_dry`` is ``None``,
     # :meth:`environment_knockdown` returns 1.0 (back-compat no-op).
     # ----------------------------------------------------------------
-    T_service: Optional[float] = None   # Service temperature (deg C)
-    M_service: Optional[float] = None   # Service moisture content (wt %)
+    T_service: float | None = None   # Service temperature (deg C)
+    M_service: float | None = None   # Service moisture content (wt %)
     T_ref: float = 23.0                 # Reference / RT (deg C); RTD baseline
     M_ref: float = 0.0                  # Reference moisture (wt %)
-    T_g_dry: Optional[float] = None     # Dry glass-transition temperature (deg C)
+    T_g_dry: float | None = None     # Dry glass-transition temperature (deg C)
 
     # Tsai-Wu interaction coefficient. None (default) -> use Tsai's
     # recommendation F_12 = -0.5 * sqrt(F_11 * F_22). For critical
     # applications, calibrate against biaxial coupon data.
-    tsai_wu_F12: Optional[float] = None
+    tsai_wu_F12: float | None = None
 
     def __post_init__(self):
         # Stiffness moduli must be positive finite (non-zero for 1/E in compliance).
@@ -327,8 +328,8 @@ class MaterialProperties:
     _SPRINGER_MOISTURE_TG_SLOPE = 25.0  # deg C per wt% moisture
 
     def environment_knockdown(self, mode: str,
-                              T: Optional[float] = None,
-                              M: Optional[float] = None) -> float:
+                              T: float | None = None,
+                              M: float | None = None) -> float:
         """Hygrothermal (T / M) knockdown factor for the requested mode.
 
         Implements the standard Chamis / Springer matrix-property ratio::
@@ -467,8 +468,8 @@ class MaterialProperties:
             f"Use one of 'lognormal', 'normal', 'uniform'."
         )
 
-    def perturb(self, draws: Dict[str, float],
-                spec: Dict[str, Tuple[str, float]]) -> "MaterialProperties":
+    def perturb(self, draws: dict[str, float],
+                spec: dict[str, tuple[str, float]]) -> MaterialProperties:
         """Return a new ``MaterialProperties`` with the fields in ``spec``
         perturbed using the per-field unit draws in ``draws``.
 

--- a/porosity_fe/mesh.py
+++ b/porosity_fe/mesh.py
@@ -1,8 +1,9 @@
 """Structured hex mesh and quality checks."""
 
+from __future__ import annotations
+
 import logging
 import warnings
-from typing import Dict, List, Optional, Tuple, Union
 
 import numpy as np
 
@@ -128,7 +129,7 @@ class CompositeMesh:
 
     def __init__(self, porosity_field: PorosityField, material: MaterialProperties,
                  nx: int = 50, ny: int = 20, nz: int = 24,
-                 ply_angles: Optional[Union[List[float], str]] = 'QI'):
+                 ply_angles: list[float] | str | None = 'QI'):
         for axis_name, value in (('nx', nx), ('ny', ny), ('nz', nz)):
             if not isinstance(value, (int, np.integer)) or value <= 0:
                 raise ValueError(
@@ -258,7 +259,7 @@ class CompositeMesh:
         return self.n_nodes * 3
 
     @property
-    def domain_size(self) -> Tuple[float, float, float]:
+    def domain_size(self) -> tuple[float, float, float]:
         return (self.L_x, self.L_y, self.L_z)
 
     def nodes_on_face(self, face: str) -> np.ndarray:
@@ -291,10 +292,10 @@ class CompositeMesh:
         else:
             raise ValueError(f"Unknown face '{face}'. Use x_min/x_max/y_min/y_max/z_min/z_max.")
 
-    def find_nodes_near(self, x: Optional[float] = None,
-                        y: Optional[float] = None,
-                        z: Optional[float] = None,
-                        tol: Optional[float] = None) -> np.ndarray:
+    def find_nodes_near(self, x: float | None = None,
+                        y: float | None = None,
+                        z: float | None = None,
+                        tol: float | None = None) -> np.ndarray:
         """Return node indices within ``tol`` of the specified target coords.
 
         Any of ``x``, ``y``, ``z`` may be ``None``, in which case that axis
@@ -359,7 +360,7 @@ class CompositeMesh:
                 f"void_elements={len(self.void_elements)})")
 
 
-def check_mesh_quality(mesh: CompositeMesh, verbose: bool = False) -> Dict:
+def check_mesh_quality(mesh: CompositeMesh, verbose: bool = False) -> dict:
     """Check mesh quality: element aspect ratios and Jacobian determinants.
 
     Parameters

--- a/porosity_fe/pipeline.py
+++ b/porosity_fe/pipeline.py
@@ -1,9 +1,11 @@
 """Sweep orchestrator: ``_analyze_one`` worker + ``compare_configurations``."""
 
+from __future__ import annotations
+
 import concurrent.futures
 import logging
 import os
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Union
 
 from .empirical import EmpiricalSolver
 from .materials import MATERIALS, MaterialProperties
@@ -17,11 +19,11 @@ logger = logging.getLogger("porosity_fe_analysis")
 # either a sentinel string (``'QI'`` / ``'UD'``) or an explicit list of ply
 # angles in degrees. ``tuple`` is included for callers that build the layup
 # from an immutable sequence.
-LayupSpec = Union[str, List[float], Tuple[float, ...]]
+LayupSpec = Union[str, list[float], tuple[float, ...]]
 
 # Default mesh resolution used by the production sweep (``_analyze_one``) so
 # every call site picks up the same defaults.
-_DEFAULT_MESH_RES: Tuple[int, int, int] = (30, 10, 12)
+_DEFAULT_MESH_RES: tuple[int, int, int] = (30, 10, 12)
 
 
 def build_empirical_pipeline(
@@ -29,10 +31,10 @@ def build_empirical_pipeline(
     void_volume_fraction: float,
     *,
     ply_angles: LayupSpec = 'QI',
-    mesh_res: Tuple[int, int, int] = _DEFAULT_MESH_RES,
-    porosity_config: Optional[Dict[str, Any]] = None,
-    seed: Optional[int] = None,
-) -> Tuple[PorosityField, CompositeMesh, EmpiricalSolver]:
+    mesh_res: tuple[int, int, int] = _DEFAULT_MESH_RES,
+    porosity_config: dict[str, Any] | None = None,
+    seed: int | None = None,
+) -> tuple[PorosityField, CompositeMesh, EmpiricalSolver]:
     """Factory: ``(material, Vp) -> (PorosityField, CompositeMesh, EmpiricalSolver)``.
 
     Single point of change for mesh defaults and ply-angle handling. The
@@ -69,7 +71,7 @@ def build_empirical_pipeline(
         The fully-constructed pipeline ready for ``get_failure_load`` /
         ``get_all_failure_loads`` calls.
     """
-    pf_kwargs: Dict[str, Any] = dict(porosity_config or {})
+    pf_kwargs: dict[str, Any] = dict(porosity_config or {})
     if seed is not None:
         pf_kwargs['seed'] = seed
     pf = PorosityField(material, void_volume_fraction, **pf_kwargs)
@@ -86,10 +88,10 @@ def build_empirical_pipeline(
 
 def _analyze_one(Vp: float,
                  name: str,
-                 config: Dict,
+                 config: dict,
                  material_name: str,
                  applied_stress: float,
-                 seed: Optional[int] = None) -> Tuple[float, str, Dict]:
+                 seed: int | None = None) -> tuple[float, str, dict]:
     """Build PorosityField/CompositeMesh/EmpiricalSolver for one (Vp, config).
 
     Top-level (picklable) helper so this can be dispatched to a
@@ -147,7 +149,7 @@ def _analyze_one(Vp: float,
     return (Vp, name, result)
 
 
-def _build_config_result(name: str, Vp: float, raw: Dict) -> 'ConfigResult':
+def _build_config_result(name: str, Vp: float, raw: dict) -> ConfigResult:
     """Distill the worker-dict shape into a lightweight :class:`ConfigResult`.
 
     Reads the headline compression / Judd-Wright knockdown from the inner
@@ -177,7 +179,7 @@ def _build_config_result(name: str, Vp: float, raw: Dict) -> 'ConfigResult':
     )
 
 
-def _build_config_artifacts(raw: Dict) -> 'ConfigArtifacts':
+def _build_config_artifacts(raw: dict) -> ConfigArtifacts:
     """Bundle the live worker objects into a :class:`ConfigArtifacts`."""
     return ConfigArtifacts(
         mesh=raw['mesh'],
@@ -187,7 +189,7 @@ def _build_config_artifacts(raw: Dict) -> 'ConfigArtifacts':
     )
 
 
-def _resolve_n_jobs(n_jobs: Optional[int]) -> int:
+def _resolve_n_jobs(n_jobs: int | None) -> int:
     """Normalise ``n_jobs`` to a positive worker count.
 
     ``None``/``0``/``-1`` map to ``os.cpu_count() or 1`` so callers can
@@ -199,7 +201,7 @@ def _resolve_n_jobs(n_jobs: Optional[int]) -> int:
     return int(n_jobs)
 
 
-def _log_result_summary(name: str, result: Dict, *, is_parallel: bool) -> None:
+def _log_result_summary(name: str, result: dict, *, is_parallel: bool) -> None:
     """Emit the per-config result-summary log lines.
 
     Both branches of :func:`compare_configurations` (serial + parallel)
@@ -251,8 +253,8 @@ def _log_result_summary(name: str, result: Dict, *, is_parallel: bool) -> None:
 def compare_configurations(void_volume_fraction: float,
                            material_name: str = 'T800_epoxy',
                            applied_stress: float = -1500.0,
-                           configs: Optional[Dict] = None,
-                           seed: Optional[int] = None,
+                           configs: dict | None = None,
+                           seed: int | None = None,
                            n_jobs: int = 1,
                            return_artifacts: bool = False):
     """Main analysis function — loops through porosity configurations.
@@ -326,7 +328,7 @@ def compare_configurations(void_volume_fraction: float,
         for name, config in configs.items()
     ]
 
-    raw_results: Dict[Tuple[float, str], Dict] = {}
+    raw_results: dict[tuple[float, str], dict] = {}
     if workers == 1 or len(tasks) <= 1:
         # Serial path — preserves the legacy behaviour byte-for-byte and
         # avoids the ProcessPoolExecutor fork cost for trivially small
@@ -353,8 +355,8 @@ def compare_configurations(void_volume_fraction: float,
     # Split the worker dict into the public-facing lightweight
     # ConfigResult (numbers + nested empirical table) and the parallel
     # ConfigArtifacts (live mesh / solver / field), per #44 item 3.
-    results: Dict[str, ConfigResult] = {}
-    artifacts: Dict[str, ConfigArtifacts] = {}
+    results: dict[str, ConfigResult] = {}
+    artifacts: dict[str, ConfigArtifacts] = {}
     for name in configs:
         raw = raw_results[(void_volume_fraction, name)]
         results[name] = _build_config_result(name, void_volume_fraction, raw)

--- a/porosity_fe/porosity_field.py
+++ b/porosity_fe/porosity_field.py
@@ -1,6 +1,6 @@
 """Continuous porosity field with optional discrete-void superposition."""
 
-from typing import List, Optional, Tuple, Union
+from __future__ import annotations
 
 import numpy as np
 
@@ -131,10 +131,10 @@ class PorosityField:
     _DISTRIBUTIONS = ('uniform', 'clustered', 'interface')
 
     def __init__(self, material: MaterialProperties, void_volume_fraction: float,
-                 distribution: str = 'uniform', void_shape: Union[str, Tuple] = 'spherical',
+                 distribution: str = 'uniform', void_shape: str | tuple = 'spherical',
                  cluster_location: str = 'midplane',
-                 discrete_voids: Optional[List[VoidGeometry]] = None,
-                 seed: Optional[int] = None):
+                 discrete_voids: list[VoidGeometry] | None = None,
+                 seed: int | None = None):
         if void_volume_fraction is None:
             raise ValueError("void_volume_fraction is None; expected a finite float in [0, 1].")
         if not isinstance(void_volume_fraction, (int, float, np.floating, np.integer)):

--- a/porosity_fe/results.py
+++ b/porosity_fe/results.py
@@ -5,8 +5,10 @@ Lives in its own module so :mod:`porosity_fe.empirical`,
 consume them without importing each other (#119).
 """
 
+from __future__ import annotations
+
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from .empirical import EmpiricalSolver
@@ -123,10 +125,10 @@ class ConfigArtifacts:
         (``compare_configurations`` is empirical-only today, so this is
         ``None`` from that path).
     """
-    mesh: 'CompositeMesh'
-    empirical_solver: 'EmpiricalSolver'
-    porosity_field: 'PorosityField'
-    field_results: Optional['FieldResults'] = None
+    mesh: CompositeMesh
+    empirical_solver: EmpiricalSolver
+    porosity_field: PorosityField
+    field_results: FieldResults | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -191,7 +193,7 @@ class ConfigResult:
     knockdown: float
     model: str
     empirical: dict
-    seed: Optional[int] = None
+    seed: int | None = None
 
     _DICT_KEYS_DIRECT = (
         'Vp', 'config_name', 'config', 'failure_stress',

--- a/porosity_fe/uq.py
+++ b/porosity_fe/uq.py
@@ -1,9 +1,10 @@
 """Uncertainty propagation (Monte Carlo / LHS) over the empirical solver."""
 
+from __future__ import annotations
+
 import contextlib
 import io
 from collections import OrderedDict
-from typing import Dict, List, Optional, Tuple, Union
 
 import numpy as np
 
@@ -27,10 +28,10 @@ _UQ_NORMAL_DISTS = ('lognormal', 'normal')
 _UQ_UNIFORM_DISTS = ('uniform',)
 
 
-def _normalize_uq_spec(material: 'MaterialProperties',
-                       covs: Optional[Dict[str, float]],
-                       spec: Optional[Dict[str, Tuple[str, float]]]
-                       ) -> "OrderedDict":
+def _normalize_uq_spec(material: MaterialProperties,
+                       covs: dict[str, float] | None,
+                       spec: dict[str, tuple[str, float]] | None
+                       ) -> OrderedDict:
     """Resolve the user-facing uncertainty description into a canonical
     ``OrderedDict{field: (dist, params)}``.
 
@@ -119,19 +120,19 @@ def _unit_to_draw(u: np.ndarray, dist: str) -> np.ndarray:
 
 
 def propagate_uncertainty(void_volume_fraction: float,
-                          material: Union[str, 'MaterialProperties'] = 'T800_epoxy',
+                          material: str | MaterialProperties = 'T800_epoxy',
                           mode: str = 'compression',
                           model: str = 'judd_wright',
                           *,
-                          covs: Optional[Dict[str, float]] = None,
-                          spec: Optional[Dict[str, Tuple[str, float]]] = None,
+                          covs: dict[str, float] | None = None,
+                          spec: dict[str, tuple[str, float]] | None = None,
                           vp_cov: float = 0.0,
                           n_samples: int = 1000,
                           method: str = 'monte_carlo',
-                          seed: Optional[int] = None,
-                          percentiles: Tuple[float, ...] = Calibration.UQ_DEFAULT_PERCENTILES,
-                          ply_angles: Optional[Union[List[float], str]] = 'QI',
-                          config: Optional[Dict] = None) -> Dict:
+                          seed: int | None = None,
+                          percentiles: tuple[float, ...] = Calibration.UQ_DEFAULT_PERCENTILES,
+                          ply_angles: list[float] | str | None = 'QI',
+                          config: dict | None = None) -> dict:
     """Propagate input uncertainty through ``EmpiricalSolver.get_failure_load``.
 
     Perturbs uncertain ``MaterialProperties`` fields (and, optionally, the
@@ -221,8 +222,8 @@ def propagate_uncertainty(void_volume_fraction: float,
 
     config = config or {}
 
-    def _build_solver(material_obj: 'MaterialProperties',
-                      vp_value: float) -> 'EmpiricalSolver':
+    def _build_solver(material_obj: MaterialProperties,
+                      vp_value: float) -> EmpiricalSolver:
         # CompositeMesh prints a banner on construction; the sampling loop
         # builds one mesh per draw, so silence it (additive: we do not touch
         # CompositeMesh itself).
@@ -273,7 +274,7 @@ def propagate_uncertainty(void_volume_fraction: float,
         fs_samples[s] = res['failure_stress']
         kd_samples[s] = res['knockdown']
 
-    def _summary(arr: np.ndarray) -> Dict:
+    def _summary(arr: np.ndarray) -> dict:
         return {
             'mean': float(np.mean(arr)),
             'std': float(np.std(arr)),

--- a/porosity_fe/void_geometry.py
+++ b/porosity_fe/void_geometry.py
@@ -1,6 +1,6 @@
 """Discrete ellipsoidal void geometry."""
 
-from typing import Tuple
+from __future__ import annotations
 
 import numpy as np
 
@@ -81,7 +81,7 @@ class VoidGeometry:
     10.0
     """
 
-    def __init__(self, center: Tuple, radii: Tuple, orientation: float = 0.0):
+    def __init__(self, center: tuple, radii: tuple, orientation: float = 0.0):
         self.center = np.array(center, dtype=float)
         self.radii = np.array(radii, dtype=float)
         if self.center.shape != (3,):


### PR DESCRIPTION
Closes #107.

## Summary

Modernizes type annotations across the `porosity_fe/` package to PEP 604 unions and PEP 585 builtin generics, the cleanup requested in #107. (The issue referenced the pre-split `porosity_fe_analysis.py`; the code now lives in the package, so the sweep targets those modules.)

- Added `from __future__ import annotations` to the package modules that lacked it.
- Swept annotations with ruff `UP006/UP007/UP035/UP037/UP045`:
  - `Optional[X]` → `X | None`
  - `Union[A, B]` → `A | B`
  - `Dict/List/Tuple[...]` → `dict/list/tuple[...]`
  - dropped quoted forward-refs
- Removed the now-unused `Optional`/`Union`/`Dict`/`List`/`Tuple` imports (remaining `typing` imports are just `Any`, `Callable`, `Literal`, `TYPE_CHECKING`, plus one `Union`).

## Python 3.9 safety

The repo declares `requires-python = ">=3.9"` and ruff `target-version = "py39"`, and there is **no 3.9 CI job**, so runtime safety was checked by hand:

- The `from __future__ import annotations` import makes all rewritten annotations lazy (strings), so PEP 604 `|` in annotation positions never evaluates at runtime — safe on 3.9.
- The one **runtime** type alias, `pipeline.LayupSpec`, deliberately keeps `typing.Union` (PEP 604 `|` would fail at import time on 3.9); its inner `list[float]`/`tuple[float, ...]` are 3.9-safe via PEP 585 runtime subscription.
- Audited: no file uses new-style annotations without the future import, and no PEP 604 `|` leaked into a runtime position.
- No runtime annotation introspection (`get_type_hints`/`__annotations__`) exists in the package, so lazy annotations don't change behavior.

## Verification

- `ruff check .` — clean
- `mypy porosity_fe porosity_fe_analysis.py` (numpy<2, matching CI) — `Success: no issues found in 24 source files`
- `pytest tests/` — 636 passed, 1 skipped

No runtime behavior change; annotations only.

https://claude.ai/code/session_018h6s3TVwye8d3brbmYu7zx

---
_Generated by [Claude Code](https://claude.ai/code/session_018h6s3TVwye8d3brbmYu7zx)_