### PR TITLE
refactor: use Literal types for closed-set string params (#109)

### DIFF
--- a/porosity_fe/__init__.py
+++ b/porosity_fe/__init__.py
@@ -62,6 +62,12 @@ _configure_matplotlib_style()
 from ._ply_angles import _PLY_ANGLES_QI as _PLY_ANGLES_QI  # noqa: F401, E402
 from ._ply_angles import _PLY_ANGLES_UD as _PLY_ANGLES_UD  # noqa: F401, E402
 from ._ply_angles import _resolve_ply_angles as _resolve_ply_angles  # noqa: F401, E402
+from ._types import ClusterLocation as ClusterLocation  # noqa: F401, E402
+from ._types import Distribution as Distribution  # noqa: F401, E402
+from ._types import FELoadingMode as FELoadingMode  # noqa: F401, E402
+from ._types import KnockdownModel as KnockdownModel  # noqa: F401, E402
+from ._types import LoadingMode as LoadingMode  # noqa: F401, E402
+from ._types import MeshFace as MeshFace  # noqa: F401, E402
 from .cli import DEFAULT_POROSITY_LEVELS as DEFAULT_POROSITY_LEVELS  # noqa: F401, E402
 from .cli import _build_arg_parser as _build_arg_parser  # noqa: F401, E402
 from .cli import _configure_cli_logging as _configure_cli_logging  # noqa: F401, E402
@@ -193,6 +199,13 @@ __all__ = [
     "build_empirical_pipeline",
     "compare_configurations",
     "main",
+    # Closed-set string type aliases (#109)
+    "ClusterLocation",
+    "Distribution",
+    "FELoadingMode",
+    "KnockdownModel",
+    "LoadingMode",
+    "MeshFace",
     # Version
     "__version__",
 ]

--- a/porosity_fe/_types.py
+++ b/porosity_fe/_types.py
@@ -1,0 +1,48 @@
+"""Closed-set string type aliases (issue #109).
+
+These ``typing.Literal`` aliases name the small, fixed sets of accepted
+string values that recur across the public API (loading modes, knockdown
+model names, porosity distribution shapes, mesh faces). Promoting the bare
+``str`` annotations on the relevant signatures to these aliases lets static
+checkers reject typos and out-of-set values at the call site, without any
+runtime behavior change — the runtime validation in each module is the
+authoritative guard and is unchanged.
+
+Each alias is the single source of truth for its closed set. The exact
+members were read off the runtime validation / dispatch in the owning
+module (cross-references in the inline comments below); keep them in lock
+step with that validation if the accepted set ever changes.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+#: Loading modes accepted by :class:`~porosity_fe.empirical.EmpiricalSolver`
+#: (``apply_loading`` / ``get_failure_load`` / ``get_all_failure_loads``).
+#: Source of truth: ``EmpiricalSolver.PRISTINE_STRENGTH_KEY`` keys.
+LoadingMode = Literal[
+    'compression', 'tension', 'shear', 'ilss', 'transverse_tension'
+]
+
+#: Loading modes accepted by :meth:`~porosity_fe.fe.solver.FESolver.solve`.
+#: Narrower than :data:`LoadingMode`: the FE boundary-condition builders
+#: cover only these four (no ``'transverse_tension'``). Source of truth:
+#: the ``loading`` dispatch in ``FESolver.solve``.
+FELoadingMode = Literal['compression', 'tension', 'shear', 'ilss']
+
+#: Built-in empirical knockdown model names. Source of truth: the
+#: ``_MODEL_FUNCS`` dispatch in ``EmpiricalSolver._resolve_knockdown_model``.
+KnockdownModel = Literal['judd_wright', 'power_law', 'linear']
+
+#: Through-thickness porosity distribution shapes. Source of truth:
+#: ``PorosityField._DISTRIBUTIONS``.
+Distribution = Literal['uniform', 'clustered', 'interface']
+
+#: Cluster-bump locations for ``distribution='clustered'``. Source of truth:
+#: ``PorosityField._CLUSTER_OFFSETS`` keys.
+ClusterLocation = Literal['midplane', 'surface', 'quarter']
+
+#: Mesh face identifiers accepted by
+#: :meth:`~porosity_fe.mesh.CompositeMesh.nodes_on_face`.
+MeshFace = Literal['x_min', 'x_max', 'y_min', 'y_max', 'z_min', 'z_max']

--- a/porosity_fe/empirical.py
+++ b/porosity_fe/empirical.py
@@ -8,6 +8,7 @@ from typing import Any, Callable
 import numpy as np
 
 from ._ply_angles import _PLY_ANGLES_QI, _PLY_ANGLES_UD, _resolve_ply_angles
+from ._types import KnockdownModel, LoadingMode
 from .fatigue import FatigueModel
 from .materials import MaterialProperties
 from .mesh import CompositeMesh
@@ -501,8 +502,8 @@ class EmpiricalSolver:
         self._validate_user_kd_callable(model, mode)
         return model, True
 
-    def apply_loading(self, mode: str = 'compression',
-                      model: str | Callable[[float, str], float] = 'judd_wright',
+    def apply_loading(self, mode: LoadingMode = 'compression',
+                      model: KnockdownModel | Callable[[float, str], float] = 'judd_wright',
                       *,
                       cycles: float | None = None,
                       environment: dict[str, float] | None = None,
@@ -603,8 +604,8 @@ class EmpiricalSolver:
             kd = kd * fat_kd
         self.nodal_knockdown = kd  # type: ignore[assignment]  # lazy-init attr starts None
 
-    def get_failure_load(self, mode: str = 'compression',
-                         model: str | Callable[[float, str], float]
+    def get_failure_load(self, mode: LoadingMode = 'compression',
+                         model: KnockdownModel | Callable[[float, str], float]
                          = 'judd_wright',
                          *,
                          cycles: float | None = None,

--- a/porosity_fe/fe/solver.py
+++ b/porosity_fe/fe/solver.py
@@ -15,6 +15,7 @@ import scipy.sparse
 import scipy.sparse.linalg
 
 from .._ply_angles import _resolve_ply_angles
+from .._types import FELoadingMode
 from ..empirical import Calibration
 from ..homogenization import _mt_effective_stiffness
 from ..io import (
@@ -407,7 +408,7 @@ class FESolver:
             )
         self.failure_criterion = failure_criterion
 
-    def solve(self, loading: str = 'compression',
+    def solve(self, loading: FELoadingMode = 'compression',
               applied_strain: float = -0.01,
               applied_load: float = -10.0,
               verbose: bool = False,

--- a/porosity_fe/mesh.py
+++ b/porosity_fe/mesh.py
@@ -8,6 +8,7 @@ import warnings
 import numpy as np
 
 from ._ply_angles import _resolve_ply_angles
+from ._types import MeshFace
 from .materials import MaterialProperties
 from .porosity_field import PorosityField
 
@@ -262,7 +263,7 @@ class CompositeMesh:
     def domain_size(self) -> tuple[float, float, float]:
         return (self.L_x, self.L_y, self.L_z)
 
-    def nodes_on_face(self, face: str) -> np.ndarray:
+    def nodes_on_face(self, face: MeshFace) -> np.ndarray:
         """Return node indices on the specified face.
 
         Parameters

--- a/porosity_fe/porosity_field.py
+++ b/porosity_fe/porosity_field.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import numpy as np
 
+from ._types import ClusterLocation, Distribution
 from .materials import MaterialProperties
 from .void_geometry import VOID_SHAPES, VoidGeometry
 
@@ -131,8 +132,8 @@ class PorosityField:
     _DISTRIBUTIONS = ('uniform', 'clustered', 'interface')
 
     def __init__(self, material: MaterialProperties, void_volume_fraction: float,
-                 distribution: str = 'uniform', void_shape: str | tuple = 'spherical',
-                 cluster_location: str = 'midplane',
+                 distribution: Distribution = 'uniform', void_shape: str | tuple = 'spherical',
+                 cluster_location: ClusterLocation = 'midplane',
                  discrete_voids: list[VoidGeometry] | None = None,
                  seed: int | None = None):
         if void_volume_fraction is None:


### PR DESCRIPTION
## Summary

Promotes bare `str` annotations on closed-set string parameters to `typing.Literal` aliases so static checkers reject typos and out-of-set values at the call site. **Pure type-annotation change; no runtime behavior change** — the per-module runtime validation remains the authoritative guard and is untouched.

## New aliases (`porosity_fe/_types.py`)

Each member set was read off the runtime validation / dispatch in the owning module (not the issue's guesses):

- `LoadingMode = Literal['compression', 'tension', 'shear', 'ilss', 'transverse_tension']` — source: `EmpiricalSolver.PRISTINE_STRENGTH_KEY` keys.
- `FELoadingMode = Literal['compression', 'tension', 'shear', 'ilss']` — narrower than `LoadingMode`; the FE BC builders cover only these four. Source: `FESolver.solve` dispatch.
- `KnockdownModel = Literal['judd_wright', 'power_law', 'linear']` — source: `_MODEL_FUNCS` in `EmpiricalSolver._resolve_knockdown_model`.
- `Distribution = Literal['uniform', 'clustered', 'interface']` — source: `PorosityField._DISTRIBUTIONS`.
- `ClusterLocation = Literal['midplane', 'surface', 'quarter']` — source: `PorosityField._CLUSTER_OFFSETS` keys.
- `MeshFace = Literal['x_min', 'x_max', 'y_min', 'y_max', 'z_min', 'z_max']` — source: `CompositeMesh.nodes_on_face`.

All six are re-exported from `porosity_fe/__init__.py` and added to `__all__` (the authoritative public surface per CLAUDE.md).

## Signatures updated (annotation only — defaults and logic unchanged)

- `EmpiricalSolver.apply_loading(mode, model)`
- `EmpiricalSolver.get_failure_load(mode, model)`
- `PorosityField.__init__(distribution, cluster_location)`
- `CompositeMesh.nodes_on_face(face)`
- `FESolver.solve(loading)`

`get_all_failure_loads` takes no `mode`/`model` parameter (it iterates all modes internally), so no signature change was needed there.

## Verify

- `ruff check .` — clean
- `mypy porosity_fe porosity_fe_analysis.py` — clean (no new errors; internal callers' literal args type-check against the new aliases)
- `python -m pytest tests/ -q` — 636 passed, 1 skipped

## Coordination

Shares files (`empirical.py`, `mesh.py`, `porosity_field.py`) with #108 (if/elif → match/case). This PR touches **signature lines + the new alias module + the `__init__.py` re-export only**; #108 owns the dispatch **bodies**. Conflicts are expected to be mechanical (signatures vs. bodies).

Closes #109

https://claude.ai/code/session_018h6s3TVwye8d3brbmYu7zx

---
_Generated by [Claude Code](https://claude.ai/code/session_018h6s3TVwye8d3brbmYu7zx)_