### PR TITLE
perf: cache per-void influence field in _apply_discrete_void_scf (#179)

### DIFF
--- a/porosity_fe/empirical.py
+++ b/porosity_fe/empirical.py
@@ -211,6 +211,18 @@ class EmpiricalSolver:
         self.mesh = mesh
         self.material = material
         self.nodal_knockdown = None
+        # Per-void cache for the discrete-void SCF post-step (#179). Each
+        # entry is a ``(influence_array, scf_dict)`` tuple keyed by the void's
+        # index in ``mesh.porosity_field.discrete_voids``. Both the influence
+        # field (from ``distance_field`` / ``radii``) and the SCF dict are
+        # independent of loading mode and knockdown model — only the scalar
+        # ``scf_dict[mode]`` differs at use time — so they are computed once
+        # and reused across all ``apply_loading`` calls. The mesh, porosity
+        # field, and voids are fixed for a solver instance, so lazy
+        # first-use caching is safe. ``None`` => not yet populated.
+        self._void_scf_cache: (
+            list[tuple[np.ndarray, dict[str, float]]] | None
+        ) = None
 
         # Resolve the ply_angles sentinel (#44 item 2). ``None`` is the
         # deprecated path and emits a DeprecationWarning inside
@@ -462,15 +474,35 @@ class EmpiricalSolver:
         R_eff = 0.1 if R is None else float(R)
         return float(FatigueModel().knockdown_factor(mode, cycles, R_eff))
 
-    def _apply_discrete_void_scf(self, base_knockdown: np.ndarray, mode: str) -> np.ndarray:
-        kd = base_knockdown.copy()
+    def _build_void_scf_cache(self) -> list[tuple[np.ndarray, dict[str, float]]]:
+        """Precompute each discrete void's influence field and SCF dict (#179).
+
+        The per-void influence array (derived from ``distance_field`` and the
+        void radii) and the stress-concentration-factor dict are independent
+        of the loading mode and the knockdown model — only the scalar
+        ``scf_dict[mode]`` selected at use time varies. Computing them once
+        and caching avoids recomputing ``distance_field`` /
+        ``stress_concentration_factor`` on every ``apply_loading`` call
+        (~15x per solver: once per mode x model). The values are byte-for-byte
+        identical to the previous inline computation; this only removes
+        redundant work.
+        """
+        cache: list[tuple[np.ndarray, dict[str, float]]] = []
         for void in self.mesh.porosity_field.discrete_voids:
             scf_dict = void.stress_concentration_factor()
-            scf = scf_dict.get(mode, 1.0)
             dist = void.distance_field(self.mesh.nodes[:, 0],
                                         self.mesh.nodes[:, 1],
                                         self.mesh.nodes[:, 2])
             influence = np.exp(-np.maximum(dist, 0) / max(void.radii))
+            cache.append((influence, scf_dict))
+        return cache
+
+    def _apply_discrete_void_scf(self, base_knockdown: np.ndarray, mode: str) -> np.ndarray:
+        if self._void_scf_cache is None:
+            self._void_scf_cache = self._build_void_scf_cache()
+        kd = base_knockdown.copy()
+        for influence, scf_dict in self._void_scf_cache:
+            scf = scf_dict.get(mode, 1.0)
             kd *= (1.0 - influence * (1.0 - 1.0 / scf))
         return kd
 

--- a/tests/test_empirical.py
+++ b/tests/test_empirical.py
@@ -774,3 +774,78 @@ class TestLocalSensitivities:
     def test_sensitivity_fd_unknown_model(self):
         with pytest.raises(ValueError, match=r"Unknown knockdown model"):
             self.solver.sensitivity_fd(mode='compression', model='bogus')
+
+
+class TestDiscreteVoidScfCache:
+    """#179: caching the per-void influence field / SCF dict in
+    ``_apply_discrete_void_scf`` must be a pure performance refactor —
+    knockdowns and failure loads stay numerically identical.
+
+    These pins live in a self-contained class (separate from #180's
+    additions to this file) so the merge stays mechanical.
+    """
+
+    def _build_solver(self):
+        material = MATERIALS['T800_epoxy']
+        v1 = VoidGeometry(center=(25, 10, material.total_thickness / 2),
+                          radii=(2, 2, 0.5))
+        v2 = VoidGeometry(center=(10, 5, material.total_thickness / 3),
+                          radii=(3, 1, 1))
+        pf = PorosityField(material, 0.03, distribution='clustered',
+                           cluster_location='midplane',
+                           discrete_voids=[v1, v2])
+        mesh = CompositeMesh(pf, material, nx=20, ny=10, nz=12,
+                             ply_angles='QI')
+        return EmpiricalSolver(mesh, material), mesh
+
+    def test_cache_matches_independent_inline_computation(self):
+        """The cached SCF post-step must equal an independently-recomputed
+        inline influence field across every mode (the cache must not change
+        results)."""
+        solver, mesh = self._build_solver()
+        nodes = mesh.nodes
+        base = np.linspace(0.4, 0.95, mesh.porosity.shape[0])
+        for mode in ('compression', 'tension', 'shear', 'ilss',
+                     'transverse_tension'):
+            # Independent reference: recompute distance_field / SCF inline,
+            # exactly as the pre-#179 implementation did.
+            expected = base.copy()
+            for void in mesh.porosity_field.discrete_voids:
+                scf = void.stress_concentration_factor().get(mode, 1.0)
+                dist = void.distance_field(nodes[:, 0], nodes[:, 1],
+                                           nodes[:, 2])
+                influence = np.exp(-np.maximum(dist, 0) / max(void.radii))
+                expected = expected * (1.0 - influence * (1.0 - 1.0 / scf))
+            got = solver._apply_discrete_void_scf(base, mode)
+            np.testing.assert_allclose(got, expected, rtol=0, atol=1e-15)
+
+    def test_cache_invariant_across_repeated_calls(self):
+        """Repeated loadings (which reuse the cache after the first build)
+        must yield identical knockdown arrays — no drift from caching."""
+        solver, _ = self._build_solver()
+        solver.apply_loading('compression', 'judd_wright')
+        first = solver.nodal_knockdown.copy()
+        # Exercise other (mode, model) pairs so the cache is reused, then
+        # return to the original combination.
+        for mode in ('tension', 'shear', 'ilss', 'transverse_tension'):
+            for model in ('judd_wright', 'power_law', 'linear'):
+                solver.apply_loading(mode, model)
+        solver.apply_loading('compression', 'judd_wright')
+        np.testing.assert_array_equal(solver.nodal_knockdown, first)
+
+    def test_failure_loads_match_reference_values(self):
+        """Hardcoded reference failure loads captured on the pre-cache code.
+        Pins numerical identity for a two-void clustered config."""
+        solver, _ = self._build_solver()
+        # (failure_stress, knockdown) per (mode, model), captured on the
+        # unmodified pre-#179 implementation.
+        expected = {
+            ('compression', 'judd_wright'): (1219.5294749813565, 0.813019649987571),
+            ('tension', 'judd_wright'): (2490.838540857552, 0.8895851931634113),
+            ('shear', 'judd_wright'): (78.66278610665533, 0.7866278610665534),
+            ('ilss', 'power_law'): (78.47210698778247, 0.8719122998642496),
+        }
+        for (mode, model), (fs, kd) in expected.items():
+            fr = solver.get_failure_load(mode, model)
+            np.testing.assert_allclose(fr.failure_stress, fs, rtol=1e-12)
+            np.testing.assert_allclose(fr.knockdown, kd, rtol=1e-12)


### PR DESCRIPTION
## Summary

Performance refactor of `EmpiricalSolver._apply_discrete_void_scf` (`porosity_fe/empirical.py`). Each discrete void's `distance_field(...)`/influence array and its `stress_concentration_factor()` dict are **independent of loading mode and knockdown model** — only the scalar `scf_dict[mode]` differs at use time. Previously both were recomputed on every `apply_loading` call (~15x per solver: once per mode x model).

## What changed

- **Precompute, once:** new `_build_void_scf_cache()` iterates `mesh.porosity_field.discrete_voids` and builds, per void, an `(influence_array, scf_dict)` tuple — where `influence = np.exp(-np.maximum(dist, 0) / max(void.radii))` and `scf_dict = void.stress_concentration_factor()`, exactly as the old inline code computed them.
- **Where stored:** lazily on the solver instance in `self._void_scf_cache` (a `list[tuple[np.ndarray, dict[str, float]]] | None`, initialized to `None` in `__init__`), keyed by void index in `discrete_voids`.
- **Lifetime:** built on first use inside `_apply_discrete_void_scf` and reused for every subsequent loading. The mesh / porosity field / voids are fixed for a solver instance (nothing mutates them between calls), so first-use caching is safe.
- **At use time:** `_apply_discrete_void_scf` multiplies in only the mode-specific scalar `scf_dict.get(mode, 1.0)` with the identical `kd *= (1.0 - influence * (1.0 - 1.0 / scf))` step and order.

`void_geometry.py` was **not** modified (read-only).

## Numerical identity — verified

Failure loads and per-node knockdowns are **bit-for-bit identical** to the pre-cache code. Reference captured on unmodified master, then compared with the cached implementation across all 15 mode x model combinations:

- max nodal-knockdown abs error: **0.0**
- max failure-stress abs error: **0.0**
- passes `np.testing.assert_allclose(rtol=1e-14, atol=0)`

## Verify results

- `ruff check .` -> clean (All checks passed)
- `mypy porosity_fe porosity_fe_analysis.py` (after `rm -rf .mypy_cache`) -> clean (no issues in 25 source files)
- `python -m pytest tests/ -q` -> 639 passed, 1 skipped
- focused: `tests/test_empirical.py` + `tests/test_integration.py` -> 191 passed

## Tests

Adds `TestDiscreteVoidScfCache` to `tests/test_empirical.py`:
- `test_cache_matches_independent_inline_computation` — cached post-step equals an independently-recomputed inline influence field per mode
- `test_cache_invariant_across_repeated_calls` — repeated loadings reuse the cache with no drift
- `test_failure_loads_match_reference_values` — hardcoded reference failure loads captured on the pre-cache code

This file is also touched by worker #180; the new pins live in a clearly-separate test class so the merge stays mechanical.

Closes #179

https://claude.ai/code/session_018h6s3TVwye8d3brbmYu7zx

---
_Generated by [Claude Code](https://claude.ai/code/session_018h6s3TVwye8d3brbmYu7zx)_