### PR TITLE
ci: harden Sphinx docs build against transient intersphinx timeouts (#187)

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -69,6 +69,29 @@ intersphinx_mapping = {
     "matplotlib": ("https://matplotlib.org/stable/", None),
 }
 
+# Bound how long each inventory fetch may hang. Without this, an
+# unreachable remote inventory (e.g. a docs.scipy.org blip) makes the
+# default socket wait ~2 minutes before Sphinx gives up -- and under the
+# CI ``-W`` flag the resulting warning is a hard build failure, which has
+# already reddened the docs build once with no code change. A short
+# timeout aborts the request fast so transient outages cause at most a
+# brief delay instead of a multi-minute hang.
+#
+# Supported by ``sphinx.ext.intersphinx`` since Sphinx 2.0; pyproject
+# pins ``sphinx>=7.0``, so this is always available here.
+#
+# Note on the ``-W`` tradeoff: even with a fast timeout, a transient
+# unreachable inventory still emits a fetch warning, which ``-W`` would
+# escalate to an error. We deliberately do NOT add it to
+# ``suppress_warnings`` -- intersphinx logs the "failed to reach any of
+# the inventories" message via a plain ``logger.warning`` with no warning
+# subtype, so there is no stable category that targets *only* the fetch
+# failure. Suppressing it would require a broad filter that could also
+# hide genuine cross-reference warnings, defeating ``-W``. The timeout
+# alone shrinks the failure window to seconds while keeping every real
+# documentation warning fatal.
+intersphinx_timeout = 5
+
 templates_path = ["_templates"]
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 


### PR DESCRIPTION
## What

Add `intersphinx_timeout = 5` to `docs/conf.py` so each remote inventory
fetch aborts after ~5 seconds instead of hanging on the default socket
wait (~2 minutes) when a remote like `docs.scipy.org` is briefly
unreachable.

The docs CI runs `python -m sphinx -W -b html docs docs/_build/html`
(warnings-as-errors). A transient inventory outage turns a slow fetch
warning into a hard build failure with no code change — this has already
reddened CI once. `intersphinx_timeout` is supported by
`sphinx.ext.intersphinx` since Sphinx 2.0; pyproject pins `sphinx>=7.0`,
so it is always available.

## The `-W` tradeoff and the choice made

A fast timeout shrinks the failure window to seconds, but a transient
unreachable inventory still emits a fetch warning that `-W` would
escalate to an error. I evaluated suppressing just that warning via
`suppress_warnings` and deliberately did **not** do so:

- intersphinx logs the "failed to reach any of the inventories" message
  via a plain `logger.warning(...)` with **no warning subtype**
  (verified in `sphinx/ext/intersphinx/_load.py` on the installed
  Sphinx), so there is no stable `suppress_warnings` category that
  targets *only* the fetch failure.
- Any filter broad enough to catch it could also hide genuine
  cross-reference warnings, defeating the purpose of `-W`.

So the change is the timeout alone (option a): least-surprising, keeps
every real documentation warning fatal, and reduces the transient-blip
window drastically. `-W` is **not** disabled in the workflow; only
`docs/conf.py` is touched.

## Verification

Ran the exact CI command from a clean build dir:

```
rm -rf docs/_build && python -m sphinx -W -b html docs docs/_build/html
```

→ `build succeeded`, exit 0, no warnings. `ruff check .` passes clean.

Closes #187

https://claude.ai/code/session_018h6s3TVwye8d3brbmYu7zx

---
_Generated by [Claude Code](https://claude.ai/code/session_018h6s3TVwye8d3brbmYu7zx)_