### PR TITLE
feat: warn on empirical knockdown extrapolation beyond Vp calibration bound (#184)

### DIFF
--- a/porosity_fe/empirical.py
+++ b/porosity_fe/empirical.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import math
+import warnings
 from typing import Any, Callable
 
 import numpy as np
@@ -16,6 +17,15 @@ from .mesh import CompositeMesh
 from .results import FailureResult
 
 logger = logging.getLogger("porosity_fe_analysis")
+
+#: Upper porosity bound (as a fraction) over which the empirical knockdown
+#: coefficients were calibrated (Elhajjar 2025, ``Vp ≲ 0.05``). Evaluating a
+#: built-in knockdown model at a larger specimen-average ``Vp`` extrapolates
+#: beyond the validated range, so :meth:`EmpiricalSolver.apply_loading` emits a
+#: single :class:`UserWarning` flagging the extrapolation (CLAUDE.md: "flag
+#: extrapolations explicitly"). User-supplied callables own their own
+#: calibration contract and are exempt from the warning.
+_VP_CALIBRATION_MAX = 0.05
 
 
 class Calibration:
@@ -337,6 +347,28 @@ class EmpiricalSolver:
         raw = self.f_md / ref
         return max(raw, floor)
 
+    def _warn_if_extrapolated(self, model: object) -> None:
+        """Emit a single ``UserWarning`` when ``Vp`` exceeds the calibration bound.
+
+        The built-in empirical coefficients are calibrated to
+        ``Vp ≲ _VP_CALIBRATION_MAX`` (Elhajjar 2025); evaluating them at a
+        larger specimen-average porosity extrapolates beyond the validated
+        range. We warn once per :meth:`apply_loading` call (never per node),
+        naming the offending ``Vp``. User-supplied callables own their own
+        calibration contract (#62), so a non-string ``model`` is exempt.
+        """
+        if not isinstance(model, str):
+            return
+        vp_max = float(self.mesh.porosity_field.Vp)
+        if vp_max > _VP_CALIBRATION_MAX:
+            warnings.warn(
+                f"Empirical knockdown evaluated beyond calibration bound "
+                f"(Vp <= {_VP_CALIBRATION_MAX}): max Vp = {vp_max:.4g}. "
+                f"Results are extrapolated and may be inaccurate.",
+                UserWarning,
+                stacklevel=3,
+            )
+
     @staticmethod
     def _check_internal_Vp(Vp: float) -> float:
         # Defensive: tolerate fp overshoot (~1e-15) from element-mean averaging
@@ -612,6 +644,10 @@ class EmpiricalSolver:
                 f"Unknown loading mode {mode!r}. "
                 f"Use one of {sorted(self.PRISTINE_STRENGTH_KEY)}."
             )
+        # Flag extrapolation past the empirical calibration bound (#184).
+        # One warning per call, built-in models only — user callables are
+        # exempt (they own their own calibration contract, #62).
+        self._warn_if_extrapolated(model)
         # #115: vectorize the built-in knockdown evaluation. The scalar list
         # comprehension was ~60x slower than NumPy on the per-node Vp array
         # (4400-element typical mesh). User-supplied callables still get the

--- a/tests/test_empirical.py
+++ b/tests/test_empirical.py
@@ -5,6 +5,8 @@ Split out of the monolithic tests/test_porosity_fe.py for issue #124.
 """
 
 
+import warnings
+
 import numpy as np
 import pytest
 
@@ -901,3 +903,66 @@ class TestDiscreteVoidScfCache:
             fr = solver.get_failure_load(mode, model)
             np.testing.assert_allclose(fr.failure_stress, fs, rtol=1e-12)
             np.testing.assert_allclose(fr.knockdown, kd, rtol=1e-12)
+
+
+class TestExtrapolationWarning:
+    """#184: warn when the empirical knockdown is evaluated beyond the
+    ``Vp <= 0.05`` calibration bound. The warning is informational only —
+    numerical results are unchanged.
+    """
+
+    def _build_solver(self, Vp):
+        material = MATERIALS['T800_epoxy']
+        pf = PorosityField(material, Vp, distribution='uniform')
+        mesh = CompositeMesh(pf, material, nx=4, ny=2, nz=2)
+        return EmpiricalSolver(mesh, material)
+
+    def test_warns_when_vp_exceeds_bound(self):
+        """A built-in model at Vp > 0.05 must emit exactly one UserWarning
+        naming the offending Vp."""
+        solver = self._build_solver(0.08)
+        with pytest.warns(
+            UserWarning,
+            match=r"beyond calibration bound.*max Vp = 0\.08",
+        ) as record:
+            solver.apply_loading('compression', 'judd_wright')
+        # Exactly one warning per call — never per node.
+        extrap = [w for w in record
+                  if issubclass(w.category, UserWarning)
+                  and 'calibration bound' in str(w.message)]
+        assert len(extrap) == 1
+
+    def test_get_failure_load_warns_once(self):
+        """``get_failure_load`` (which routes through ``apply_loading``) must
+        also emit exactly one extrapolation warning."""
+        solver = self._build_solver(0.08)
+        with pytest.warns(UserWarning, match=r"beyond calibration bound") as record:
+            solver.get_failure_load('compression', 'judd_wright')
+        extrap = [w for w in record
+                  if issubclass(w.category, UserWarning)
+                  and 'calibration bound' in str(w.message)]
+        assert len(extrap) == 1
+
+    def test_no_warning_within_bound(self):
+        """At Vp <= 0.05 no extrapolation warning is emitted."""
+        solver = self._build_solver(0.05)
+        with warnings.catch_warnings(record=True) as record:
+            warnings.simplefilter('always')
+            solver.apply_loading('compression', 'judd_wright')
+        extrap = [w for w in record
+                  if issubclass(w.category, UserWarning)
+                  and 'calibration bound' in str(w.message)]
+        assert extrap == []
+
+    def test_no_warning_for_user_callable(self):
+        """User-supplied callables own their own calibration contract (#62),
+        so they are exempt from the extrapolation warning even past the
+        bound."""
+        solver = self._build_solver(0.08)
+        with warnings.catch_warnings(record=True) as record:
+            warnings.simplefilter('always')
+            solver.apply_loading('compression', model=lambda Vp, mode: 0.5)
+        extrap = [w for w in record
+                  if issubclass(w.category, UserWarning)
+                  and 'calibration bound' in str(w.message)]
+        assert extrap == []


### PR DESCRIPTION
## Summary

The built-in empirical knockdown coefficients are calibrated only to `Vp ≲ 0.05` (Elhajjar 2025). CLAUDE.md says to "flag extrapolations explicitly", but no warning existed. This PR adds one.

## What changed

- New module-level constant `_VP_CALIBRATION_MAX = 0.05` in `porosity_fe/empirical.py`.
- `EmpiricalSolver.apply_loading()` now emits a single `UserWarning` when the evaluated specimen-average `Vp` exceeds the bound, naming the offending value:
  > `Empirical knockdown evaluated beyond calibration bound (Vp <= 0.05): max Vp = 0.08. Results are extrapolated and may be inaccurate.`
- The warning fires **once per call**, never per node. Because `get_failure_load()` routes through `apply_loading()`, it warns too.

## User-callable suppression

User-supplied knockdown callables own their own calibration contract (#62), so a non-string `model` is **exempt** — the warning is gated on `isinstance(model, str)` via the `_warn_if_extrapolated` helper.

## Numerical impact

None. This is a behavior addition (a warning) only; all knockdown math is unchanged.

## Tests

Added `TestExtrapolationWarning` to `tests/test_empirical.py`:
- exactly one `UserWarning` (message match) for `Vp > 0.05` via `pytest.warns` — covered for both `apply_loading` and `get_failure_load`,
- **no** warning for `Vp <= 0.05` (via `warnings.catch_warnings(record=True)`),
- **no** warning for a user-supplied callable model.

No existing tests required updating: the repo has no `filterwarnings = error` setting, so tests in `test_validation_database.py` (and others) that legitimately evaluate `Vp > 0.05` simply surface the new warning without failing.

## Verify results

- `ruff check .` → clean
- `mypy porosity_fe porosity_fe_analysis.py` → `Success: no issues found in 25 source files` (after `rm -rf .mypy_cache`)
- `python -m pytest tests/ -q` → **655 passed, 1 skipped**

Closes #184

https://claude.ai/code/session_018h6s3TVwye8d3brbmYu7zx

---
_Generated by [Claude Code](https://claude.ai/code/session_018h6s3TVwye8d3brbmYu7zx)_