### PR TITLE
test: cover io provenance version/git-SHA fallback paths (#186)

### DIFF
--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -374,6 +374,53 @@ class TestBuildProvenance:
         prov = _build_provenance()
         assert prov['git_commit'] is None or isinstance(prov['git_commit'], str)
 
+    def test_version_lookup_failure_falls_back_to_package_attr(self, monkeypatch):
+        """io.py:101-108: if importlib.metadata.version() raises (source
+        checkout not pip-installed), the version fields fall back to the
+        package ``__version__`` attribute, never silently None."""
+        import importlib.metadata as ilm
+
+        from porosity_fe import __version__ as pkg_version
+
+        def _boom(_dist_name):
+            raise ilm.PackageNotFoundError("porosity-fe")
+
+        # _build_provenance does ``import importlib.metadata as _ilm`` then
+        # calls ``_ilm.version(...)``; patch the symbol at its real home.
+        monkeypatch.setattr(ilm, "version", _boom)
+        prov = _build_provenance()
+        assert prov['porosity_fe_version'] == pkg_version
+        assert prov['package_version'] == pkg_version
+
+    def test_git_subprocess_filenotfound_yields_none_sha(self, monkeypatch):
+        """io.py:117-128: a missing ``git`` binary (FileNotFoundError) must
+        degrade gracefully to a None git SHA, not propagate."""
+        from porosity_fe import io as io_mod
+
+        def _no_git(*_args, **_kwargs):
+            raise FileNotFoundError("git")
+
+        monkeypatch.setattr(io_mod.subprocess, "run", _no_git)
+        prov = _build_provenance()
+        assert prov['git_commit'] is None
+        assert prov['git_sha'] is None
+
+    def test_git_subprocess_timeout_yields_none_sha(self, monkeypatch):
+        """io.py:117-128: a hung ``git`` (TimeoutExpired) must also degrade
+        gracefully to a None git SHA."""
+        import subprocess as _subprocess
+
+        from porosity_fe import io as io_mod
+
+        def _timeout(*_args, **_kwargs):
+            raise _subprocess.TimeoutExpired(cmd="git rev-parse HEAD",
+                                             timeout=5)
+
+        monkeypatch.setattr(io_mod.subprocess, "run", _timeout)
+        prov = _build_provenance()
+        assert prov['git_commit'] is None
+        assert prov['git_sha'] is None
+
 
 class TestProvenanceInSaveResultsJson:
     """Integration: provenance is present and valid in save_results_to_json output."""


### PR DESCRIPTION
## What

Adds three tests to `tests/test_io.py::TestBuildProvenance` covering the two previously-unexercised exception-handling fallback branches in `porosity_fe/io.py`'s `_build_provenance()`. Test-only change; `io.py` is untouched.

## Fallback branches covered

1. **Package-version lookup failure** — `porosity_fe/io.py:101-108`. The `try` around `importlib.metadata.version("porosity-fe")` (`_ilm.version(...)`). On any exception it falls back to `from . import __version__`, so `porosity_fe_version` / `package_version` carry the package attr (`1.2.0`) instead of `None`.
2. **Git SHA subprocess failure** — `porosity_fe/io.py:117-128`. The `try` around `subprocess.run(["git", "rev-parse", "HEAD"], ...)`. On `FileNotFoundError` / `TimeoutExpired` / any exception, `git_commit` (and its alias `git_sha`) degrade to `None`.

## How each test forces the branch

- `test_version_lookup_failure_falls_back_to_package_attr` — `monkeypatch.setattr(importlib.metadata, "version", ...)` to raise `PackageNotFoundError`; asserts `porosity_fe_version == package_version == porosity_fe.__version__`. Patched at the symbol's real home since `_build_provenance` does `import importlib.metadata as _ilm` then `_ilm.version(...)`.
- `test_git_subprocess_filenotfound_yields_none_sha` — `monkeypatch.setattr(io.subprocess, "run", ...)` to raise `FileNotFoundError`; asserts `git_commit is None and git_sha is None`.
- `test_git_subprocess_timeout_yields_none_sha` — same patch target raising `subprocess.TimeoutExpired`; asserts graceful `None`.

Patches target where `io.py` looks up the symbols (`io.subprocess.run`, `importlib.metadata.version`), verified against io.py's imports.

## Verify

- `ruff check .` → clean (All checks passed)
- `mypy porosity_fe porosity_fe_analysis.py` (after `rm -rf .mypy_cache`) → clean (no issues in 25 source files)
- `python -m pytest tests/ -q` → 654 passed, 1 skipped; the 3 new tests included and green

Closes #186

https://claude.ai/code/session_018h6s3TVwye8d3brbmYu7zx

---
_Generated by [Claude Code](https://claude.ai/code/session_018h6s3TVwye8d3brbmYu7zx)_