### PR TITLE
perf: vectorize CompositeMesh.generate_mesh (#178)

### DIFF
--- a/porosity_fe/mesh.py
+++ b/porosity_fe/mesh.py
@@ -175,14 +175,14 @@ class CompositeMesh:
         y = np.linspace(0, self.L_y, self.ny + 1)
         z = np.linspace(0, self.L_z, self.nz + 1)
 
-        nodes = []
-
-        for zk in z:
-            for yj in y:
-                for xi in x:
-                    nodes.append([xi, yj, zk])
-
-        self.nodes = np.array(nodes)
+        # Vectorized node construction. Node ordering is z (outer) ->
+        # y (middle) -> x (inner), i.e. node_id = k*(ny+1)*(nx+1)
+        # + j*(nx+1) + i. ``indexing='ij'`` with axis order (z, y, x)
+        # then C-order ravel reproduces that exact ordering, matching the
+        # original triple-nested ``for zk: for yj: for xi`` loop.
+        zz, yy, xx = np.meshgrid(z, y, x, indexing='ij')
+        self.nodes = np.column_stack(
+            (xx.ravel(), yy.ravel(), zz.ravel()))
 
         # Sample porosity at all nodes
         self.porosity = self.porosity_field.local_porosity(
@@ -195,22 +195,26 @@ class CompositeMesh:
         self.ply_ids = np.clip((z_normalized * self.material.n_plies).astype(int),
                                0, self.material.n_plies - 1)
 
-        # Hex element connectivity
-        elements = []
-        for k in range(self.nz):
-            for j in range(self.ny):
-                for i in range(self.nx):
-                    n0 = k * (self.ny + 1) * (self.nx + 1) + j * (self.nx + 1) + i
-                    n1 = n0 + 1
-                    n2 = n0 + (self.nx + 1) + 1
-                    n3 = n0 + (self.nx + 1)
-                    n4 = n0 + (self.ny + 1) * (self.nx + 1)
-                    n5 = n4 + 1
-                    n6 = n4 + (self.nx + 1) + 1
-                    n7 = n4 + (self.nx + 1)
-                    elements.append([n0, n1, n2, n3, n4, n5, n6, n7])
-
-        self.elements = np.array(elements)
+        # Vectorized hex element connectivity. Element ordering is
+        # k (outer) -> j (middle) -> i (inner), matching the original
+        # triple-nested loop. ``indexing='ij'`` with axis order
+        # (k, j, i) then a C-order ravel of each corner offset array
+        # reproduces that exact element ordering and per-element corner
+        # ordering.
+        nx1 = self.nx + 1
+        layer = (self.ny + 1) * nx1
+        k, j, i = np.meshgrid(
+            np.arange(self.nz), np.arange(self.ny), np.arange(self.nx),
+            indexing='ij')
+        n0 = (k * layer + j * nx1 + i).ravel()
+        n1 = n0 + 1
+        n2 = n0 + nx1 + 1
+        n3 = n0 + nx1
+        n4 = n0 + layer
+        n5 = n4 + 1
+        n6 = n4 + nx1 + 1
+        n7 = n4 + nx1
+        self.elements = np.column_stack((n0, n1, n2, n3, n4, n5, n6, n7))
 
         # Identify void elements: check if element centroid falls inside
         # any discrete void geometry (explicit inclusion modeling)

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -77,6 +77,49 @@ class TestCompositeMesh:
         with pytest.raises(ValueError, match=r"exhaust memory|exceeds"):
             CompositeMesh(self.pf, self.material, nx=20_000, ny=5, nz=6)
 
+    @pytest.mark.parametrize("nx,ny,nz", [(1, 1, 1), (4, 3, 2), (5, 3, 4),
+                                          (2, 7, 3), (10, 5, 6)])
+    def test_mesh_ordering_matches_reference_loop(self, nx, ny, nz):
+        """Pin the exact node ordering and hex8 corner ordering.
+
+        The FE solver's DOF/BC indexing depends on the precise node id
+        formula ``node_id = k*(ny+1)*(nx+1) + j*(nx+1) + i`` and the
+        per-element 8-corner order. This regression test reproduces both
+        with a self-contained triple-nested reference loop so the
+        contract is pinned independently of the (vectorized)
+        implementation. See issue #178.
+        """
+        mesh = CompositeMesh(self.pf, self.material, nx=nx, ny=ny, nz=nz)
+
+        x = np.linspace(0, mesh.L_x, nx + 1)
+        y = np.linspace(0, mesh.L_y, ny + 1)
+        z = np.linspace(0, mesh.L_z, nz + 1)
+
+        ref_nodes = []
+        for zk in z:
+            for yj in y:
+                for xi in x:
+                    ref_nodes.append([xi, yj, zk])
+        ref_nodes = np.array(ref_nodes)
+
+        ref_elements = []
+        for k in range(nz):
+            for j in range(ny):
+                for i in range(nx):
+                    n0 = k * (ny + 1) * (nx + 1) + j * (nx + 1) + i
+                    n1 = n0 + 1
+                    n2 = n0 + (nx + 1) + 1
+                    n3 = n0 + (nx + 1)
+                    n4 = n0 + (ny + 1) * (nx + 1)
+                    n5 = n4 + 1
+                    n6 = n4 + (nx + 1) + 1
+                    n7 = n4 + (nx + 1)
+                    ref_elements.append([n0, n1, n2, n3, n4, n5, n6, n7])
+        ref_elements = np.array(ref_elements)
+
+        np.testing.assert_array_equal(mesh.nodes, ref_nodes)
+        np.testing.assert_array_equal(mesh.elements, ref_elements)
+
 
 class TestCompositeMeshFE:
     """Tests for the FE-related additions to CompositeMesh."""


### PR DESCRIPTION
## Summary

Performance refactor of `CompositeMesh.generate_mesh` in `porosity_fe/mesh.py`. Replaces the triple-nested Python loops + `.append` for both hex8 node construction and element connectivity with `np.meshgrid(..., indexing='ij')` + broadcasted index arithmetic. No Python-level per-node/per-element loops remain.

- **Nodes**: `np.meshgrid(z, y, x, indexing='ij')` then C-order ravel + `np.column_stack((x, y, z))` reproduces the z(outer)->y(middle)->x(inner) ordering, i.e. `node_id = k*(ny+1)*(nx+1) + j*(nx+1) + i`.
- **Elements**: `np.meshgrid(arange(nz), arange(ny), arange(nx), indexing='ij')` gives the per-element base index `n0`; the 8 corner offsets (`n0..n7`) are computed by broadcasted arithmetic, preserving the exact hex8 corner order.

## Correctness

**Bit-for-bit identical nodes/elements — verified by regression test.** Output `nodes` (float64) and `elements` (int64) match the prior loop output exactly (dtype, shape, and values) across multiple mesh sizes `(1,1,1)`, `(4,3,2)`, `(5,3,4)`, `(2,7,3)`, `(10,5,6)`. A new parametrized test in `tests/test_mesh.py` pins the contract against a self-contained inline reference triple-loop using `np.testing.assert_array_equal`, independent of the implementation.

## Verify

- `ruff check .` → clean
- `mypy porosity_fe porosity_fe_analysis.py` (after `rm -rf .mypy_cache`) → clean, no issues in 25 source files
- `python -m pytest tests/ -q` → 641 passed, 1 skipped (FE solver/integration tests depend on exact mesh ordering and stay green)

Only `porosity_fe/mesh.py` and `tests/test_mesh.py` are touched.

Closes #178

https://claude.ai/code/session_018h6s3TVwye8d3brbmYu7zx

---
_Generated by [Claude Code](https://claude.ai/code/session_018h6s3TVwye8d3brbmYu7zx)_