### PR TITLE
refactor: replace string-dispatch if/elif chains with match/case (#108)

### DIFF
--- a/app.py
+++ b/app.py
@@ -301,7 +301,7 @@ def plot_results(result: dict, layup_str: str):
     width = 0.8 / n_models
 
     for i, (model_key, label, color, hatch) in enumerate(
-        zip(models, model_labels, colors, hatches)
+        zip(models, model_labels, colors, hatches, strict=True)
     ):
         vals = []
         for mode in modes:
@@ -310,7 +310,7 @@ def plot_results(result: dict, layup_str: str):
             else:
                 vals.append(emp[mode][model_key]["knockdown"])
         bar_x = x + i * width - (n_models - 1) * width / 2
-        for bx, bv in zip(bar_x, vals):
+        for bx, bv in zip(bar_x, vals, strict=True):
             if not np.isnan(bv):
                 ax.bar(bx, bv, width, color=color, hatch=hatch,
                        edgecolor="white" if hatch is None else "0.3",

--- a/examples/compute_degraded_clt_moduli.py
+++ b/examples/compute_degraded_clt_moduli.py
@@ -50,7 +50,7 @@ def main() -> None:
 
     print("Layup: [0/45/-45/90]_s   (8 plies, T800_epoxy)")
     print(f"{'Vp(%)':>7s} {'Ex/Ex0':>9s} {'Ey/Ey0':>9s} {'Gxy/Gxy0':>11s}")
-    for v, ex, ey, g in zip(Vps, Ex / Ex[0], Ey / Ey[0], Gxy / Gxy[0]):
+    for v, ex, ey, g in zip(Vps, Ex / Ex[0], Ey / Ey[0], Gxy / Gxy[0], strict=True):
         print(f"{v*100:7.2f} {ex:9.4f} {ey:9.4f} {g:11.4f}")
 
     fig, ax = plt.subplots(figsize=(7, 5))

--- a/examples/distribution_comparison.py
+++ b/examples/distribution_comparison.py
@@ -172,7 +172,7 @@ def _plot_profiles(material, save_path):
     """Plot the through-thickness Vp profile for each distribution."""
     fig, ax = plt.subplots(1, 1, figsize=(7, 6))
     colors = ["tab:blue", "tab:orange", "tab:green", "tab:red"]
-    for (label, kwargs), c in zip(DISTRIBUTIONS, colors):
+    for (label, kwargs), c in zip(DISTRIBUTIONS, colors, strict=True):
         pf = PorosityField(material, VP_MEAN, **kwargs)
         z, Vp = pf.effective_porosity_profile(nz=400)
         ax.plot(Vp * 100.0, z, label=label, color=c, linewidth=2)

--- a/porosity_fe/empirical.py
+++ b/porosity_fe/empirical.py
@@ -579,18 +579,19 @@ class EmpiricalSolver:
         if isinstance(model, str):
             # Mode validation already done above; this picks built-ins or
             # raises a clear error before we touch the array.
-            if model == 'judd_wright':
-                kd = np.exp(-self.JUDD_WRIGHT_ALPHA[mode] * Vp_arr)
-            elif model == 'power_law':
-                kd = (1.0 - Vp_arr) ** self.POWER_LAW_N[mode]
-            elif model == 'linear':
-                kd = np.maximum(1.0 - self.LINEAR_BETA[mode] * Vp_arr, 0.0)
-            else:
-                raise ValueError(
-                    f"Unknown knockdown model {model!r}. "
-                    f"Use one of ['judd_wright', 'power_law', 'linear'] "
-                    f"or pass a callable."
-                )
+            match model:
+                case 'judd_wright':
+                    kd = np.exp(-self.JUDD_WRIGHT_ALPHA[mode] * Vp_arr)
+                case 'power_law':
+                    kd = (1.0 - Vp_arr) ** self.POWER_LAW_N[mode]
+                case 'linear':
+                    kd = np.maximum(1.0 - self.LINEAR_BETA[mode] * Vp_arr, 0.0)
+                case _:
+                    raise ValueError(
+                        f"Unknown knockdown model {model!r}. "
+                        f"Use one of ['judd_wright', 'power_law', 'linear'] "
+                        f"or pass a callable."
+                    )
         else:
             self._validate_user_kd_callable(model, mode)
             kd = np.array([model(Vp, mode) for Vp in Vp_arr])
@@ -801,54 +802,56 @@ class EmpiricalSolver:
         if Vp is None:
             Vp = self.mesh.porosity_field.Vp
         Vp = self._check_internal_Vp(Vp)
-        if model == 'judd_wright':
-            alpha = self.JUDD_WRIGHT_ALPHA[mode]
-            kd = float(np.exp(-alpha * Vp))
-            return {
-                'KD': kd,
-                'dKD_dVp': float(-alpha * kd),
-                'dKD_dcoef': float(-Vp * kd),
-            }
-        if model == 'power_law':
-            n = self.POWER_LAW_N[mode]
-            one_minus = 1.0 - Vp
-            kd = float(one_minus**n)
-            # Guard the log when Vp = 1 (degenerate edge): KD is 0 there
-            # and the d/dn partial collapses to 0 because KD * ln(1-Vp)
-            # is 0 * (-inf) in the limit.  We pin it to 0.0 explicitly so
-            # callers see a finite value.
-            if one_minus <= 0.0:
-                d_dcoef = 0.0
-                d_dVp = 0.0
-            else:
-                d_dcoef = float(kd * np.log(one_minus))
-                d_dVp = float(-n * one_minus**(n - 1.0))
-            return {
-                'KD': kd,
-                'dKD_dVp': d_dVp,
-                'dKD_dcoef': d_dcoef,
-            }
-        if model == 'linear':
-            beta = self.LINEAR_BETA[mode]
-            raw = 1.0 - beta * Vp
-            kd = float(max(raw, 0.0))
-            # The linear law is clipped at 0: once raw < 0, the
-            # piecewise-constant 0 floor has zero gradient.
-            if raw <= 0.0:
-                d_dVp = 0.0
-                d_dcoef = 0.0
-            else:
-                d_dVp = float(-beta)
-                d_dcoef = float(-Vp)
-            return {
-                'KD': kd,
-                'dKD_dVp': d_dVp,
-                'dKD_dcoef': d_dcoef,
-            }
-        raise ValueError(
-            f"Unknown knockdown model {model!r}. "
-            f"Use one of ['judd_wright', 'linear', 'power_law']."
-        )
+        match model:
+            case 'judd_wright':
+                alpha = self.JUDD_WRIGHT_ALPHA[mode]
+                kd = float(np.exp(-alpha * Vp))
+                return {
+                    'KD': kd,
+                    'dKD_dVp': float(-alpha * kd),
+                    'dKD_dcoef': float(-Vp * kd),
+                }
+            case 'power_law':
+                n = self.POWER_LAW_N[mode]
+                one_minus = 1.0 - Vp
+                kd = float(one_minus**n)
+                # Guard the log when Vp = 1 (degenerate edge): KD is 0 there
+                # and the d/dn partial collapses to 0 because KD * ln(1-Vp)
+                # is 0 * (-inf) in the limit.  We pin it to 0.0 explicitly so
+                # callers see a finite value.
+                if one_minus <= 0.0:
+                    d_dcoef = 0.0
+                    d_dVp = 0.0
+                else:
+                    d_dcoef = float(kd * np.log(one_minus))
+                    d_dVp = float(-n * one_minus**(n - 1.0))
+                return {
+                    'KD': kd,
+                    'dKD_dVp': d_dVp,
+                    'dKD_dcoef': d_dcoef,
+                }
+            case 'linear':
+                beta = self.LINEAR_BETA[mode]
+                raw = 1.0 - beta * Vp
+                kd = float(max(raw, 0.0))
+                # The linear law is clipped at 0: once raw < 0, the
+                # piecewise-constant 0 floor has zero gradient.
+                if raw <= 0.0:
+                    d_dVp = 0.0
+                    d_dcoef = 0.0
+                else:
+                    d_dVp = float(-beta)
+                    d_dcoef = float(-Vp)
+                return {
+                    'KD': kd,
+                    'dKD_dVp': d_dVp,
+                    'dKD_dcoef': d_dcoef,
+                }
+            case _:
+                raise ValueError(
+                    f"Unknown knockdown model {model!r}. "
+                    f"Use one of ['judd_wright', 'linear', 'power_law']."
+                )
 
     def sensitivity_fd(self, mode: str = 'compression',
                        model: str = 'judd_wright',
@@ -897,18 +900,19 @@ class EmpiricalSolver:
 
         # Select the analytic functional form so we can perturb the
         # parameter without mutating solver state.
-        if model == 'judd_wright':
-            coef0 = float(self.JUDD_WRIGHT_ALPHA[mode])
-            def f(Vp_val, coef_val):
-                return float(np.exp(-coef_val * Vp_val))
-        elif model == 'power_law':
-            coef0 = float(self.POWER_LAW_N[mode])
-            def f(Vp_val, coef_val):
-                return float((1.0 - Vp_val)**coef_val)
-        else:  # linear
-            coef0 = float(self.LINEAR_BETA[mode])
-            def f(Vp_val, coef_val):
-                return float(max(1.0 - coef_val * Vp_val, 0.0))
+        match model:
+            case 'judd_wright':
+                coef0 = float(self.JUDD_WRIGHT_ALPHA[mode])
+                def f(Vp_val, coef_val):
+                    return float(np.exp(-coef_val * Vp_val))
+            case 'power_law':
+                coef0 = float(self.POWER_LAW_N[mode])
+                def f(Vp_val, coef_val):
+                    return float((1.0 - Vp_val)**coef_val)
+            case _:  # linear
+                coef0 = float(self.LINEAR_BETA[mode])
+                def f(Vp_val, coef_val):
+                    return float(max(1.0 - coef_val * Vp_val, 0.0))
 
         if param == 'Vp':
             return float((f(Vp0 + h, coef0) - f(Vp0 - h, coef0)) / (2.0 * h))

--- a/porosity_fe/mesh.py
+++ b/porosity_fe/mesh.py
@@ -277,20 +277,21 @@ class CompositeMesh:
         """
         tol = 1e-8
         coords = self.nodes
-        if face == 'x_min':
-            return np.where(np.abs(coords[:, 0] - coords[:, 0].min()) < tol)[0]
-        elif face == 'x_max':
-            return np.where(np.abs(coords[:, 0] - coords[:, 0].max()) < tol)[0]
-        elif face == 'y_min':
-            return np.where(np.abs(coords[:, 1] - coords[:, 1].min()) < tol)[0]
-        elif face == 'y_max':
-            return np.where(np.abs(coords[:, 1] - coords[:, 1].max()) < tol)[0]
-        elif face == 'z_min':
-            return np.where(np.abs(coords[:, 2] - coords[:, 2].min()) < tol)[0]
-        elif face == 'z_max':
-            return np.where(np.abs(coords[:, 2] - coords[:, 2].max()) < tol)[0]
-        else:
-            raise ValueError(f"Unknown face '{face}'. Use x_min/x_max/y_min/y_max/z_min/z_max.")
+        match face:
+            case 'x_min':
+                return np.where(np.abs(coords[:, 0] - coords[:, 0].min()) < tol)[0]
+            case 'x_max':
+                return np.where(np.abs(coords[:, 0] - coords[:, 0].max()) < tol)[0]
+            case 'y_min':
+                return np.where(np.abs(coords[:, 1] - coords[:, 1].min()) < tol)[0]
+            case 'y_max':
+                return np.where(np.abs(coords[:, 1] - coords[:, 1].max()) < tol)[0]
+            case 'z_min':
+                return np.where(np.abs(coords[:, 2] - coords[:, 2].min()) < tol)[0]
+            case 'z_max':
+                return np.where(np.abs(coords[:, 2] - coords[:, 2].max()) < tol)[0]
+            case _:
+                raise ValueError(f"Unknown face '{face}'. Use x_min/x_max/y_min/y_max/z_min/z_max.")
 
     def find_nodes_near(self, x: float | None = None,
                         y: float | None = None,

--- a/porosity_fe/pipeline.py
+++ b/porosity_fe/pipeline.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import concurrent.futures
 import logging
 import os
-from typing import Any, Union
+from typing import Any
 
 from .empirical import EmpiricalSolver
 from .materials import MATERIALS, MaterialProperties
@@ -19,7 +19,7 @@ logger = logging.getLogger("porosity_fe_analysis")
 # either a sentinel string (``'QI'`` / ``'UD'``) or an explicit list of ply
 # angles in degrees. ``tuple`` is included for callers that build the layup
 # from an immutable sequence.
-LayupSpec = Union[str, list[float], tuple[float, ...]]
+LayupSpec = str | list[float] | tuple[float, ...]
 
 # Default mesh resolution used by the production sweep (``_analyze_one``) so
 # every call site picks up the same defaults.

--- a/porosity_fe/porosity_field.py
+++ b/porosity_fe/porosity_field.py
@@ -194,47 +194,49 @@ class PorosityField:
     def _compute_normalization(self, distribution: str, cluster_location: str) -> float:
         """Compute normalization factor over the full domain so average equals Vp."""
         z_ref = np.linspace(0, self.Lz, 1000)
-        if distribution == 'clustered':
-            z0 = self.Lz * self._CLUSTER_OFFSETS[cluster_location]
-            sigma = self.Lz / 6
-            profile_ref = np.exp(-0.5 * ((z_ref - z0) / sigma)**2)
-        elif distribution == 'interface':
-            t = self.material.t_ply
-            n = self.material.n_plies
-            profile_ref = np.zeros_like(z_ref)
-            for k in range(1, n):
-                z_int = k * t
-                profile_ref += np.exp(-0.5 * ((z_ref - z_int) / (t * 0.35))**2)
-        else:
-            return 1.0
+        match distribution:
+            case 'clustered':
+                z0 = self.Lz * self._CLUSTER_OFFSETS[cluster_location]
+                sigma = self.Lz / 6
+                profile_ref = np.exp(-0.5 * ((z_ref - z0) / sigma)**2)
+            case 'interface':
+                t = self.material.t_ply
+                n = self.material.n_plies
+                profile_ref = np.zeros_like(z_ref)
+                for k in range(1, n):
+                    z_int = k * t
+                    profile_ref += np.exp(-0.5 * ((z_ref - z_int) / (t * 0.35))**2)
+            case _:
+                return 1.0
         mean_val = np.mean(profile_ref)
         return mean_val if mean_val > 0 else 1.0
 
     def _distributed_porosity(self, z: np.ndarray) -> np.ndarray:
         """Through-thickness distributed porosity profile."""
         z = np.asarray(z, dtype=float)
-        if self.distribution == 'uniform':
-            return np.full_like(z, self.Vp)
-        elif self.distribution == 'clustered':
-            z0 = self.Lz * self._CLUSTER_OFFSETS[self.cluster_location]
-            sigma = self.Lz / 6
-            profile = np.exp(-0.5 * ((z - z0) / sigma)**2)
-            norm = self._compute_normalization('clustered', self.cluster_location)
-            return self.Vp * profile / norm
-        elif self.distribution == 'interface':
-            t = self.material.t_ply
-            n = self.material.n_plies
-            profile = np.zeros_like(z)
-            for k in range(1, n):
-                z_int = k * t
-                profile += np.exp(-0.5 * ((z - z_int) / (t * 0.35))**2)
-            norm = self._compute_normalization('interface', self.cluster_location)
-            return self.Vp * profile / norm
-        else:
-            raise ValueError(
-                f"Unknown distribution {self.distribution!r}. "
-                f"Use one of {list(self._DISTRIBUTIONS)}."
-            )
+        match self.distribution:
+            case 'uniform':
+                return np.full_like(z, self.Vp)
+            case 'clustered':
+                z0 = self.Lz * self._CLUSTER_OFFSETS[self.cluster_location]
+                sigma = self.Lz / 6
+                profile = np.exp(-0.5 * ((z - z0) / sigma)**2)
+                norm = self._compute_normalization('clustered', self.cluster_location)
+                return self.Vp * profile / norm
+            case 'interface':
+                t = self.material.t_ply
+                n = self.material.n_plies
+                profile = np.zeros_like(z)
+                for k in range(1, n):
+                    z_int = k * t
+                    profile += np.exp(-0.5 * ((z - z_int) / (t * 0.35))**2)
+                norm = self._compute_normalization('interface', self.cluster_location)
+                return self.Vp * profile / norm
+            case _:
+                raise ValueError(
+                    f"Unknown distribution {self.distribution!r}. "
+                    f"Use one of {list(self._DISTRIBUTIONS)}."
+                )
 
     def local_porosity(self, x, y, z) -> np.ndarray:
         x, y, z = np.asarray(x), np.asarray(y), np.asarray(z)

--- a/porosity_fe/viz.py
+++ b/porosity_fe/viz.py
@@ -75,7 +75,7 @@ class FEVisualizer:
                 corners = mesh.nodes[mesh.elements[eidx]]  # (8, 3)
                 for i1, i2 in hex_edges:
                     ax.plot3D(
-                        *zip(corners[i1], corners[i2]),
+                        *zip(corners[i1], corners[i2], strict=True),
                         color='red', linewidth=1.5, alpha=0.8, zorder=6,
                     )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "1.2.0"
 description = "Streamlit web app for porosity-degraded composite laminate analysis"
 readme = "README.md"
 license = {text = "MIT"}
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 authors = [
     {name = "Rani Elhajjar", email = "elhajjar@uwm.edu"},
 ]
@@ -26,7 +26,6 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -88,7 +87,7 @@ testpaths = ["tests"]
 [tool.ruff]
 # Match the existing wide-format scientific code; nothing reflows.
 line-length = 120
-target-version = "py39"
+target-version = "py310"
 
 [tool.ruff.lint]
 # Pragmatic baseline: pyflakes (F), pycodestyle errors (E),
@@ -103,6 +102,17 @@ ignore = [
     # separately.
     "UP006",
     "UP035",
+    # UP007: rewriting `typing.Union[...]` -> `X | Y`. Same py310-gated
+    # pyupgrade family as UP006/UP035; the remaining `Union` alias is part
+    # of the separate typing-modernization slice and is kept out of scope
+    # for the match/case readability refactor (#108).
+    "UP007",
+    # B905: `zip()` without `strict=`. This rule only activates once the
+    # ruff target is py310+ (bumped here so `match`/`case` parses). The
+    # flagged call sites are pre-existing and span unrelated modules/tests;
+    # adding `strict=` is a separate behavior-touching slice, kept out of
+    # scope for the match/case readability refactor (#108).
+    "B905",
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,17 +102,6 @@ ignore = [
     # separately.
     "UP006",
     "UP035",
-    # UP007: rewriting `typing.Union[...]` -> `X | Y`. Same py310-gated
-    # pyupgrade family as UP006/UP035; the remaining `Union` alias is part
-    # of the separate typing-modernization slice and is kept out of scope
-    # for the match/case readability refactor (#108).
-    "UP007",
-    # B905: `zip()` without `strict=`. This rule only activates once the
-    # ruff target is py310+ (bumped here so `match`/`case` parses). The
-    # flagged call sites are pre-existing and span unrelated modules/tests;
-    # adding `strict=` is a separate behavior-touching slice, kept out of
-    # scope for the match/case readability refactor (#108).
-    "B905",
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/tests/test_homogenization.py
+++ b/tests/test_homogenization.py
@@ -370,7 +370,7 @@ class TestDegradedCompositeStiffness:
             C = _degraded_composite_stiffness(Vp, (1, 1, 1), self.mat)
             S = np.linalg.inv(C)
             E22_seq.append(1.0 / S[1, 1])
-        for a, b in zip(E22_seq, E22_seq[1:]):
+        for a, b in zip(E22_seq, E22_seq[1:], strict=False):
             assert b < a, f"E22 should drop monotonically with Vp: got {E22_seq}"
 
     def test_monotonic_degradation(self):
@@ -388,9 +388,9 @@ class TestDegradedCompositeStiffness:
             S = np.linalg.inv(C)
             E22_seq.append(1.0 / S[1, 1])
             G12_seq.append(1.0 / S[5, 5])
-        for a, b in zip(E22_seq, E22_seq[1:]):
+        for a, b in zip(E22_seq, E22_seq[1:], strict=False):
             assert b < a, f"E22 should drop monotonically with Vp: got {E22_seq}"
-        for a, b in zip(G12_seq, G12_seq[1:]):
+        for a, b in zip(G12_seq, G12_seq[1:], strict=False):
             assert b < a, f"G12 should drop monotonically with Vp: got {G12_seq}"
 
     def test_returned_stiffness_positive_definite(self):

--- a/tests/test_uq.py
+++ b/tests/test_uq.py
@@ -262,7 +262,7 @@ class TestValidationBands:
         band = prop['predicted_band']
         pred = prop['predicted']
         assert len(band) == len(pred)
-        for (lo, hi), p in zip(band, pred):
+        for (lo, hi), p in zip(band, pred, strict=True):
             # The band must be ordered and must straddle the central point.
             assert lo <= p <= hi, (
                 f"Band [{lo}, {hi}] does not straddle central prediction {p}"


### PR DESCRIPTION
Converts the genuine multi-way string-dispatch `if`/`elif` chains to equivalent `match`/`case` blocks. Pure readability refactor — **behavior-preserving** (same branch order, same returned values, same `ValueError` messages via `case _`). Trivial 2-branch ifs were left alone.

## Converted sites (file:function)

- `porosity_fe/porosity_field.py`
  - `PorosityField._compute_normalization` — `distribution` dispatch
  - `PorosityField._distributed_porosity` — `distribution` dispatch
- `porosity_fe/mesh.py`
  - `CompositeMesh.nodes_on_face` — 6-way face dispatch
- `porosity_fe/empirical.py`
  - `EmpiricalSolver.apply_loading` knockdown selection
  - `EmpiricalSolver` analytic-sensitivity dispatch
  - `EmpiricalSolver` finite-difference derivative helper

## Tooling / version bump

`match`/`case` is Python 3.10+ **runtime** syntax (it raises `SyntaxError` on 3.9), so:
- `requires-python` bumped to `>=3.10`, the 3.9 trove classifier dropped. (CI already only tests 3.10–3.13, so 3.9 was declared-but-untested.)
- ruff `target-version` set to `py310`.

The py310 target surfaced two pre-existing lint families, which are now **fixed** (not suppressed):
- **UP007** — the one runtime `Union` alias (`pipeline.LayupSpec`) converted to PEP 604 `str | list[float] | tuple[float, ...]`, now runtime-safe on the ≥3.10 floor; unused `Union` import dropped.
- **B905** — explicit `strict=` added to every flagged `zip()`: `strict=True` where the iterables are equal-length by construction (app bar chart, CLT-moduli sweep, distribution/colors, viz edge transpose, UQ band/pred), and `strict=False` for the intentional sliding-window pairs `zip(seq, seq[1:])` in `test_homogenization` (where `strict=True` would raise).

## Verification

- `ruff check .` → All checks passed (UP007/B905 now enforced)
- `mypy porosity_fe porosity_fe_analysis.py` → Success, no issues (numpy 1.26.4)
- `python -m pytest tests/ -q` → 636 passed, 1 skipped

Rebased onto master (now includes #123 and #109); the shared-file edits merged mechanically (#109 signatures vs. this PR's dispatch bodies).

Closes #108

https://claude.ai/code/session_018h6s3TVwye8d3brbmYu7zx