### PR TITLE
test: pin two-solver distribution contract + transforms/gauss/ply-angles coverage

### DIFF
--- a/tests/test_gauss.py
+++ b/tests/test_gauss.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Property tests for ``porosity_fe.gauss`` (Gauss-Legendre quadrature).
+
+The quadrature rules underpin every FE element integral but had no dedicated
+test module. These tests pin the defining contract of an ``n``-point
+Gauss-Legendre rule: the weights integrate the constant function exactly (sum
+to the measure of the domain), the abscissae are symmetric and interior, and
+the rule integrates polynomials up to degree ``2n - 1`` exactly while failing
+at degree ``2n`` (the property that makes Gauss optimal). The 3D hex rule is
+checked as the tensor product of the 1D rule.
+"""
+
+import numpy as np
+import pytest
+
+import matplotlib
+matplotlib.use('Agg')
+
+from porosity_fe.gauss import gauss_points_1d, gauss_points_hex
+
+
+def _quad_1d(points, weights, k):
+    """Quadrature estimate of integral of x**k over [-1, 1]."""
+    return float(np.sum(weights * points ** k))
+
+
+def _exact_monomial_1d(k):
+    """Analytic integral of x**k over [-1, 1]: 0 for odd k, 2/(k+1) for even."""
+    return 0.0 if k % 2 else 2.0 / (k + 1)
+
+
+# --- gauss_points_1d ---------------------------------------------------
+
+@pytest.mark.parametrize('n', [1, 2, 3])
+def test_1d_weights_sum_to_interval_measure(n):
+    _points, weights = gauss_points_1d(n)
+    assert weights.sum() == pytest.approx(2.0, abs=1e-14)
+    assert np.all(weights > 0.0)
+
+
+@pytest.mark.parametrize('n', [1, 2, 3])
+def test_1d_points_are_interior_and_symmetric(n):
+    points, _weights = gauss_points_1d(n)
+    assert points.shape == (n,)
+    assert np.all(np.abs(points) < 1.0)
+    # Abscissae are symmetric about the origin.
+    np.testing.assert_allclose(np.sort(points), -np.sort(points)[::-1], atol=1e-14)
+
+
+@pytest.mark.parametrize('n', [1, 2, 3])
+def test_1d_rule_integrates_up_to_degree_2n_minus_1_exactly(n):
+    points, weights = gauss_points_1d(n)
+    for k in range(2 * n):  # degrees 0 .. 2n-1
+        assert _quad_1d(points, weights, k) == pytest.approx(_exact_monomial_1d(k), abs=1e-12)
+
+
+@pytest.mark.parametrize('n', [1, 2, 3])
+def test_1d_rule_is_not_exact_at_degree_2n(n):
+    # The defining optimality bound: an n-point rule cannot integrate the
+    # degree-2n monomial exactly.
+    points, weights = gauss_points_1d(n)
+    k = 2 * n
+    assert abs(_quad_1d(points, weights, k) - _exact_monomial_1d(k)) > 1e-3
+
+
+@pytest.mark.parametrize('n', [0, 4, 5])
+def test_1d_rejects_unsupported_point_counts(n):
+    with pytest.raises(ValueError, match=r"n=1, 2, 3"):
+        gauss_points_1d(n)
+
+
+# --- gauss_points_hex --------------------------------------------------
+
+def test_hex_default_is_2x2x2_eight_point_rule():
+    points, weights = gauss_points_hex()  # default order=2
+    assert points.shape == (8, 3)
+    assert weights.shape == (8,)
+    # Weights integrate the unit constant over the [-1,1]^3 cube (volume 8).
+    assert weights.sum() == pytest.approx(8.0, abs=1e-13)
+    assert np.all(np.abs(points) < 1.0)
+
+
+def test_hex_order_one_is_single_centroid_point():
+    points, weights = gauss_points_hex(order=1)
+    assert points.shape == (1, 3)
+    np.testing.assert_allclose(points, [[0.0, 0.0, 0.0]], atol=1e-15)
+    assert weights.sum() == pytest.approx(8.0, abs=1e-14)
+
+
+@pytest.mark.parametrize('a,b,c', [(2, 0, 0), (2, 2, 0), (0, 0, 2), (2, 2, 2), (3, 1, 0)])
+def test_hex_integrates_separable_monomials_exactly(a, b, c):
+    # A 2-point-per-axis rule is exact for separable polynomials up to degree
+    # 3 in each variable; the cube integral factorizes over the 1D integrals.
+    points, weights = gauss_points_hex(order=2)
+    x, y, z = points[:, 0], points[:, 1], points[:, 2]
+    quad = float(np.sum(weights * x ** a * y ** b * z ** c))
+    exact = _exact_monomial_1d(a) * _exact_monomial_1d(b) * _exact_monomial_1d(c)
+    assert quad == pytest.approx(exact, abs=1e-13)

--- a/tests/test_ply_angles.py
+++ b/tests/test_ply_angles.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Direct unit tests for the shared ``_resolve_ply_angles`` helper.
+
+``EmpiricalSolver``, ``CompositeMesh`` and ``FESolver`` all funnel their
+``ply_angles`` argument through
+``porosity_fe._ply_angles._resolve_ply_angles`` so the three solver paths
+can never drift to divergent ``None`` defaults (#44 item 2). Those classes
+only ever call the helper with the production ``none_means='QI'``, so the
+``'UD'`` / ``'UD_legacy'`` / invalid-``none_means`` branches of its
+documented contract were previously reached by no caller and no test. These
+tests exercise the helper directly to pin its full contract.
+"""
+
+import warnings
+
+import pytest
+
+from porosity_fe._ply_angles import (
+    _PLY_ANGLES_QI,
+    _PLY_ANGLES_UD,
+    _resolve_ply_angles,
+)
+
+
+# --- String sentinels --------------------------------------------------
+
+def test_qi_sentinel_expands_to_canonical_stack():
+    assert _resolve_ply_angles('QI') == list(_PLY_ANGLES_QI)
+
+
+def test_ud_sentinel_expands_to_all_zero_stack():
+    assert _resolve_ply_angles('UD') == list(_PLY_ANGLES_UD)
+
+
+@pytest.mark.parametrize('sentinel', ['qi', 'Qi', 'ud', 'Ud'])
+def test_sentinels_are_case_insensitive(sentinel):
+    expected = (list(_PLY_ANGLES_QI) if sentinel.upper() == 'QI'
+                else list(_PLY_ANGLES_UD))
+    assert _resolve_ply_angles(sentinel) == expected
+
+
+def test_unknown_string_sentinel_raises_value_error():
+    with pytest.raises(ValueError, match=r"'QI' or 'UD'"):
+        _resolve_ply_angles('nonsense')
+
+
+def test_bad_sentinel_error_names_the_caller_and_value():
+    with pytest.raises(ValueError, match=r"MyCaller.*'oops'"):
+        _resolve_ply_angles('oops', caller='MyCaller')
+
+
+# --- Explicit sequences ------------------------------------------------
+
+def test_explicit_list_returned_verbatim_as_floats():
+    result = _resolve_ply_angles([0, 45, 90, -45])
+    assert result == [0.0, 45.0, 90.0, -45.0]
+    assert all(isinstance(a, float) for a in result)
+
+
+def test_explicit_tuple_is_converted_to_a_list_of_floats():
+    result = _resolve_ply_angles((0, 90))
+    assert isinstance(result, list)
+    assert result == [0.0, 90.0]
+
+
+def test_sentinel_returns_a_fresh_list_not_the_module_baseline():
+    # Mutating a resolved list must not corrupt the shared baseline for the
+    # next caller (the helper returns a fresh ``list(...)``, not the tuple).
+    first = _resolve_ply_angles('QI')
+    first.append(123.0)
+    second = _resolve_ply_angles('QI')
+    assert second == list(_PLY_ANGLES_QI)
+
+
+def test_explicit_inputs_do_not_warn():
+    # Only the ``None`` back-compat shim is deprecated; sentinels and
+    # explicit sequences must resolve silently.
+    with warnings.catch_warnings():
+        warnings.simplefilter('error')
+        assert _resolve_ply_angles('QI') == list(_PLY_ANGLES_QI)
+        assert _resolve_ply_angles('UD') == list(_PLY_ANGLES_UD)
+        assert _resolve_ply_angles([0, 90]) == [0.0, 90.0]
+
+
+# --- None back-compat shim + none_means dispatch -----------------------
+
+def test_none_defaults_to_qi_with_deprecation_warning():
+    with pytest.warns(DeprecationWarning, match='deprecated'):
+        result = _resolve_ply_angles(None)
+    assert result == list(_PLY_ANGLES_QI)
+
+
+def test_none_with_none_means_ud_resolves_to_ud():
+    with pytest.warns(DeprecationWarning):
+        result = _resolve_ply_angles(None, none_means='UD')
+    assert result == list(_PLY_ANGLES_UD)
+
+
+def test_none_with_ud_legacy_returns_none():
+    # CompositeMesh's historical "None means a literal all-zero array"
+    # behaviour is preserved as none_means='UD_legacy' -> None.
+    with pytest.warns(DeprecationWarning):
+        result = _resolve_ply_angles(None, none_means='UD_legacy')
+    assert result is None
+
+
+def test_none_with_unsupported_none_means_raises_internal_error():
+    # The shim warns first, then the none_means dispatch rejects an
+    # unsupported value with a clear internal-error ValueError.
+    with pytest.warns(DeprecationWarning), \
+            pytest.raises(ValueError, match='unsupported none_means'):
+        _resolve_ply_angles(None, none_means='bogus')
+
+
+def test_deprecation_message_names_the_caller():
+    with pytest.warns(DeprecationWarning, match=r'FESolver\.ply_angles'):
+        _resolve_ply_angles(None, caller='FESolver.ply_angles')

--- a/tests/test_solver_distribution_contract.py
+++ b/tests/test_solver_distribution_contract.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""The two-solver porosity-distribution contract.
+
+PorosityFE ships two solver paths over the same
+``PorosityField`` + ``CompositeMesh`` + ``MaterialProperties`` triple, and they
+are *designed to disagree* on the effect of the porosity distribution shape
+(see the "Two solver paths, one mesh" section of CLAUDE.md):
+
+* :class:`EmpiricalSolver` applies a closed-form knockdown once at the laminate
+  level using the specimen-average ``Vp``. The distribution shape
+  (``uniform`` vs ``clustered`` vs ``interface``) has **no effect**, because
+  ``get_failure_load`` evaluates the knockdown at ``porosity_field.Vp`` (the
+  mean), which is identical across shapes at fixed mean porosity.
+* :class:`FESolver` applies stiffness/strength degradation **per element** from
+  the local ``Vp(x, y, z)`` field, so a clustered or interface distribution
+  concentrates porosity into hot-spots and **does** change the result.
+
+These tests pin that contract so a future refactor can't quietly make the
+empirical path shape-sensitive or the FE path shape-blind. They are the
+behavioural guard for an architectural claim, not a coverage filler.
+"""
+
+import warnings
+
+import numpy as np
+import pytest
+
+import matplotlib
+matplotlib.use('Agg')
+
+from porosity_fe import (
+    MATERIALS,
+    CompositeMesh,
+    EmpiricalSolver,
+    FESolver,
+    PorosityField,
+)
+
+MATERIAL = MATERIALS['T800_epoxy']
+VP = 0.03  # within the empirical calibration bound (Vp <= 0.05); no extrapolation
+DISTRIBUTIONS = ('uniform', 'clustered', 'interface')
+EMPIRICAL_MODES = ('compression', 'tension', 'shear', 'ilss', 'transverse_tension')
+
+
+def _empirical_failure(distribution, mode):
+    pf = PorosityField(MATERIAL, VP, distribution=distribution)
+    mesh = CompositeMesh(pf, MATERIAL, nx=4, ny=2, nz=4)
+    solver = EmpiricalSolver(mesh, MATERIAL)
+    return solver.get_failure_load(mode, 'judd_wright')
+
+
+def _per_node_porosity(distribution):
+    pf = PorosityField(MATERIAL, VP, distribution=distribution)
+    mesh = CompositeMesh(pf, MATERIAL, nx=8, ny=4, nz=8)
+    return np.asarray(mesh.porosity)
+
+
+def _fe_max_failure_index(distribution):
+    pf = PorosityField(MATERIAL, VP, distribution=distribution)
+    # nz=8 resolves the through-thickness clustering; the thin elements raise a
+    # benign mesh-distortion heads-up that is irrelevant to this contract.
+    mesh = CompositeMesh(pf, MATERIAL, nx=3, ny=2, nz=8)
+    solver = FESolver(mesh, MATERIAL, pf)
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore')
+        results = solver.solve(loading='compression', applied_strain=-0.001)
+    return results.max_failure_index
+
+
+# --- Empirical path: distribution-invariant ----------------------------
+
+@pytest.mark.parametrize('mode', EMPIRICAL_MODES)
+def test_empirical_failure_is_identical_across_distributions(mode):
+    """The empirical headline knockdown/strength must not depend on shape."""
+    baseline = _empirical_failure('uniform', mode)
+    for distribution in ('clustered', 'interface'):
+        result = _empirical_failure(distribution, mode)
+        # Same scalar mean Vp -> same code path -> bitwise-identical result.
+        assert result.knockdown == baseline.knockdown
+        assert result.failure_stress == baseline.failure_stress
+
+
+# --- The inputs genuinely differ (keeps the invariance non-vacuous) -----
+
+def test_distribution_shapes_produce_distinct_porosity_fields():
+    fields = {d: _per_node_porosity(d) for d in DISTRIBUTIONS}
+
+    # Uniform is constant at the mean; the others are graded with peaks that
+    # exceed the mean (that is exactly the signal the empirical path ignores).
+    assert np.std(fields['uniform']) == pytest.approx(0.0, abs=1e-12)
+    for distribution in ('clustered', 'interface'):
+        assert np.std(fields[distribution]) > 0.0
+        assert np.max(fields[distribution]) > VP
+        assert not np.allclose(fields['uniform'], fields[distribution])
+
+
+# --- FE path: distribution-sensitive -----------------------------------
+
+def test_fe_failure_index_depends_on_distribution():
+    fi = {d: _fe_max_failure_index(d) for d in DISTRIBUTIONS}
+
+    mean_fi = np.mean(list(fi.values()))
+    spread = (max(fi.values()) - min(fi.values())) / mean_fi
+    # The three shapes must produce a materially different worst-case failure
+    # index (observed ~0.5%); fp noise on this deterministic solve is ~1e-10.
+    assert spread > 1e-3
+
+    # Concentrating porosity (clustered / interface) creates a worse local
+    # hot-spot than a uniform field of the same mean Vp.
+    assert fi['clustered'] > fi['uniform']
+    assert fi['interface'] > fi['uniform']
+
+
+def test_empirical_blind_but_fe_sensitive_on_the_same_contrast():
+    """Capstone: the same uniform->clustered change moves FE but not empirical."""
+    emp_uniform = _empirical_failure('uniform', 'compression').knockdown
+    emp_clustered = _empirical_failure('clustered', 'compression').knockdown
+    assert emp_clustered == emp_uniform  # empirical: no change
+
+    fe_uniform = _fe_max_failure_index('uniform')
+    fe_clustered = _fe_max_failure_index('clustered')
+    assert fe_clustered != pytest.approx(fe_uniform, rel=1e-3)  # FE: changes

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""Property tests for ``porosity_fe.transforms``.
+
+The 3D rotation helpers (rotation matrix, 6x6 Voigt stress / strain
+transforms, and the stiffness rotation) are consumed by ``homogenization``,
+``fe.element`` and ``fe.solver`` but had no dedicated test module — they were
+exercised only indirectly through the FE path. These tests pin their
+mathematical contract directly: orthonormality, the negative-angle inverse,
+the Reuter stress/strain duality, and the physical invariants of a rotated
+stiffness (round-trip identity, preserved symmetry, isotropic invariance, and
+the 90-degree in-plane axis swap).
+"""
+
+import numpy as np
+import pytest
+
+import matplotlib
+matplotlib.use('Agg')
+
+from porosity_fe.transforms import (
+    rotate_stiffness_3d,
+    rotation_matrix_3d,
+    strain_transformation_3d,
+    stress_transformation_3d,
+)
+
+I3 = np.eye(3)
+I6 = np.eye(6)
+AXES = ['z', 'y']
+ANGLES = [0.0, np.pi / 6, np.pi / 4, np.pi / 3, np.pi / 2, -np.pi / 5, 1.0, 2.3]
+
+
+def _isotropic_stiffness(lam: float = 5000.0, mu: float = 3000.0) -> np.ndarray:
+    """A Voigt 6x6 isotropic stiffness (MPa) — rotation-invariant by construction."""
+    C = np.zeros((6, 6))
+    C[:3, :3] = lam
+    C[0, 0] = C[1, 1] = C[2, 2] = lam + 2.0 * mu
+    C[3, 3] = C[4, 4] = C[5, 5] = mu
+    return C
+
+
+def _orthotropic_stiffness() -> np.ndarray:
+    """A symmetric orthotropic stiffness with distinct 11/22/33 normal terms."""
+    C = np.diag([160000.0, 9000.0, 11000.0, 3500.0, 4500.0, 4600.0]).astype(float)
+    C[0, 1] = C[1, 0] = 4000.0
+    C[0, 2] = C[2, 0] = 3000.0
+    C[1, 2] = C[2, 1] = 2500.0
+    return C
+
+
+# --- rotation_matrix_3d ------------------------------------------------
+
+@pytest.mark.parametrize('axis', AXES)
+@pytest.mark.parametrize('angle', ANGLES)
+def test_rotation_matrix_is_orthonormal_with_unit_determinant(angle, axis):
+    R = rotation_matrix_3d(angle, axis=axis)
+    np.testing.assert_allclose(R @ R.T, I3, atol=1e-12)
+    assert np.linalg.det(R) == pytest.approx(1.0, abs=1e-12)
+
+
+@pytest.mark.parametrize('axis', AXES)
+def test_rotation_matrix_zero_angle_is_identity(axis):
+    np.testing.assert_allclose(rotation_matrix_3d(0.0, axis=axis), I3, atol=1e-15)
+
+
+@pytest.mark.parametrize('axis', AXES)
+@pytest.mark.parametrize('angle', ANGLES)
+def test_rotation_inverse_is_the_negative_angle(angle, axis):
+    R = rotation_matrix_3d(angle, axis=axis)
+    R_inv = rotation_matrix_3d(-angle, axis=axis)
+    np.testing.assert_allclose(R @ R_inv, I3, atol=1e-12)
+
+
+def test_rotation_matrix_rejects_unknown_axis():
+    with pytest.raises(ValueError, match=r"Unsupported axis"):
+        rotation_matrix_3d(0.5, axis='x')
+
+
+# --- stress / strain transformation matrices ---------------------------
+
+@pytest.mark.parametrize('builder', [stress_transformation_3d, strain_transformation_3d])
+@pytest.mark.parametrize('axis', AXES)
+def test_voigt_transform_zero_angle_is_identity(builder, axis):
+    np.testing.assert_allclose(builder(0.0, axis=axis), I6, atol=1e-14)
+
+
+@pytest.mark.parametrize('builder', [stress_transformation_3d, strain_transformation_3d])
+@pytest.mark.parametrize('axis', AXES)
+@pytest.mark.parametrize('angle', ANGLES)
+def test_voigt_transform_inverse_is_the_negative_angle(builder, axis, angle):
+    T = builder(angle, axis=axis)
+    T_inv = builder(-angle, axis=axis)
+    np.testing.assert_allclose(T @ T_inv, I6, atol=1e-10)
+
+
+@pytest.mark.parametrize('builder', [stress_transformation_3d, strain_transformation_3d])
+def test_voigt_transform_rejects_unknown_axis(builder):
+    with pytest.raises(ValueError, match=r"Unsupported axis"):
+        builder(0.5, axis='x')
+
+
+@pytest.mark.parametrize('axis', AXES)
+@pytest.mark.parametrize('angle', ANGLES)
+def test_stress_and_strain_transforms_are_energy_conjugate(angle, axis):
+    # Strain energy sigma:epsilon is frame-invariant, which forces the
+    # engineering strain transform to be the inverse-transpose of the stress
+    # transform: T_eps^T == T_sig^{-1}. Pin that algebraic duality.
+    T_sig = stress_transformation_3d(angle, axis=axis)
+    T_eps = strain_transformation_3d(angle, axis=axis)
+    np.testing.assert_allclose(T_eps.T, np.linalg.inv(T_sig), atol=1e-10)
+
+
+# --- rotate_stiffness_3d -----------------------------------------------
+
+def test_rotate_stiffness_rejects_non_6x6():
+    with pytest.raises(ValueError, match=r"must be 6x6"):
+        rotate_stiffness_3d(np.eye(3), 0.5, axis='z')
+
+
+@pytest.mark.parametrize('axis', AXES)
+def test_rotate_stiffness_zero_angle_is_unchanged(axis):
+    C = _orthotropic_stiffness()
+    np.testing.assert_allclose(rotate_stiffness_3d(C, 0.0, axis=axis), C, atol=1e-9)
+
+
+@pytest.mark.parametrize('axis', AXES)
+@pytest.mark.parametrize('angle', [np.pi / 6, np.pi / 4, 1.1, -0.7])
+def test_rotate_stiffness_round_trip_recovers_original(angle, axis):
+    C = _orthotropic_stiffness()
+    rotated = rotate_stiffness_3d(C, angle, axis=axis)
+    restored = rotate_stiffness_3d(rotated, -angle, axis=axis)
+    np.testing.assert_allclose(restored, C, rtol=1e-9, atol=1e-6)
+
+
+@pytest.mark.parametrize('axis', AXES)
+@pytest.mark.parametrize('angle', [0.3, np.pi / 4, 1.2])
+def test_rotate_stiffness_preserves_symmetry(angle, axis):
+    rotated = rotate_stiffness_3d(_orthotropic_stiffness(), angle, axis=axis)
+    np.testing.assert_allclose(rotated, rotated.T, atol=1e-6)
+
+
+@pytest.mark.parametrize('axis', AXES)
+@pytest.mark.parametrize('angle', ANGLES)
+def test_isotropic_stiffness_is_rotation_invariant(angle, axis):
+    # An isotropic material has no preferred direction, so rotating its
+    # stiffness to any frame must return the same matrix.
+    C = _isotropic_stiffness()
+    np.testing.assert_allclose(rotate_stiffness_3d(C, angle, axis=axis), C, atol=1e-7)
+
+
+def test_ninety_degree_z_rotation_swaps_in_plane_normal_terms():
+    # A 90-degree rotation about z exchanges the 1 and 2 material directions,
+    # so C_11 <-> C_22 while the through-thickness C_33 is untouched.
+    C = _orthotropic_stiffness()
+    C90 = rotate_stiffness_3d(C, np.pi / 2, axis='z')
+    assert C90[0, 0] == pytest.approx(C[1, 1], abs=1e-6)
+    assert C90[1, 1] == pytest.approx(C[0, 0], abs=1e-6)
+    assert C90[2, 2] == pytest.approx(C[2, 2], abs=1e-6)


### PR DESCRIPTION
## Summary

Adds four test modules that harden the repository's most architecturally load-bearing and thinly-covered areas. Test-only change — no production code touched.

### 1. `tests/test_solver_distribution_contract.py` — the two-solver contract
PorosityFE runs two solver paths over the same mesh that are *designed to disagree* on the effect of porosity distribution shape (CLAUDE.md, "Two solver paths, one mesh"). These tests pin that contract:
- **`EmpiricalSolver` is distribution-invariant** — `get_failure_load` evaluates the knockdown at the specimen-average `Vp`, so `uniform`/`clustered`/`interface` give **bitwise-identical** failure stress and knockdown at fixed mean `Vp` (verified across 5 loading modes).
- **`FESolver` is distribution-sensitive** — per-element degradation picks up clustered/interface hot-spots, so `max_failure_index` materially differs (clustered/interface worse than uniform).
- A non-vacuous guard proves the *inputs* genuinely differ (uniform field is constant; clustered/interface are graded with peaks above the mean), and a capstone test asserts the same uniform→clustered change moves FE but not empirical.

### 2. `tests/test_transforms.py` — rotation property tests
The 3D rotation helpers were exercised only indirectly through the FE path. Pins: rotation-matrix orthonormality + unit determinant, negative-angle inverse, the Reuter stress/strain energy-conjugacy duality (`T_ε^T = T_σ⁻¹`), stiffness round-trip recovery, preserved symmetry, **isotropic rotation-invariance**, and the 90° in-plane axis swap (C₁₁↔C₂₂).

### 3. `tests/test_gauss.py` — quadrature property tests
Pins the defining Gauss-Legendre contract: weights sum to the domain measure, symmetric interior abscissae, **exact to degree 2n−1 and inexact at 2n**, and the tensor-product hex rule. Covers the previously-untested `n=1` branch.

### 4. `tests/test_ply_angles.py` — recovered from stale branches
Direct unit test of the shared `_resolve_ply_angles` helper (`_ply_angles.py` 78%→**100%**, previously the largest coverage gap). Recovered byte-identical from the duplicate branches `claude/ply-angles-tests` / `claude/blissful-albattani-lsj98h`, which can be deleted once this lands.

### Coverage / verification
- **170 new tests**; `gauss.py` 95%→**100%**, `transforms.py` and `_ply_angles.py` pinned at **100%** with dedicated modules.
- Full suite: **832 passed, 1 skipped** (was 662 on master).
- `ruff check .` clean.

https://claude.ai/code/session_013VsFb2DFwpNaEvXo2VC6hy

---
_Generated by [Claude Code](https://claude.ai/code/session_013VsFb2DFwpNaEvXo2VC6hy)_